### PR TITLE
Eliminated video preloads in HTML reports

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -420,7 +420,7 @@ def media_to_html(media_path, files_found, report_folder):
             mimetype = magic.from_file(match, mime = True)
             
             if 'video' in mimetype:
-                thumb = f'<video width="320" height="240" controls="controls"><source src="{source}" type="video/mp4">Your browser does not support the video tag.</video>'
+                thumb = f'<video width="320" height="240" controls="controls" preload="none"><source src="{source}" type="video/mp4">Your browser does not support the video tag.</video>'
             elif 'image' in mimetype:
                 thumb = f'<img src="{source}"width="300"></img>'
             else:


### PR DESCRIPTION
This allows videos to be played within the HTML beyond Chome's 1K preload video limitation.

Video player will not have a preview thumbnail but all videos will be playable from the report.