### PR TITLE
Add latest features of other LEAPPs in RLEAPP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ blackboxprotobuf
 packaging==20.1
 protobuf==3.10.0
 PyCryptodome
-PySimpleGUI==4.16.0
+PySimpleGUI
 simplekml
 xmltodict
 xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,6 @@ PyMuPDF
 openpyxl
 PyPDF2
 ijson
-python-magic==0.4.24; platform_system == "Linux"
-python-magic-bin==0.4.14; platform_system == "Windows"
-python-magic-bin==0.4.14; platform_system == "Darwin"
 pillow-heif
 mammoth
 bencoding

--- a/rleapp.py
+++ b/rleapp.py
@@ -13,7 +13,7 @@ from scripts.version_info import rleapp_version
 from time import process_time, gmtime, strftime, perf_counter
 
 def validate_args(args):
-    if args.artifact_paths or args.create_profile:
+    if args.artifact_paths or args.create_profile_casedata:
         return  # Skip further validation if --artifact_paths is used
 
     # Ensure other arguments are provided
@@ -29,6 +29,9 @@ def validate_args(args):
 
     if not os.path.exists(args.output_path):
         raise argparse.ArgumentError(None, 'OUTPUT folder does not exist! Run the program again.')
+
+    if args.load_case_data and not os.path.exists(args.load_case_data):
+        raise argparse.ArgumentError(None, 'LEAPP Case Data file not found! Run the program again.')
 
     if args.load_profile and not os.path.exists(args.load_profile):
         raise argparse.ArgumentError(None, 'RLEAPP Profile file not found! Run the program again.')
@@ -49,8 +52,7 @@ def create_profile(available_plugins, path):
     parsers_in_profile = {}
     
     user_choice = ''
-    print('-' * 50)
-    print('Welcome to the RLEAPP Profile file creation\n')
+    print('--- RLEAPP Profile file creation ---\n')
     instructions = 'You can type:\n'
     instructions += '   - \'a\' to add or remove parsers in the profile file\n'
     instructions += '   - \'l\' to display the list of all available parsers with their number\n'
@@ -105,13 +107,33 @@ def create_profile(available_plugins, path):
                 with open(filename, "wt", encoding="utf-8") as profile_file:
                     json.dump({"leapp": "rleapp", "format_version": 1, "plugins": parsers}, profile_file)
                 print('\nProfile saved:', filename)
+                print()
             else:
                 print('No parser added. The profile file was not created.\n')
+                print()
             return
         else:
             print('Please enter a valid choice!!!\n')
             user_choice = ''
-
+  
+def create_casedata(path):
+    case_data_values = {}
+    print('--- LEAPP Case Data file creation ---\n')
+    print('Enter the following information:')
+    case_data_values['Case Number'] = input("Case Number: ")
+    case_data_values['Agency'] = input("Agency: ")
+    case_data_values['Examiner'] = input("Examiner : ")
+    print()
+    case_data_filename = ''
+    while not case_data_filename:
+        case_data_filename = input('Enter the name of the Case Data file: ')
+    case_data_filename += '.lcasedata'
+    filename = os.path.join(path, case_data_filename)
+    with open(filename, "wt", encoding="utf-8") as case_data_file:
+        json.dump({"leapp": "case_data", "case_data_values": case_data_values}, case_data_file)
+    print('\nCase Data file saved:', filename)
+    print()
+    return
 
 def main():
     parser = argparse.ArgumentParser(description='RLEAPP: Returns, Logs, Events, and Protobuf Parser.')
@@ -126,9 +148,10 @@ def main():
     parser.add_argument('-tz', '--timezone', required=False, action="store", default='UTC', type=str, help="Timezone name (e.g., 'America/New_York')")
     parser.add_argument('-w', '--wrap_text', required=False, action="store_false", default=True,
                         help='Do not wrap text for output of data files')
-    parser.add_argument('-l', '--load_profile', required=False, action="store", help="Path to RLEAPP Profile file (.rlprofile).")
-    parser.add_argument('-c', '--create_profile', required=False, action="store",
-                        help=("Generate a RLEAPP Profile file (.rlprofile) into the specified path. "
+    parser.add_argument('-m', '--load_profile', required=False, action="store", help="Path to RLEAPP Profile file (.rlprofile).")
+    parser.add_argument('-d', '--load_case_data', required=False, action="store", help="Path to LEAPP Case Data file (.lcasedata).")
+    parser.add_argument('-c', '--create_profile_casedata', required=False, action="store",
+                        help=("Generate a RLEAPP Profile file (.rlprofile) or LEAPP Case Data file (.lcasedata) into the specified path. "
                               "This argument is meant to be used alone, without any other arguments."))
     parser.add_argument('-p', '--artifact_paths', required=False, action="store_true",
                         help=("Generate a text file list of artifact paths. "
@@ -137,8 +160,8 @@ def main():
     loader = plugin_loader.PluginLoader()
     available_plugins = list(loader.plugins)
     profile_filename = None
-    
-    print(f"Info: {len(available_plugins)} plugins loaded.")
+    casedata = {}
+
     selected_plugins = available_plugins.copy()
 
     args = parser.parse_args()
@@ -164,22 +187,67 @@ def main():
         print('Artifact path list generation completed')
         return
 
-    if args.create_profile:
-        if os.path.isdir(args.create_profile):
-            create_profile(selected_plugins, args.create_profile)
-            return
+    if args.create_profile_casedata:
+        if os.path.isdir(args.create_profile_casedata):
+            create_choice = ''
+            print('-' * 55)
+            print('Welcome to RLEAP Profile or Case Data file creation\n')
+            instructions = 'You can type:\n'
+            instructions += '   - \'1\' to create a RLEAPP Profile file (.rlprofile)\n'
+            instructions += '   - \'2\' to create a LEAPP Case Data file (.lcasedata)\n'
+            instructions += '   - \'q\' to quit\n'
+            while not create_choice:
+                print(instructions)
+                create_choice = input('Please enter your choice: ').lower()
+                print()
+                if create_choice == '1':
+                    create_profile(selected_plugins, args.create_profile_casedata)
+                    create_choice = ''
+                elif create_choice == '2':
+                    create_casedata(args.create_profile_casedata)
+                    create_choice = ''
+                elif create_choice == 'q':
+                    return
+                else:
+                    print('Please enter a valid choice!!!\n')
+                    create_choice = ''
         else:
             print('OUTPUT folder for storing RLEAPP Profile file does not exist!\nRun the program again.')
             return
 
+    if args.load_case_data:
+        case_data_filename = args.load_case_data
+        case_data_load_error = None
+        with open(case_data_filename, "rt", encoding="utf-8") as case_data_file:
+            try:
+                case_data = json.load(case_data_file)
+            except:
+                case_data_load_error = "File was not a valid case data file: invalid format"
+                print(case_data_load_error)
+                return
+
+        if not case_data_load_error:
+            if isinstance(case_data, dict):
+                if case_data.get("leapp") != "case_data":
+                    case_data_load_error = "File was not a valid case data file"
+                    print(case_data_load_error)
+                    return
+                else:
+                    print(f'Case Data loaded: {case_data_filename}')
+                    casedata = case_data.get('case_data_values', {})
+            else:
+                case_data_load_error = "File was not a valid case data file: invalid format"
+                print(case_data_load_error)
+                return
+    
     if args.load_profile:
         profile_filename = args.load_profile
         profile_load_error = None
         with open(profile_filename, "rt", encoding="utf-8") as profile_file:
             try:
                 profile = json.load(profile_file)
-            except json.JSONDecodeError as json_ex:
-                profile_load_error = f"File was not a valid profile file: {json_ex}"
+            except:
+                profile_load_error = "File was not a valid case data file: invalid format"
                 print(profile_load_error)
                 return
 
@@ -190,6 +258,7 @@ def main():
                     print(profile_load_error)
                     return
                 else:
+                    print(f'Profile loaded: {profile_filename}')
                     profile_plugins = set(profile.get("plugins", []))
                     selected_plugins = [selected_plugin for selected_plugin in available_plugins 
                                         if selected_plugin.name in profile_plugins]
@@ -211,11 +280,7 @@ def main():
         if output_path[1] == ':': output_path = '\\\\?\\' + output_path.replace('/', '\\')
 
     out_params = OutputParameters(output_path)
-
-    try:
-        casedata
-    except NameError:
-        casedata = {}
+    print(f"Info: {len(available_plugins)} plugins loaded.")
 
     crunch_artifacts(selected_plugins, extracttype, input_path, out_params, 1, wrap_text, loader, casedata, time_offset, profile_filename)
 
@@ -265,12 +330,11 @@ def crunch_artifacts(
     logfunc('\n--------------------------------------------------------------------------------------')
 
     log = open(os.path.join(out_params.report_folder_base, 'Script Logs', 'ProcessedFilesLog.html'), 'w+', encoding='utf8')
-    nl = '\n' #literal in order to have new lines in fstrings that create text files
     log.write(f'Extraction/Path selected: {input_path}<br><br>')
     log.write(f'Timezone selected: {time_offset}<br><br>')
     
     categories_searched = 0
-    
+
     # Search for the files per the arguments
     for plugin in plugins:
         if isinstance(plugin.search, list) or isinstance(plugin.search, tuple):

--- a/rleappGUI.py
+++ b/rleappGUI.py
@@ -4,48 +4,130 @@ import rleapp
 import PySimpleGUI as sg
 import webbrowser
 import plugin_loader
-
 from scripts.ilapfuncs import *
 from scripts.version_info import rleapp_version
 from scripts.search_files import *
 
 MODULE_START_INDEX = 1000
 
+def add_case_data(casedata):
+    case_data_font = ("Helvetica", 12)
+    case_data_layout = [
+        [sg.Text('Add Case Data', font=("Helvetica", 18))],
+        [sg.Frame(layout=[
+            [sg.Input(size=(80,1), key='Case Number', default_text=casedata.get('Case Number', ''))]], title='Case Number')],
+        [sg.Frame(layout=[
+            [sg.Input(size=(80,1), key='Agency', default_text=casedata.get('Agency', ''))]], title='Agency')],
+        [sg.Frame(layout=[
+            [sg.Input(size=(80,1), key='Examiner', default_text=casedata.get('Examiner', ''))]], title='Examiner')],
+        [sg.Text('')],
+        [sg.Button('Load Case Data File', font=normal_font, key='LOADCASEDATA'),
+         sg.Button('Save Case Data File', font=normal_font, key='SAVECASEDATA'),
+         sg.Text(' | ', font=("Helvetica", 14)),
+         sg.Button('Clear', font=normal_font, key='CLEAR'),
+         sg.Button('Close', font=normal_font)]
+        ]
+    
+    case_data_window = sg.Window('Add Case Data', case_data_layout, font=case_data_font)
+
+    while True:
+        case_data_event, case_data_values = case_data_window.read()
+
+        if case_data_event in (None, 'Close'):
+            case_data_window.close()
+            return case_data_values
+
+        if case_data_event == 'CLEAR':
+            case_data_window['Case Number'].update('')
+            case_data_window['Agency'].update('')
+            case_data_window['Examiner'].update('')
+            continue
+
+        if case_data_event == 'SAVECASEDATA':
+            destination_path = sg.popup_get_file(
+                "Save case data file", save_as=True,
+                file_types=(('LEAPP Case Data (*.lcasedata)', '*.lcasedata'),),
+                default_extension='.icasedata', no_window=True, keep_on_top=True)
+
+            if destination_path:
+                with open(destination_path, "wt", encoding="utf-8") as case_data_out:
+                    json.dump({"leapp": "case_data", "case_data_values": case_data_values}, case_data_out)
+                sg.Popup(f"Case Data saved: {destination_path}", title="Save Case Data")
+                case_data_window.close()    
+            else:
+                continue
+            
+            return case_data_values
+
+        if case_data_event == 'LOADCASEDATA':
+            destination_path = sg.popup_get_file(
+                "Load case data", save_as=False,
+                file_types=(('LEAPP Case Data (*.lcasedata)', '*.lcasedata'), ('All Files', '*')),
+                default_extension='.lcasedata', no_window=True)
+            
+            if destination_path and os.path.exists(destination_path):
+                case_data_load_error = None
+                with open(destination_path, "rt", encoding="utf-8") as case_data_in:
+                    try:
+                        case_data = json.load(case_data_in)
+                    except:
+                        case_data_load_error = "File was not a valid case data file: invalid format"
+                        
+                if not case_data_load_error:
+                    if isinstance(case_data, dict):
+                        if case_data.get("leapp") != "case_data":
+                            case_data_load_error = "File was not a valid case data file"
+                        else:
+                            casedata = case_data.get('case_data_values', {})
+                            for key, value in casedata.items():
+                                case_data_window[key].update(value)
+                    else:
+                        case_data_load_error = "File was not a valid case data file: invalid format"
+                
+                if case_data_load_error:
+                    sg.popup(case_data_load_error)
+                    continue
+                else:
+                    sg.popup(f"Loaded Case Data: {destination_path}", title="Load Case Data")
+                    continue            
+            else:
+                continue
+
 def ValidateInput(values, window):
     '''Returns tuple (success, extraction_type)'''
     global module_end_index
 
-    i_path = values[0] # input file/folder
-    o_path = values[1] # output folder
+    i_path = values['INPUTPATH'] # input file/folder
+    o_path = values['OUTPUTPATH'] # output folder
     ext_type = ''
 
     if len(i_path) == 0:
-        sg.PopupError('No INPUT file or folder selected!')
+        sg.PopupError('No INPUT file or folder selected!', title="Error")
         return False, ext_type
     elif not os.path.exists(i_path):
-        sg.PopupError('INPUT file/folder does not exist!')
+        sg.PopupError('INPUT file/folder does not exist!', title="Error")
         return False, ext_type
     elif os.path.isdir(i_path):
         ext_type = 'fs'
     else: # must be an existing file then
         if not i_path.lower().endswith('.tar') and not i_path.lower().endswith('.zip') and not i_path.lower().endswith('.gz'):
-            sg.PopupError('Input file is not a supported archive! ', i_path)
+            sg.PopupError('Input file is not a supported archive! ', i_path, title="Error")
             return False, ext_type
         else:
             ext_type = Path(i_path).suffix[1:].lower() 
     
     # check output now
     if len(o_path) == 0 : # output folder
-        sg.PopupError('No OUTPUT folder selected!')
+        sg.PopupError('No OUTPUT folder selected!', title="Error")
         return False, ext_type
 
     one_element_is_selected = False
     for x in range(1000, module_end_index):
-        if window.FindElement(x).Get():
+        if window[x].Get():
             one_element_is_selected = True
             break
     if not one_element_is_selected:
-        sg.PopupError('No module selected for processing!')
+        sg.PopupError('No module selected for processing!', title="Error")
         return False, ext_type
 
     return True, ext_type
@@ -86,14 +168,16 @@ tzvalues = ['Africa/Abidjan', 'Africa/Accra', 'Africa/Addis_Ababa', 'Africa/Algi
 layout = [  [sg.Text('Returns, Logs, Events, And Protobuf Parser', font=("Helvetica", 22))],
             [sg.Text('https://github.com/abrignoni/RLEAPP', font=("Helvetica", 14))],
             [sg.Frame(layout=[
-                    [sg.Input(size=(97,1)), 
+                    [sg.Input(size=(97,1), key='INPUTPATH'), 
                      sg.FileBrowse(font=normal_font, button_text='Browse File', key='INPUTFILEBROWSE'),
                      sg.FolderBrowse(font=normal_font, button_text='Browse Folder', target=(sg.ThisRow, -2), key='INPUTFOLDERBROWSE')
                     ]
                 ],
                 title='Select the file (tar/zip/gz) or directory containing the data to be parsed:')],
             [sg.Frame(layout=[
-                    [sg.Input(size=(112,1)), sg.FolderBrowse(font=normal_font, button_text='Browse Folder')]
+                    [sg.Input(size=(112,1), key='OUTPUTPATH'), 
+                     sg.FolderBrowse(font=normal_font, button_text='Browse Folder')
+                    ]
                 ], 
                     title='Select Output Folder:')],
             [sg.Text('Available Modules')],
@@ -107,12 +191,12 @@ layout = [  [sg.Text('Returns, Logs, Events, And Protobuf Parser', font=("Helvet
              #     file_types=(('RLEAPP Profile (*.rlprofile)', '*.rlprofile'), ('All Files', '*')),
              #     default_extension='.rlprofile')
             sg.Text('  |', font=("Helvetica", 14)),
-            sg.Button('Load Case Data', key='LOAD CASE DATA'),
+            sg.Button('Add Case Data', key='ADD CASE DATA'),
             sg.Text('  |', font=("Helvetica", 14)),
                     sg.Text('Timezone Offset (Not Implemented Yet):', font=("Helvetica", 14)),
                     sg.Combo(list(tzvalues), size=(20,15), key='timezone',readonly=True)
             ],
-            [sg.Column(mlist, size=(300,310), scrollable=True),  sg.Output(size=(85,20))] ,
+            [sg.Column(mlist, size=(300,310), scrollable=True), sg.Output(size=(85,29))],
             [sg.ProgressBar(max_value=GuiWindow.progress_bar_total, orientation='h', size=(86, 7), key='PROGRESSBAR', bar_color=('DarkGreen', 'White'))],
             [sg.Submit('Process', font=normal_font), sg.Button('Close', font=normal_font)] ]
             
@@ -120,6 +204,7 @@ layout = [  [sg.Text('Returns, Logs, Events, And Protobuf Parser', font=("Helvet
 window = sg.Window(f'RLEAPP version {rleapp_version}', layout)
 GuiWindow.progress_bar_handle = window['PROGRESSBAR']
 profile_filename = None
+casedata = {}
 
 # Event Loop to process "events" and get the "values" of the inputs
 while True:
@@ -131,6 +216,7 @@ while True:
         # mark all modules
         for x in range(MODULE_START_INDEX, module_end_index):
             window[x].Update(True)
+
     if event == "DESELECT ALL":  
          # none modules
         for x in range(MODULE_START_INDEX, module_end_index):
@@ -145,7 +231,7 @@ while True:
         if destination_path:
             ticked = []
             for x in range(MODULE_START_INDEX, module_end_index):
-                if window.FindElement(x).Get():
+                if window[x].Get():
                     key = window[x].metadata
                     ticked.append(key)
             with open(destination_path, "wt", encoding="utf-8") as profile_out:
@@ -163,8 +249,8 @@ while True:
             with open(destination_path, "rt", encoding="utf-8") as profile_in:
                 try:
                     profile = json.load(profile_in)
-                except json.JSONDecodeError as json_ex:
-                    profile_load_error = f"File was not a valid profile file: {json_ex}"
+                except:
+                    profile_load_error = "File was not a valid profile file: invalid format"
 
             if not profile_load_error:
                 if isinstance(profile, dict):
@@ -184,41 +270,19 @@ while True:
             if profile_load_error:
                 sg.popup(profile_load_error)
             else:
-                sg.popup(f"Loaded profile: {destination_path}")
+                sg.popup(f"Loaded profile: {destination_path}", title="Load a profile")
                 profile_filename = destination_path
     
-    if event == 'LOAD CASE DATA':
-        destination_path = sg.popup_get_file(
-            "Load a case data", save_as=False,
-            file_types=(('RLEAPP Profile (*.rlprofile)', '*.rlprofile'), ('All Files', '*')),
-            default_extension='.rlprofile', no_window=True)
-        
-        if destination_path and os.path.exists(destination_path):
-            profile_load_error = None
-            with open(destination_path, "rt", encoding="utf-8") as profile_in:
-                try:
-                    profile = json.load(profile_in)
-                except json.JSONDecodeError as json_ex:
-                    profile_load_error = f"File was not a valid profile file: {json_ex}"
-                    
-            if not profile_load_error:
-                if isinstance(profile, dict):
-                    casedata = profile
-                else:
-                    profile_load_error = "File was not a valid profile file: invalid format"
-            
-            if profile_load_error:
-                sg.popup(profile_load_error)
-            else:
-                sg.popup(f"Loaded Case Data: {destination_path}")
-    
+    if event == "ADD CASE DATA":
+        casedata = add_case_data(casedata)
+
     if event == 'Process':
         #check is selections made properly; if not we will return to input form without exiting app altogether
         is_valid, extracttype = ValidateInput(values, window)
         if is_valid:
             GuiWindow.window_handle = window
-            input_path = values[0]
-            output_folder = values[1]
+            input_path = values['INPUTPATH']
+            output_folder = values['OUTPUTPATH']
 
             # File system extractions contain paths > 260 char, which causes problems
             # This fixes the problem by prefixing \\?\ on each windows path.
@@ -233,7 +297,7 @@ while True:
 
             s_items = 0
             for x in range(MODULE_START_INDEX, module_end_index):
-                if window.FindElement(x).Get():
+                if window[x].Get():
                     key = window[x].metadata
                     if key in loader:
                         search_list.append(loader[key])
@@ -252,11 +316,6 @@ while True:
             if time_offset == '':
                 time_offset = 'UTC'
             
-            try:
-                casedata
-            except NameError:
-                casedata = {}
-            
             crunch_successful = rleapp.crunch_artifacts(
                 search_list, extracttype, input_path, out_params, len(loader)/s_items, wrap_text, loader, casedata, time_offset, profile_filename)
             if crunch_successful:
@@ -273,6 +332,6 @@ while True:
                 log_path = out_params.screen_output_file_path
                 if log_path.startswith('\\\\?\\'): # windows
                     log_path = log_path[4:]
-                sg.Popup('Processing failed    :( ', f'See log for error details..\nLog file located at {log_path}')
+                sg.Popup('Processing failed    :( ', f'See log for error details..\nLog file located at {log_path}', title="Error")
             break
 window.close()

--- a/scripts/artifacts/documentsFolder.py
+++ b/scripts/artifacts/documentsFolder.py
@@ -6,8 +6,8 @@
 
 import os
 import datetime
-import magic
 
+from scripts.filetype import guess_mime, guess_extension
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
 
@@ -25,8 +25,8 @@ def get_documentsFolder(files_found, report_folder, seeker, wrap_text, time_offs
         utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
         
         if os.path.isfile(file_found):
-            mime = magic.from_file(file_found, mime=True)
-            ext = (mime.split('/')[1])
+            mime = guess_mime(file_found)
+            ext = guess_extension(file_found)
             
             linktofile = media_to_html(file_found, files_found, report_folder)
             if is_platform_windows:

--- a/scripts/artifacts/fbigAccountInfo.py
+++ b/scripts/artifacts/fbigAccountInfo.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigArchiveStories.py
+++ b/scripts/artifacts/fbigArchiveStories.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path

--- a/scripts/artifacts/fbigComments.py
+++ b/scripts/artifacts/fbigComments.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigDevices.py
+++ b/scripts/artifacts/fbigDevices.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigDirecShares.py
+++ b/scripts/artifacts/fbigDirecShares.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigDirectStories.py
+++ b/scripts/artifacts/fbigDirectStories.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigFollowers.py
+++ b/scripts/artifacts/fbigFollowers.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigFollowing.py
+++ b/scripts/artifacts/fbigFollowing.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigIncoFollow.py
+++ b/scripts/artifacts/fbigIncoFollow.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigLikes.py
+++ b/scripts/artifacts/fbigLikes.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigNcmec.py
+++ b/scripts/artifacts/fbigNcmec.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigPhotos.py
+++ b/scripts/artifacts/fbigPhotos.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigPofilePic.py
+++ b/scripts/artifacts/fbigPofilePic.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigUnifiedmessaging.py
+++ b/scripts/artifacts/fbigUnifiedmessaging.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/fbigVideos.py
+++ b/scripts/artifacts/fbigVideos.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from bs4 import BeautifulSoup
 from pathlib import Path	

--- a/scripts/artifacts/googleReturnsmbox.py
+++ b/scripts/artifacts/googleReturnsmbox.py
@@ -2,9 +2,9 @@ import os
 import datetime
 import csv
 import mailbox
-import magic
 import email
 
+from scripts.filetype import guess_extension
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
 
@@ -71,12 +71,9 @@ def get_googleReturnsmbox(files_found, report_folder, seeker, wrap_text, time_of
                     with open(pathfile, "wb") as f:
                         f.write(part.get_payload(decode=True))
                         
-                    fileExtension = magic.from_file(pathfile, mime=True)
-                    extension = fileExtension.split("/")[1]
-                    if extension == 'plain':
-                        extension = 'txt'
+                    extension = guess_extension(pathfile)
                         
-                    renamed = f'{pathfile}.{extension}'
+                    renamed = f'{pathfile}.{extension}' if extension else pathfile
                     try:
                         os.rename(pathfile, renamed)
                     except:

--- a/scripts/artifacts/icloudReturnsphotolibrary.py
+++ b/scripts/artifacts/icloudReturnsphotolibrary.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 import base64
 from PIL import Image

--- a/scripts/artifacts/instagramAdsclicked.py
+++ b/scripts/artifacts/instagramAdsclicked.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramAdsviewed.py
+++ b/scripts/artifacts/instagramAdsviewed.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramBlocked.py
+++ b/scripts/artifacts/instagramBlocked.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramDevices.py
+++ b/scripts/artifacts/instagramDevices.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramDevicescam.py
+++ b/scripts/artifacts/instagramDevicescam.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramFollowers.py
+++ b/scripts/artifacts/instagramFollowers.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramFollowing.py
+++ b/scripts/artifacts/instagramFollowing.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramInfotoadv.py
+++ b/scripts/artifacts/instagramInfotoadv.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramInterests.py
+++ b/scripts/artifacts/instagramInterests.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramLikedcomm.py
+++ b/scripts/artifacts/instagramLikedcomm.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramLikedposts.py
+++ b/scripts/artifacts/instagramLikedposts.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramLogin.py
+++ b/scripts/artifacts/instagramLogin.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramLogout.py
+++ b/scripts/artifacts/instagramLogout.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramMessageReq.py
+++ b/scripts/artifacts/instagramMessageReq.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramMessages.py
+++ b/scripts/artifacts/instagramMessages.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramMusicheard.py
+++ b/scripts/artifacts/instagramMusicheard.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramNointerest.py
+++ b/scripts/artifacts/instagramNointerest.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPasswordchange.py
+++ b/scripts/artifacts/instagramPasswordchange.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPending.py
+++ b/scripts/artifacts/instagramPending.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPolls.py
+++ b/scripts/artifacts/instagramPolls.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPostcom.py
+++ b/scripts/artifacts/instagramPostcom.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPosts.py
+++ b/scripts/artifacts/instagramPosts.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPostsviewed.py
+++ b/scripts/artifacts/instagramPostsviewed.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramPrivacychange.py
+++ b/scripts/artifacts/instagramPrivacychange.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramRecentreq.py
+++ b/scripts/artifacts/instagramRecentreq.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramRemovedsug.py
+++ b/scripts/artifacts/instagramRemovedsug.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramSavedposts.py
+++ b/scripts/artifacts/instagramSavedposts.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramSearches.py
+++ b/scripts/artifacts/instagramSearches.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramStories.py
+++ b/scripts/artifacts/instagramStories.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramSuggestedviewed.py
+++ b/scripts/artifacts/instagramSuggestedviewed.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/instagramVideoswatched.py
+++ b/scripts/artifacts/instagramVideoswatched.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import json
-import magic
 import shutil
 from pathlib import Path	
 

--- a/scripts/artifacts/kikProfilepic.py
+++ b/scripts/artifacts/kikProfilepic.py
@@ -3,7 +3,6 @@ import datetime
 import csv
 import codecs
 import shutil
-import magic
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html

--- a/scripts/artifacts/kikReturns.py
+++ b/scripts/artifacts/kikReturns.py
@@ -3,7 +3,6 @@ import datetime
 import csv
 import codecs
 import shutil
-import magic
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html

--- a/scripts/artifacts/netflixArchive.py
+++ b/scripts/artifacts/netflixArchive.py
@@ -3,7 +3,6 @@ import datetime
 import csv
 import codecs
 import shutil
-import magic
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, usergen, ipgen

--- a/scripts/artifacts/snapChatmemo.py
+++ b/scripts/artifacts/snapChatmemo.py
@@ -3,7 +3,6 @@ import datetime
 import csv
 import codecs
 import shutil
-import magic
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen

--- a/scripts/artifacts/snapChatsubsinfo.py
+++ b/scripts/artifacts/snapChatsubsinfo.py
@@ -3,7 +3,6 @@ import datetime
 import csv
 import codecs
 import shutil
-import magic
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows

--- a/scripts/artifacts/takeoutGoogleMail.py
+++ b/scripts/artifacts/takeoutGoogleMail.py
@@ -2,9 +2,9 @@ import os
 import datetime
 import csv
 import mailbox
-import magic
 import email
 
+from scripts.filetype import guess_extension
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
 
@@ -45,8 +45,9 @@ def get_takeoutGoogleMail(files_found, report_folder, seeker, wrap_text, time_of
             msubject = str(message['Subject'])
             
             msentdate = message['date']
-            msentdate = msentdate.replace('Sun, ','').replace('Mon, ','').replace('Tue, ','').replace('Wed, ','').replace('Thu, ','').replace('Fri, ','').replace('Sat, ','')
-            msentdate_split = msentdate.split(' ')
+            if msentdate:
+                msentdate = msentdate.replace('Sun, ','').replace('Mon, ','').replace('Tue, ','').replace('Wed, ','').replace('Thu, ','').replace('Fri, ','').replace('Sat, ','')
+                msentdate_split = msentdate.split(' ')
             
             day = msentdate_split[0]
             if len(day) < 2:
@@ -114,12 +115,9 @@ def get_takeoutGoogleMail(files_found, report_folder, seeker, wrap_text, time_of
                     with open(pathfile, "wb") as f:
                         f.write(part.get_payload(decode=True))
                         
-                    fileExtension = magic.from_file(pathfile, mime=True)
-                    extension = fileExtension.split("/")[1]
-                    if extension == 'plain':
-                        extension = 'txt'
+                    extension = guess_extension(pathfile)
                         
-                    renamed = f'{pathfile}.{extension}'
+                    renamed = f'{pathfile}.{extension}' if extension else pathfile
                     try:
                         os.rename(pathfile, renamed)
                     except:

--- a/scripts/artifacts/twitterReturns.py
+++ b/scripts/artifacts/twitterReturns.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import csv
 import codecs
 import shutil
-import magic
 import json
 
 from scripts.artifact_report import ArtifactHtmlReport

--- a/scripts/filetype.py
+++ b/scripts/filetype.py
@@ -1,0 +1,340 @@
+"""
+This is a Python port from filetype Go package.
+Small and dependency free Python package to infer file type and MIME type checking the magic numbers signature of a file or buffer.
+Version: 1.2.0
+Copyright (c) 2016 Tomás Aparicio
+
+-----
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# -*- coding: utf-8 -*-
+import pathlib
+
+from scripts.filetypes import ARCHIVE as archive_matchers
+from scripts.filetypes import AUDIO as audio_matchers
+from scripts.filetypes import APPLICATION as application_matchers
+from scripts.filetypes import DOCUMENT as document_matchers
+from scripts.filetypes import FONT as font_matchers
+from scripts.filetypes import IMAGE as image_matchers
+from scripts.filetypes import VIDEO as video_matchers
+from scripts.filetypes import TYPES, Type
+
+
+# utils.py
+
+_NUM_SIGNATURE_BYTES = 8192
+
+
+def get_signature_bytes(path):
+    """
+    Reads file from disk and returns the first 8192 bytes
+    of data representing the magic number header signature.
+
+    Args:
+        path: path string to file.
+
+    Returns:
+        First 8192 bytes of the file content as bytearray type.
+    """
+    with open(path, 'rb') as fp:
+        return bytearray(fp.read(_NUM_SIGNATURE_BYTES))
+
+
+def signature(array):
+    """
+    Returns the first 8192 bytes of the given bytearray
+    as part of the file header signature.
+
+    Args:
+        array: bytearray to extract the header signature.
+
+    Returns:
+        First 8192 bytes of the file content as bytearray type.
+    """
+    length = len(array)
+    index = _NUM_SIGNATURE_BYTES if length > _NUM_SIGNATURE_BYTES else length
+
+    return array[:index]
+
+
+def get_bytes(obj):
+    """
+    Infers the input type and reads the first 8192 bytes,
+    returning a sliced bytearray.
+
+    Args:
+        obj: path to readable, file-like object(with read() method), bytes,
+        bytearray or memoryview
+
+    Returns:
+        First 8192 bytes of the file content as bytearray type.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    if isinstance(obj, bytearray):
+        return signature(obj)
+
+    if isinstance(obj, str):
+        return get_signature_bytes(obj)
+
+    if isinstance(obj, bytes):
+        return signature(obj)
+
+    if isinstance(obj, memoryview):
+        return bytearray(signature(obj).tolist())
+
+    if isinstance(obj, pathlib.PurePath):
+        return get_signature_bytes(obj)
+
+    if hasattr(obj, 'read'):
+        if hasattr(obj, 'tell') and hasattr(obj, 'seek'):
+            start_pos = obj.tell()
+            obj.seek(0)
+            magic_bytes = obj.read(_NUM_SIGNATURE_BYTES)
+            obj.seek(start_pos)
+            return get_bytes(magic_bytes)
+        return get_bytes(obj.read(_NUM_SIGNATURE_BYTES))
+
+    raise TypeError('Unsupported type as file input: %s' % type(obj))
+
+
+# match.py
+
+def match(obj, matchers=TYPES):
+    """
+    Matches the given input against the available
+    file type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if type matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    buf = get_bytes(obj)
+
+    for matcher in matchers:
+        if matcher.match(buf):
+            return matcher
+
+    return None
+
+
+def image_match(obj):
+    """
+    Matches the given input against the available
+    image type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, image_matchers)
+
+
+def font_match(obj):
+    """
+    Matches the given input against the available
+    font type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, font_matchers)
+
+
+def video_match(obj):
+    """
+    Matches the given input against the available
+    video type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, video_matchers)
+
+
+def audio_match(obj):
+    """
+    Matches the given input against the available
+    autio type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, audio_matchers)
+
+
+def archive_match(obj):
+    """
+    Matches the given input against the available
+    archive type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, archive_matchers)
+
+
+def application_match(obj):
+    """
+    Matches the given input against the available
+    application type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, application_matchers)
+
+
+def document_match(obj):
+    """
+    Matches the given input against the available
+    document type matchers.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        Type instance if matches. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj, document_matchers)
+
+
+# Expose supported matchers types
+types = TYPES
+
+
+def guess(obj):
+    """
+    Infers the type of the given input.
+
+    Function is overloaded to accept multiple types in input
+    and perform the needed type inference based on it.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        The matched type instance. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    return match(obj) if obj else None
+
+
+def guess_mime(obj):
+    """
+    Infers the file type of the given input
+    and returns its MIME type.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        The matched MIME type as string. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    kind = guess(obj)
+    return kind.mime if kind else kind
+
+
+def guess_extension(obj):
+    """
+    Infers the file type of the given input
+    and returns its RFC file extension.
+
+    Args:
+        obj: path to file, bytes or bytearray.
+
+    Returns:
+        The matched file extension as string. Otherwise None.
+
+    Raises:
+        TypeError: if obj is not a supported type.
+    """
+    kind = guess(obj)
+    return kind.extension if kind else kind
+
+
+def get_type(mime=None, ext=None):
+    """
+    Returns the file type instance searching by
+    MIME type or file extension.
+
+    Args:
+        ext: file extension string. E.g: jpg, png, mp4, mp3
+        mime: MIME string. E.g: image/jpeg, video/mpeg
+
+    Returns:
+        The matched file type instance. Otherwise None.
+    """
+    for kind in types:
+        if kind.extension == ext or kind.mime == mime:
+            return kind
+    return None
+

--- a/scripts/filetypes/__init__.py
+++ b/scripts/filetypes/__init__.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+from . import application
+from . import archive
+from . import audio
+from . import document
+from . import font
+from . import image
+from . import text
+from . import video
+from .base import Type  # noqa
+
+# Supported image types
+IMAGE = (
+    image.Dwg(),
+    image.Xcf(),
+    image.Jpeg(),
+    image.Jpx(),
+    image.Apng(),
+    image.Png(),
+    image.Gif(),
+    image.Webp(),
+    image.Tiff(),
+    image.Cr2(),
+    image.Bmp(),
+    image.Jxr(),
+    image.Psd(),
+    image.Ico(),
+    image.Heic(),
+    image.Dcm(),
+    image.Avif(),
+    image.Qoi(),
+)
+
+# Supported video types
+VIDEO = (
+    video.M3gp(),
+    video.Mp4(),
+    video.M4v(),
+    video.Mkv(),
+    video.Mov(),
+    video.Avi(),
+    video.Wmv(),
+    video.Mpeg(),
+    video.Webm(),
+    video.Flv(),
+)
+
+# Supported audio types
+AUDIO = (
+    audio.Aac(),
+    audio.Midi(),
+    audio.Mp3(),
+    audio.M4a(),
+    audio.Ogg(),
+    audio.Flac(),
+    audio.Wav(),
+    audio.Amr(),
+    audio.Aiff(),
+)
+
+# Supported font types
+FONT = (font.Woff(), font.Woff2(), font.Ttf(), font.Otf())
+
+# Supported archive container types
+ARCHIVE = (
+    archive.Br(),
+    archive.Rpm(),
+    archive.Dcm(),
+    archive.Epub(),
+    archive.Zip(),
+    archive.Tar(),
+    archive.Rar(),
+    archive.Gz(),
+    archive.Bz2(),
+    archive.SevenZ(),
+    archive.Pdf(),
+    archive.Exe(),
+    archive.Swf(),
+    archive.Rtf(),
+    archive.Nes(),
+    archive.Crx(),
+    archive.Cab(),
+    archive.Eot(),
+    archive.Ps(),
+    archive.Xz(),
+    archive.Sqlite(),
+    archive.Deb(),
+    archive.Ar(),
+    archive.Z(),
+    archive.Lzop(),
+    archive.Lz(),
+    archive.Elf(),
+    archive.Lz4(),
+    archive.Zstd(),
+)
+
+# Supported archive container types
+APPLICATION = (
+    application.Wasm(),
+)
+
+# Supported document types
+DOCUMENT = (
+    document.Doc(),
+    document.Docx(),
+    document.Odt(),
+    document.Xls(),
+    document.Xlsx(),
+    document.Ods(),
+    document.Ppt(),
+    document.Pptx(),
+    document.Odp(),
+)
+
+# Supported text types
+TEXT = (
+    text.Json(),
+    text.Plist(),
+    text.Html(),
+)
+
+
+# Expose supported type matchers
+TYPES = list(IMAGE + AUDIO + VIDEO + FONT + DOCUMENT + ARCHIVE + APPLICATION + TEXT)

--- a/scripts/filetypes/application.py
+++ b/scripts/filetypes/application.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+
+
+class Wasm(Type):
+    """Implements the Wasm image type matcher."""
+
+    MIME = 'application/wasm'
+    EXTENSION = 'wasm'
+
+    def __init__(self):
+        super(Wasm, self).__init__(
+            mime=Wasm.MIME,
+            extension=Wasm.EXTENSION
+        )
+
+    def match(self, buf):
+        return buf[:8] == bytearray([0x00, 0x61, 0x73, 0x6d,
+                                     0x01, 0x00, 0x00, 0x00])

--- a/scripts/filetypes/archive.py
+++ b/scripts/filetypes/archive.py
@@ -1,0 +1,686 @@
+# -*- coding: utf-8 -*-
+
+import struct
+
+from .base import Type
+
+
+class Epub(Type):
+    """
+    Implements the EPUB archive type matcher.
+    """
+    MIME = 'application/epub+zip'
+    EXTENSION = 'epub'
+
+    def __init__(self):
+        super(Epub, self).__init__(
+            mime=Epub.MIME,
+            extension=Epub.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 57 and
+                buf[0] == 0x50 and buf[1] == 0x4B and
+                buf[2] == 0x3 and buf[3] == 0x4 and
+                buf[30] == 0x6D and buf[31] == 0x69 and
+                buf[32] == 0x6D and buf[33] == 0x65 and
+                buf[34] == 0x74 and buf[35] == 0x79 and
+                buf[36] == 0x70 and buf[37] == 0x65 and
+                buf[38] == 0x61 and buf[39] == 0x70 and
+                buf[40] == 0x70 and buf[41] == 0x6C and
+                buf[42] == 0x69 and buf[43] == 0x63 and
+                buf[44] == 0x61 and buf[45] == 0x74 and
+                buf[46] == 0x69 and buf[47] == 0x6F and
+                buf[48] == 0x6E and buf[49] == 0x2F and
+                buf[50] == 0x65 and buf[51] == 0x70 and
+                buf[52] == 0x75 and buf[53] == 0x62 and
+                buf[54] == 0x2B and buf[55] == 0x7A and
+                buf[56] == 0x69 and buf[57] == 0x70)
+
+
+class Zip(Type):
+    """
+    Implements the Zip archive type matcher.
+    """
+    MIME = 'application/zip'
+    EXTENSION = 'zip'
+
+    def __init__(self):
+        super(Zip, self).__init__(
+            mime=Zip.MIME,
+            extension=Zip.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x50 and buf[1] == 0x4B and
+                (buf[2] == 0x3 or buf[2] == 0x5 or
+                    buf[2] == 0x7) and
+                (buf[3] == 0x4 or buf[3] == 0x6 or
+                    buf[3] == 0x8))
+
+
+class Tar(Type):
+    """
+    Implements the Tar archive type matcher.
+    """
+    MIME = 'application/x-tar'
+    EXTENSION = 'tar'
+
+    def __init__(self):
+        super(Tar, self).__init__(
+            mime=Tar.MIME,
+            extension=Tar.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 261 and
+                buf[257] == 0x75 and
+                buf[258] == 0x73 and
+                buf[259] == 0x74 and
+                buf[260] == 0x61 and
+                buf[261] == 0x72)
+
+
+class Rar(Type):
+    """
+    Implements the RAR archive type matcher.
+    """
+    MIME = 'application/x-rar-compressed'
+    EXTENSION = 'rar'
+
+    def __init__(self):
+        super(Rar, self).__init__(
+            mime=Rar.MIME,
+            extension=Rar.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 6 and
+                buf[0] == 0x52 and
+                buf[1] == 0x61 and
+                buf[2] == 0x72 and
+                buf[3] == 0x21 and
+                buf[4] == 0x1A and
+                buf[5] == 0x7 and
+                (buf[6] == 0x0 or
+                    buf[6] == 0x1))
+
+
+class Gz(Type):
+    """
+    Implements the GZ archive type matcher.
+    """
+    MIME = 'application/gzip'
+    EXTENSION = 'gz'
+
+    def __init__(self):
+        super(Gz, self).__init__(
+            mime=Gz.MIME,
+            extension=Gz.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 2 and
+                buf[0] == 0x1F and
+                buf[1] == 0x8B and
+                buf[2] == 0x8)
+
+
+class Bz2(Type):
+    """
+    Implements the BZ2 archive type matcher.
+    """
+    MIME = 'application/x-bzip2'
+    EXTENSION = 'bz2'
+
+    def __init__(self):
+        super(Bz2, self).__init__(
+            mime=Bz2.MIME,
+            extension=Bz2.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 2 and
+                buf[0] == 0x42 and
+                buf[1] == 0x5A and
+                buf[2] == 0x68)
+
+
+class SevenZ(Type):
+    """
+    Implements the SevenZ (7z) archive type matcher.
+    """
+    MIME = 'application/x-7z-compressed'
+    EXTENSION = '7z'
+
+    def __init__(self):
+        super(SevenZ, self).__init__(
+            mime=SevenZ.MIME,
+            extension=SevenZ.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 5 and
+                buf[0] == 0x37 and
+                buf[1] == 0x7A and
+                buf[2] == 0xBC and
+                buf[3] == 0xAF and
+                buf[4] == 0x27 and
+                buf[5] == 0x1C)
+
+
+class Pdf(Type):
+    """
+    Implements the PDF archive type matcher.
+    """
+    MIME = 'application/pdf'
+    EXTENSION = 'pdf'
+
+    def __init__(self):
+        super(Pdf, self).__init__(
+            mime=Pdf.MIME,
+            extension=Pdf.EXTENSION
+        )
+
+    def match(self, buf):
+        # Detect BOM and skip first 3 bytes
+        if (len(buf) > 3 and
+            buf[0] == 0xEF and
+            buf[1] == 0xBB and
+            buf[2] == 0xBF):  # noqa E129
+            buf = buf[3:]
+
+        return (len(buf) > 3 and
+                buf[0] == 0x25 and
+                buf[1] == 0x50 and
+                buf[2] == 0x44 and
+                buf[3] == 0x46)
+
+
+class Exe(Type):
+    """
+    Implements the EXE archive type matcher.
+    """
+    MIME = 'application/x-msdownload'
+    EXTENSION = 'exe'
+
+    def __init__(self):
+        super(Exe, self).__init__(
+            mime=Exe.MIME,
+            extension=Exe.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 1 and
+                buf[0] == 0x4D and
+                buf[1] == 0x5A)
+
+
+class Swf(Type):
+    """
+    Implements the SWF archive type matcher.
+    """
+    MIME = 'application/x-shockwave-flash'
+    EXTENSION = 'swf'
+
+    def __init__(self):
+        super(Swf, self).__init__(
+            mime=Swf.MIME,
+            extension=Swf.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 2 and
+                (buf[0] == 0x46 or
+                 buf[0] == 0x43 or
+                 buf[0] == 0x5A) and
+                buf[1] == 0x57 and
+                buf[2] == 0x53)
+
+
+class Rtf(Type):
+    """
+    Implements the RTF archive type matcher.
+    """
+    MIME = 'application/rtf'
+    EXTENSION = 'rtf'
+
+    def __init__(self):
+        super(Rtf, self).__init__(
+            mime=Rtf.MIME,
+            extension=Rtf.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 4 and
+                buf[0] == 0x7B and
+                buf[1] == 0x5C and
+                buf[2] == 0x72 and
+                buf[3] == 0x74 and
+                buf[4] == 0x66)
+
+
+class Nes(Type):
+    """
+    Implements the NES archive type matcher.
+    """
+    MIME = 'application/x-nintendo-nes-rom'
+    EXTENSION = 'nes'
+
+    def __init__(self):
+        super(Nes, self).__init__(
+            mime=Nes.MIME,
+            extension=Nes.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x4E and
+                buf[1] == 0x45 and
+                buf[2] == 0x53 and
+                buf[3] == 0x1A)
+
+
+class Crx(Type):
+    """
+    Implements the CRX archive type matcher.
+    """
+    MIME = 'application/x-google-chrome-extension'
+    EXTENSION = 'crx'
+
+    def __init__(self):
+        super(Crx, self).__init__(
+            mime=Crx.MIME,
+            extension=Crx.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x43 and
+                buf[1] == 0x72 and
+                buf[2] == 0x32 and
+                buf[3] == 0x34)
+
+
+class Cab(Type):
+    """
+    Implements the CAB archive type matcher.
+    """
+    MIME = 'application/vnd.ms-cab-compressed'
+    EXTENSION = 'cab'
+
+    def __init__(self):
+        super(Cab, self).__init__(
+            mime=Cab.MIME,
+            extension=Cab.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                ((buf[0] == 0x4D and
+                    buf[1] == 0x53 and
+                    buf[2] == 0x43 and
+                    buf[3] == 0x46) or
+                    (buf[0] == 0x49 and
+                        buf[1] == 0x53 and
+                        buf[2] == 0x63 and
+                        buf[3] == 0x28)))
+
+
+class Eot(Type):
+    """
+    Implements the EOT archive type matcher.
+    """
+    MIME = 'application/octet-stream'
+    EXTENSION = 'eot'
+
+    def __init__(self):
+        super(Eot, self).__init__(
+            mime=Eot.MIME,
+            extension=Eot.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 35 and
+                buf[34] == 0x4C and
+                buf[35] == 0x50 and
+                ((buf[8] == 0x02 and
+                    buf[9] == 0x00 and
+                    buf[10] == 0x01) or
+                (buf[8] == 0x01 and
+                    buf[9] == 0x00 and
+                    buf[10] == 0x00) or
+                    (buf[8] == 0x02 and
+                        buf[9] == 0x00 and
+                        buf[10] == 0x02)))
+
+
+class Ps(Type):
+    """
+    Implements the PS archive type matcher.
+    """
+    MIME = 'application/postscript'
+    EXTENSION = 'ps'
+
+    def __init__(self):
+        super(Ps, self).__init__(
+            mime=Ps.MIME,
+            extension=Ps.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 1 and
+                buf[0] == 0x25 and
+                buf[1] == 0x21)
+
+
+class Xz(Type):
+    """
+    Implements the XS archive type matcher.
+    """
+    MIME = 'application/x-xz'
+    EXTENSION = 'xz'
+
+    def __init__(self):
+        super(Xz, self).__init__(
+            mime=Xz.MIME,
+            extension=Xz.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 5 and
+                buf[0] == 0xFD and
+                buf[1] == 0x37 and
+                buf[2] == 0x7A and
+                buf[3] == 0x58 and
+                buf[4] == 0x5A and
+                buf[5] == 0x00)
+
+
+class Sqlite(Type):
+    """
+    Implements the Sqlite DB archive type matcher.
+    """
+    MIME = 'application/x-sqlite3'
+    EXTENSION = 'sqlite'
+
+    def __init__(self):
+        super(Sqlite, self).__init__(
+            mime=Sqlite.MIME,
+            extension=Sqlite.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x53 and
+                buf[1] == 0x51 and
+                buf[2] == 0x4C and
+                buf[3] == 0x69)
+
+
+class Deb(Type):
+    """
+    Implements the DEB archive type matcher.
+    """
+    MIME = 'application/x-deb'
+    EXTENSION = 'deb'
+
+    def __init__(self):
+        super(Deb, self).__init__(
+            mime=Deb.MIME,
+            extension=Deb.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 20 and
+                buf[0] == 0x21 and
+                buf[1] == 0x3C and
+                buf[2] == 0x61 and
+                buf[3] == 0x72 and
+                buf[4] == 0x63 and
+                buf[5] == 0x68 and
+                buf[6] == 0x3E and
+                buf[7] == 0x0A and
+                buf[8] == 0x64 and
+                buf[9] == 0x65 and
+                buf[10] == 0x62 and
+                buf[11] == 0x69 and
+                buf[12] == 0x61 and
+                buf[13] == 0x6E and
+                buf[14] == 0x2D and
+                buf[15] == 0x62 and
+                buf[16] == 0x69 and
+                buf[17] == 0x6E and
+                buf[18] == 0x61 and
+                buf[19] == 0x72 and
+                buf[20] == 0x79)
+
+
+class Ar(Type):
+    """
+    Implements the AR archive type matcher.
+    """
+    MIME = 'application/x-unix-archive'
+    EXTENSION = 'ar'
+
+    def __init__(self):
+        super(Ar, self).__init__(
+            mime=Ar.MIME,
+            extension=Ar.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 6 and
+                buf[0] == 0x21 and
+                buf[1] == 0x3C and
+                buf[2] == 0x61 and
+                buf[3] == 0x72 and
+                buf[4] == 0x63 and
+                buf[5] == 0x68 and
+                buf[6] == 0x3E)
+
+
+class Z(Type):
+    """
+    Implements the Z archive type matcher.
+    """
+    MIME = 'application/x-compress'
+    EXTENSION = 'Z'
+
+    def __init__(self):
+        super(Z, self).__init__(
+            mime=Z.MIME,
+            extension=Z.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 1 and
+                ((buf[0] == 0x1F and
+                    buf[1] == 0xA0) or
+                (buf[0] == 0x1F and
+                    buf[1] == 0x9D)))
+
+
+class Lzop(Type):
+    """
+    Implements the Lzop archive type matcher.
+    """
+    MIME = 'application/x-lzop'
+    EXTENSION = 'lzo'
+
+    def __init__(self):
+        super(Lzop, self).__init__(
+            mime=Lzop.MIME,
+            extension=Lzop.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 7 and
+                buf[0] == 0x89 and
+                buf[1] == 0x4C and
+                buf[2] == 0x5A and
+                buf[3] == 0x4F and
+                buf[4] == 0x00 and
+                buf[5] == 0x0D and
+                buf[6] == 0x0A and
+                buf[7] == 0x1A)
+
+
+class Lz(Type):
+    """
+    Implements the Lz archive type matcher.
+    """
+    MIME = 'application/x-lzip'
+    EXTENSION = 'lz'
+
+    def __init__(self):
+        super(Lz, self).__init__(
+            mime=Lz.MIME,
+            extension=Lz.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x4C and
+                buf[1] == 0x5A and
+                buf[2] == 0x49 and
+                buf[3] == 0x50)
+
+
+class Elf(Type):
+    """
+    Implements the Elf archive type matcher
+    """
+    MIME = 'application/x-executable'
+    EXTENSION = 'elf'
+
+    def __init__(self):
+        super(Elf, self).__init__(
+            mime=Elf.MIME,
+            extension=Elf.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 52 and
+                buf[0] == 0x7F and
+                buf[1] == 0x45 and
+                buf[2] == 0x4C and
+                buf[3] == 0x46)
+
+
+class Lz4(Type):
+    """
+    Implements the Lz4 archive type matcher.
+    """
+    MIME = 'application/x-lz4'
+    EXTENSION = 'lz4'
+
+    def __init__(self):
+        super(Lz4, self).__init__(
+            mime=Lz4.MIME,
+            extension=Lz4.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x04 and
+                buf[1] == 0x22 and
+                buf[2] == 0x4D and
+                buf[3] == 0x18)
+
+
+class Br(Type):
+    """Implements the Br image type matcher."""
+
+    MIME = 'application/x-brotli'
+    EXTENSION = 'br'
+
+    def __init__(self):
+        super(Br, self).__init__(
+            mime=Br.MIME,
+            extension=Br.EXTENSION
+        )
+
+    def match(self, buf):
+        return buf[:4] == bytearray([0xce, 0xb2, 0xcf, 0x81])
+
+
+class Dcm(Type):
+    """Implements the Dcm image type matcher."""
+
+    MIME = 'application/dicom'
+    EXTENSION = 'dcm'
+
+    def __init__(self):
+        super(Dcm, self).__init__(
+            mime=Dcm.MIME,
+            extension=Dcm.EXTENSION
+        )
+
+    def match(self, buf):
+        return buf[128:131] == bytearray([0x44, 0x49, 0x43, 0x4d])
+
+
+class Rpm(Type):
+    """Implements the Rpm image type matcher."""
+
+    MIME = 'application/x-rpm'
+    EXTENSION = 'rpm'
+
+    def __init__(self):
+        super(Rpm, self).__init__(
+            mime=Rpm.MIME,
+            extension=Rpm.EXTENSION
+        )
+
+    def match(self, buf):
+        return buf[:4] == bytearray([0xed, 0xab, 0xee, 0xdb])
+
+
+class Zstd(Type):
+    """
+    Implements the Zstd archive type matcher.
+    https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md
+    """
+    MIME = 'application/zstd'
+    EXTENSION = 'zst'
+    MAGIC_SKIPPABLE_START = 0x184D2A50
+    MAGIC_SKIPPABLE_MASK = 0xFFFFFFF0
+
+    def __init__(self):
+        super(Zstd, self).__init__(
+            mime=Zstd.MIME,
+            extension=Zstd.EXTENSION
+        )
+
+    @staticmethod
+    def _to_little_endian_int(buf):
+        # return int.from_bytes(buf, byteorder='little')
+        return struct.unpack('<L', buf)[0]
+
+    def match(self, buf):
+        # Zstandard compressed data is made of one or more frames.
+        # There are two frame formats defined by Zstandard:
+        # Zstandard frames and Skippable frames.
+        # See more details from
+        # https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2
+        is_zstd = (
+            len(buf) > 3 and
+            buf[0] in (0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28) and
+            buf[1] == 0xb5 and
+            buf[2] == 0x2f and
+            buf[3] == 0xfd)
+        if is_zstd:
+            return True
+        # skippable frames
+        if len(buf) < 8:
+            return False
+        magic = self._to_little_endian_int(buf[:4]) & Zstd.MAGIC_SKIPPABLE_MASK
+        if magic == Zstd.MAGIC_SKIPPABLE_START:
+            user_data_len = self._to_little_endian_int(buf[4:8])
+            if len(buf) < 8 + user_data_len:
+                return False
+            next_frame = buf[8 + user_data_len:]
+            return self.match(next_frame)
+        return False

--- a/scripts/filetypes/audio.py
+++ b/scripts/filetypes/audio.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+
+
+class Midi(Type):
+    """
+    Implements the Midi audio type matcher.
+    """
+    MIME = 'audio/midi'
+    EXTENSION = 'midi'
+
+    def __init__(self):
+        super(Midi, self).__init__(
+            mime=Midi.MIME,
+            extension=Midi.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x4D and
+                buf[1] == 0x54 and
+                buf[2] == 0x68 and
+                buf[3] == 0x64)
+
+
+class Mp3(Type):
+    """
+    Implements the MP3 audio type matcher.
+    """
+    MIME = 'audio/mpeg'
+    EXTENSION = 'mp3'
+
+    def __init__(self):
+        super(Mp3, self).__init__(
+            mime=Mp3.MIME,
+            extension=Mp3.EXTENSION
+        )
+
+    def match(self, buf):
+        if len(buf) > 2:
+            if (
+                buf[0] == 0x49 and
+                buf[1] == 0x44 and
+                buf[2] == 0x33
+            ):
+                return True
+
+            if buf[0] == 0xFF:
+                if (
+                    buf[1] == 0xE2 or  # MPEG 2.5 with error protection
+                    buf[1] == 0xE3 or  # MPEG 2.5 w/o error protection
+                    buf[1] == 0xF2 or  # MPEG 2 with error protection
+                    buf[1] == 0xF3 or  # MPEG 2 w/o error protection
+                    buf[1] == 0xFA or  # MPEG 1 with error protection
+                    buf[1] == 0xFB     # MPEG 1 w/o error protection
+                ):
+                    return True
+        return False
+
+
+class M4a(Type):
+    """
+    Implements the M4A audio type matcher.
+    """
+    MIME = 'audio/mp4'
+    EXTENSION = 'm4a'
+
+    def __init__(self):
+        super(M4a, self).__init__(
+            mime=M4a.MIME,
+            extension=M4a.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 10 and
+                ((buf[4] == 0x66 and
+                    buf[5] == 0x74 and
+                    buf[6] == 0x79 and
+                    buf[7] == 0x70 and
+                    buf[8] == 0x4D and
+                    buf[9] == 0x34 and
+                    buf[10] == 0x41) or
+                (buf[0] == 0x4D and
+                    buf[1] == 0x34 and
+                    buf[2] == 0x41 and
+                    buf[3] == 0x20)))
+
+
+class Ogg(Type):
+    """
+    Implements the OGG audio type matcher.
+    """
+    MIME = 'audio/ogg'
+    EXTENSION = 'ogg'
+
+    def __init__(self):
+        super(Ogg, self).__init__(
+            mime=Ogg.MIME,
+            extension=Ogg.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x4F and
+                buf[1] == 0x67 and
+                buf[2] == 0x67 and
+                buf[3] == 0x53)
+
+
+class Flac(Type):
+    """
+    Implements the FLAC audio type matcher.
+    """
+    MIME = 'audio/x-flac'
+    EXTENSION = 'flac'
+
+    def __init__(self):
+        super(Flac, self).__init__(
+            mime=Flac.MIME,
+            extension=Flac.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x66 and
+                buf[1] == 0x4C and
+                buf[2] == 0x61 and
+                buf[3] == 0x43)
+
+
+class Wav(Type):
+    """
+    Implements the WAV audio type matcher.
+    """
+    MIME = 'audio/x-wav'
+    EXTENSION = 'wav'
+
+    def __init__(self):
+        super(Wav, self).__init__(
+            mime=Wav.MIME,
+            extension=Wav.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 11 and
+                buf[0] == 0x52 and
+                buf[1] == 0x49 and
+                buf[2] == 0x46 and
+                buf[3] == 0x46 and
+                buf[8] == 0x57 and
+                buf[9] == 0x41 and
+                buf[10] == 0x56 and
+                buf[11] == 0x45)
+
+
+class Amr(Type):
+    """
+    Implements the AMR audio type matcher.
+    """
+    MIME = 'audio/amr'
+    EXTENSION = 'amr'
+
+    def __init__(self):
+        super(Amr, self).__init__(
+            mime=Amr.MIME,
+            extension=Amr.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 11 and
+                buf[0] == 0x23 and
+                buf[1] == 0x21 and
+                buf[2] == 0x41 and
+                buf[3] == 0x4D and
+                buf[4] == 0x52 and
+                buf[5] == 0x0A)
+
+
+class Aac(Type):
+    """Implements the Aac audio type matcher."""
+
+    MIME = 'audio/aac'
+    EXTENSION = 'aac'
+
+    def __init__(self):
+        super(Aac, self).__init__(
+            mime=Aac.MIME,
+            extension=Aac.EXTENSION
+        )
+
+    def match(self, buf):
+        return (buf[:2] == bytearray([0xff, 0xf1]) or
+                buf[:2] == bytearray([0xff, 0xf9]))
+
+
+class Aiff(Type):
+    """
+    Implements the AIFF audio type matcher.
+    """
+    MIME = 'audio/x-aiff'
+    EXTENSION = 'aiff'
+
+    def __init__(self):
+        super(Aiff, self).__init__(
+            mime=Aiff.MIME,
+            extension=Aiff.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 11 and
+                buf[0] == 0x46 and
+                buf[1] == 0x4F and
+                buf[2] == 0x52 and
+                buf[3] == 0x4D and
+                buf[8] == 0x41 and
+                buf[9] == 0x49 and
+                buf[10] == 0x46 and
+                buf[11] == 0x46)

--- a/scripts/filetypes/base.py
+++ b/scripts/filetypes/base.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+
+class Type(object):
+    """
+    Represents the file type object inherited by
+    specific file type matchers.
+    Provides convenient accessor and helper methods.
+    """
+    def __init__(self, mime, extension):
+        self.__mime = mime
+        self.__extension = extension
+
+    @property
+    def mime(self):
+        return self.__mime
+
+    @property
+    def extension(self):
+        return self.__extension
+
+    def is_extension(self, extension):
+        return self.__extension is extension
+
+    def is_mime(self, mime):
+        return self.__mime is mime
+
+    def match(self, buf):
+        raise NotImplementedError

--- a/scripts/filetypes/document.py
+++ b/scripts/filetypes/document.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+
+
+class ZippedDocumentBase(Type):
+    def match(self, buf):
+        # start by checking for ZIP local file header signature
+        idx = self.search_signature(buf, 0, 6000)
+        if idx != 0:
+            return
+
+        return self.match_document(buf)
+
+    def match_document(self, buf):
+        raise NotImplementedError
+
+    def compare_bytes(self, buf, subslice, start_offset):
+        sl = len(subslice)
+
+        if start_offset + sl > len(buf):
+            return False
+
+        return buf[start_offset:start_offset + sl] == subslice
+
+    def search_signature(self, buf, start, rangeNum):
+        signature = b"PK\x03\x04"
+        length = len(buf)
+
+        end = start + rangeNum
+        end = length if end > length else end
+
+        if start >= end:
+            return -1
+
+        try:
+            return buf.index(signature, start, end)
+        except ValueError:
+            return -1
+
+
+class OpenDocument(ZippedDocumentBase):
+    def match_document(self, buf):
+        # Check if first file in archive is the identifying file
+        if not self.compare_bytes(buf, b"mimetype", 0x1E):
+            return
+
+        # Check content of mimetype file if it matches current mime
+        return self.compare_bytes(buf, bytes(self.mime, "ASCII"), 0x26)
+
+
+class OfficeOpenXml(ZippedDocumentBase):
+    def match_document(self, buf):
+        # Check if first file in archive is the identifying file
+        ft = self.match_filename(buf, 0x1E)
+        if ft:
+            return ft
+
+        # Otherwise check that the fist file is one of these
+        if (
+            not self.compare_bytes(buf, b"[Content_Types].xml", 0x1E)
+            and not self.compare_bytes(buf, b"_rels/.rels", 0x1E)
+            and not self.compare_bytes(buf, b"docProps", 0x1E)
+        ):
+            return
+
+        # Loop through next 3 files and check if they match
+        # NOTE: OpenOffice/Libreoffice orders ZIP entry differently, so check the 4th file
+        # https://github.com/h2non/filetype/blob/d730d98ad5c990883148485b6fd5adbdd378364a/matchers/document.go#L134
+        idx = 0
+        for i in range(4):
+            # Search for next file header
+            idx = self.search_signature(buf, idx + 4, 6000)
+            if idx == -1:
+                return
+
+            # Filename is at file header + 30
+            ft = self.match_filename(buf, idx + 30)
+            if ft:
+                return ft
+
+    def match_filename(self, buf, offset):
+        if self.compare_bytes(buf, b"word/", offset):
+            return (
+                self.mime
+                == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            )
+        if self.compare_bytes(buf, b"ppt/", offset):
+            return (
+                self.mime
+                == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            )
+        if self.compare_bytes(buf, b"xl/", offset):
+            return (
+                self.mime
+                == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+
+
+class Doc(Type):
+    """
+    Implements the Microsoft Word (Office 97-2003) document type matcher.
+    """
+
+    MIME = "application/msword"
+    EXTENSION = "doc"
+
+    def __init__(self):
+        super(Doc, self).__init__(mime=Doc.MIME, extension=Doc.EXTENSION)
+
+    def match(self, buf):
+        if len(buf) > 515 and buf[0:8] == b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1":
+            if buf[512:516] == b"\xEC\xA5\xC1\x00":
+                return True
+            if (
+                len(buf) > 2142
+                and (
+                    b"\x00\x0A\x00\x00\x00MSWordDoc\x00\x10\x00\x00\x00Word.Document.8\x00\xF49\xB2q"
+                    in buf[2075:2142]
+                    or b"W\0o\0r\0d\0D\0o\0c\0u\0m\0e\0n\0t\0"
+                    in buf[0x580:0x598]
+                )
+            ):
+                return True
+
+        return False
+
+
+class Docx(OfficeOpenXml):
+    """
+    Implements the Microsoft Word OOXML (Office 2007+) document type matcher.
+    """
+
+    MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    EXTENSION = "docx"
+
+    def __init__(self):
+        super(Docx, self).__init__(mime=Docx.MIME, extension=Docx.EXTENSION)
+
+
+class Odt(OpenDocument):
+    """
+    Implements the OpenDocument Text document type matcher.
+    """
+
+    MIME = "application/vnd.oasis.opendocument.text"
+    EXTENSION = "odt"
+
+    def __init__(self):
+        super(Odt, self).__init__(mime=Odt.MIME, extension=Odt.EXTENSION)
+
+
+class Xls(Type):
+    """
+    Implements the Microsoft Excel (Office 97-2003) document type matcher.
+    """
+
+    MIME = "application/vnd.ms-excel"
+    EXTENSION = "xls"
+
+    def __init__(self):
+        super(Xls, self).__init__(mime=Xls.MIME, extension=Xls.EXTENSION)
+
+    def match(self, buf):
+        if len(buf) > 520 and buf[0:8] == b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1":
+            if buf[512:516] == b"\xFD\xFF\xFF\xFF" and (
+                buf[518] == 0x00 or buf[518] == 0x02
+            ):
+                return True
+            if buf[512:520] == b"\x09\x08\x10\x00\x00\x06\x05\x00":
+                return True
+            if (
+                len(buf) > 2095
+                and b"\xE2\x00\x00\x00\x5C\x00\x70\x00\x04\x00\x00Calc"
+                in buf[1568:2095]
+            ):
+                return True
+
+        return False
+
+
+class Xlsx(OfficeOpenXml):
+    """
+    Implements the Microsoft Excel OOXML (Office 2007+) document type matcher.
+    """
+
+    MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    EXTENSION = "xlsx"
+
+    def __init__(self):
+        super(Xlsx, self).__init__(mime=Xlsx.MIME, extension=Xlsx.EXTENSION)
+
+
+class Ods(OpenDocument):
+    """
+    Implements the OpenDocument Spreadsheet document type matcher.
+    """
+
+    MIME = "application/vnd.oasis.opendocument.spreadsheet"
+    EXTENSION = "ods"
+
+    def __init__(self):
+        super(Ods, self).__init__(mime=Ods.MIME, extension=Ods.EXTENSION)
+
+
+class Ppt(Type):
+    """
+    Implements the Microsoft PowerPoint (Office 97-2003) document type matcher.
+    """
+
+    MIME = "application/vnd.ms-powerpoint"
+    EXTENSION = "ppt"
+
+    def __init__(self):
+        super(Ppt, self).__init__(mime=Ppt.MIME, extension=Ppt.EXTENSION)
+
+    def match(self, buf):
+        if len(buf) > 524 and buf[0:8] == b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1":
+            if buf[512:516] == b"\xA0\x46\x1D\xF0":
+                return True
+            if buf[512:516] == b"\x00\x6E\x1E\xF0":
+                return True
+            if buf[512:516] == b"\x0F\x00\xE8\x03":
+                return True
+            if buf[512:516] == b"\xFD\xFF\xFF\xFF" and buf[522:524] == b"\x00\x00":
+                return True
+            if (
+                len(buf) > 2096
+                and buf[2072:2096]
+                == b"\x00\xB9\x29\xE8\x11\x00\x00\x00MS PowerPoint 97"
+            ):
+                return True
+
+        return False
+
+
+class Pptx(OfficeOpenXml):
+    """
+    Implements the Microsoft PowerPoint OOXML (Office 2007+) document type matcher.
+    """
+
+    MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    EXTENSION = "pptx"
+
+    def __init__(self):
+        super(Pptx, self).__init__(mime=Pptx.MIME, extension=Pptx.EXTENSION)
+
+
+class Odp(OpenDocument):
+    """
+    Implements the OpenDocument Presentation document type matcher.
+    """
+
+    MIME = "application/vnd.oasis.opendocument.presentation"
+    EXTENSION = "odp"
+
+    def __init__(self):
+        super(Odp, self).__init__(mime=Odp.MIME, extension=Odp.EXTENSION)

--- a/scripts/filetypes/font.py
+++ b/scripts/filetypes/font.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+
+
+class Woff(Type):
+    """
+    Implements the WOFF font type matcher.
+    """
+    MIME = 'application/font-woff'
+    EXTENSION = 'woff'
+
+    def __init__(self):
+        super(Woff, self).__init__(
+            mime=Woff.MIME,
+            extension=Woff.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 7 and
+                buf[0] == 0x77 and
+                buf[1] == 0x4F and
+                buf[2] == 0x46 and
+                buf[3] == 0x46 and
+                ((buf[4] == 0x00 and
+                  buf[5] == 0x01 and
+                  buf[6] == 0x00 and
+                  buf[7] == 0x00) or
+                 (buf[4] == 0x4F and
+                  buf[5] == 0x54 and
+                  buf[6] == 0x54 and
+                  buf[7] == 0x4F) or
+                 (buf[4] == 0x74 and
+                  buf[5] == 0x72 and
+                  buf[6] == 0x75 and
+                  buf[7] == 0x65)))
+
+
+class Woff2(Type):
+    """
+    Implements the WOFF2 font type matcher.
+    """
+    MIME = 'application/font-woff'
+    EXTENSION = 'woff2'
+
+    def __init__(self):
+        super(Woff2, self).__init__(
+            mime=Woff2.MIME,
+            extension=Woff2.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 7 and
+                buf[0] == 0x77 and
+                buf[1] == 0x4F and
+                buf[2] == 0x46 and
+                buf[3] == 0x32 and
+                ((buf[4] == 0x00 and
+                  buf[5] == 0x01 and
+                  buf[6] == 0x00 and
+                  buf[7] == 0x00) or
+                 (buf[4] == 0x4F and
+                  buf[5] == 0x54 and
+                  buf[6] == 0x54 and
+                  buf[7] == 0x4F) or
+                 (buf[4] == 0x74 and
+                  buf[5] == 0x72 and
+                  buf[6] == 0x75 and
+                  buf[7] == 0x65)))
+
+
+class Ttf(Type):
+    """
+    Implements the TTF font type matcher.
+    """
+    MIME = 'application/font-sfnt'
+    EXTENSION = 'ttf'
+
+    def __init__(self):
+        super(Ttf, self).__init__(
+            mime=Ttf.MIME,
+            extension=Ttf.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 4 and
+                buf[0] == 0x00 and
+                buf[1] == 0x01 and
+                buf[2] == 0x00 and
+                buf[3] == 0x00 and
+                buf[4] == 0x00)
+
+
+class Otf(Type):
+    """
+    Implements the OTF font type matcher.
+    """
+    MIME = 'application/font-sfnt'
+    EXTENSION = 'otf'
+
+    def __init__(self):
+        super(Otf, self).__init__(
+            mime=Otf.MIME,
+            extension=Otf.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 4 and
+                buf[0] == 0x4F and
+                buf[1] == 0x54 and
+                buf[2] == 0x54 and
+                buf[3] == 0x4F and
+                buf[4] == 0x00)

--- a/scripts/filetypes/image.py
+++ b/scripts/filetypes/image.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+from .isobmff import IsoBmff
+
+
+class Jpeg(Type):
+    """
+    Implements the JPEG image type matcher.
+    """
+    MIME = 'image/jpeg'
+    EXTENSION = 'jpg'
+
+    def __init__(self):
+        super(Jpeg, self).__init__(
+            mime=Jpeg.MIME,
+            extension=Jpeg.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 2 and
+                buf[0] == 0xFF and
+                buf[1] == 0xD8 and
+                buf[2] == 0xFF)
+
+
+class Jpx(Type):
+    """
+    Implements the JPEG2000 image type matcher.
+    """
+
+    MIME = "image/jpx"
+    EXTENSION = "jpx"
+
+    def __init__(self):
+        super(Jpx, self).__init__(mime=Jpx.MIME, extension=Jpx.EXTENSION)
+
+    def match(self, buf):
+        return (
+            len(buf) > 50
+            and buf[0] == 0x00
+            and buf[1] == 0x00
+            and buf[2] == 0x00
+            and buf[3] == 0x0C
+            and buf[16:24] == b"ftypjp2 "
+        )
+
+
+class Apng(Type):
+    """
+    Implements the APNG image type matcher.
+    """
+    MIME = 'image/apng'
+    EXTENSION = 'apng'
+
+    def __init__(self):
+        super(Apng, self).__init__(
+            mime=Apng.MIME,
+            extension=Apng.EXTENSION
+        )
+
+    def match(self, buf):
+        if (len(buf) > 8 and
+            buf[:8] == bytearray([0x89, 0x50, 0x4e, 0x47,
+                                  0x0d, 0x0a, 0x1a, 0x0a])):
+            # cursor in buf, skip already readed 8 bytes
+            i = 8
+            while len(buf) > i:
+                data_length = int.from_bytes(buf[i:i+4], byteorder="big")
+                i += 4
+
+                chunk_type = buf[i:i+4].decode("ascii", errors='ignore')
+                i += 4
+
+                # acTL chunk in APNG must appear before IDAT
+                # IEND is end of PNG
+                if (chunk_type == "IDAT" or chunk_type == "IEND"):
+                    return False
+                if (chunk_type == "acTL"):
+                    return True
+
+                # move to the next chunk by skipping data and crc (4 bytes)
+                i += data_length + 4
+
+        return False
+
+
+class Png(Type):
+    """
+    Implements the PNG image type matcher.
+    """
+    MIME = 'image/png'
+    EXTENSION = 'png'
+
+    def __init__(self):
+        super(Png, self).__init__(
+            mime=Png.MIME,
+            extension=Png.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x89 and
+                buf[1] == 0x50 and
+                buf[2] == 0x4E and
+                buf[3] == 0x47)
+
+
+class Gif(Type):
+    """
+    Implements the GIF image type matcher.
+    """
+    MIME = 'image/gif'
+    EXTENSION = 'gif'
+
+    def __init__(self):
+        super(Gif, self).__init__(
+            mime=Gif.MIME,
+            extension=Gif.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 2 and
+                buf[0] == 0x47 and
+                buf[1] == 0x49 and
+                buf[2] == 0x46)
+
+
+class Webp(Type):
+    """
+    Implements the WEBP image type matcher.
+    """
+    MIME = 'image/webp'
+    EXTENSION = 'webp'
+
+    def __init__(self):
+        super(Webp, self).__init__(
+            mime=Webp.MIME,
+            extension=Webp.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 13 and
+                buf[0] == 0x52 and
+                buf[1] == 0x49 and
+                buf[2] == 0x46 and
+                buf[3] == 0x46 and
+                buf[8] == 0x57 and
+                buf[9] == 0x45 and
+                buf[10] == 0x42 and
+                buf[11] == 0x50 and
+                buf[12] == 0x56 and
+                buf[13] == 0x50)
+
+
+class Cr2(Type):
+    """
+    Implements the CR2 image type matcher.
+    """
+    MIME = 'image/x-canon-cr2'
+    EXTENSION = 'cr2'
+
+    def __init__(self):
+        super(Cr2, self).__init__(
+            mime=Cr2.MIME,
+            extension=Cr2.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 9 and
+                ((buf[0] == 0x49 and buf[1] == 0x49 and
+                    buf[2] == 0x2A and buf[3] == 0x0) or
+                (buf[0] == 0x4D and buf[1] == 0x4D and
+                    buf[2] == 0x0 and buf[3] == 0x2A)) and
+                buf[8] == 0x43 and buf[9] == 0x52)
+
+
+class Tiff(Type):
+    """
+    Implements the TIFF image type matcher.
+    """
+    MIME = 'image/tiff'
+    EXTENSION = 'tif'
+
+    def __init__(self):
+        super(Tiff, self).__init__(
+            mime=Tiff.MIME,
+            extension=Tiff.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 9 and
+                ((buf[0] == 0x49 and buf[1] == 0x49 and
+                    buf[2] == 0x2A and buf[3] == 0x0) or
+                (buf[0] == 0x4D and buf[1] == 0x4D and
+                    buf[2] == 0x0 and buf[3] == 0x2A))
+                and not (buf[8] == 0x43 and buf[9] == 0x52))
+
+
+class Bmp(Type):
+    """
+    Implements the BMP image type matcher.
+    """
+    MIME = 'image/bmp'
+    EXTENSION = 'bmp'
+
+    def __init__(self):
+        super(Bmp, self).__init__(
+            mime=Bmp.MIME,
+            extension=Bmp.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 1 and
+                buf[0] == 0x42 and
+                buf[1] == 0x4D)
+
+
+class Jxr(Type):
+    """
+    Implements the JXR image type matcher.
+    """
+    MIME = 'image/vnd.ms-photo'
+    EXTENSION = 'jxr'
+
+    def __init__(self):
+        super(Jxr, self).__init__(
+            mime=Jxr.MIME,
+            extension=Jxr.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 2 and
+                buf[0] == 0x49 and
+                buf[1] == 0x49 and
+                buf[2] == 0xBC)
+
+
+class Psd(Type):
+    """
+    Implements the PSD image type matcher.
+    """
+    MIME = 'image/vnd.adobe.photoshop'
+    EXTENSION = 'psd'
+
+    def __init__(self):
+        super(Psd, self).__init__(
+            mime=Psd.MIME,
+            extension=Psd.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x38 and
+                buf[1] == 0x42 and
+                buf[2] == 0x50 and
+                buf[3] == 0x53)
+
+
+class Ico(Type):
+    """
+    Implements the ICO image type matcher.
+    """
+    MIME = 'image/x-icon'
+    EXTENSION = 'ico'
+
+    def __init__(self):
+        super(Ico, self).__init__(
+            mime=Ico.MIME,
+            extension=Ico.EXTENSION,
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x00 and
+                buf[1] == 0x00 and
+                buf[2] == 0x01 and
+                buf[3] == 0x00)
+
+
+class Heic(IsoBmff):
+    """
+    Implements the HEIC image type matcher.
+    """
+    MIME = 'image/heic'
+    EXTENSION = 'heic'
+
+    def __init__(self):
+        super(Heic, self).__init__(
+            mime=Heic.MIME,
+            extension=Heic.EXTENSION
+        )
+
+    def match(self, buf):
+        if not self._is_isobmff(buf):
+            return False
+
+        major_brand, minor_version, compatible_brands = self._get_ftyp(buf)
+        if major_brand == 'heic':
+            return True
+        if major_brand in ['mif1', 'msf1'] and 'heic' in compatible_brands:
+            return True
+        return False
+
+
+class Dcm(Type):
+
+    MIME = 'application/dicom'
+    EXTENSION = 'dcm'
+    OFFSET = 128
+
+    def __init__(self):
+        super(Dcm, self).__init__(
+            mime=Dcm.MIME,
+            extension=Dcm.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > Dcm.OFFSET + 4 and
+                buf[Dcm.OFFSET + 0] == 0x44 and
+                buf[Dcm.OFFSET + 1] == 0x49 and
+                buf[Dcm.OFFSET + 2] == 0x43 and
+                buf[Dcm.OFFSET + 3] == 0x4D)
+
+
+class Dwg(Type):
+    """Implements the Dwg image type matcher."""
+
+    MIME = 'image/vnd.dwg'
+    EXTENSION = 'dwg'
+
+    def __init__(self):
+        super(Dwg, self).__init__(
+            mime=Dwg.MIME,
+            extension=Dwg.EXTENSION
+        )
+
+    def match(self, buf):
+        return buf[:4] == bytearray([0x41, 0x43, 0x31, 0x30])
+
+
+class Xcf(Type):
+    """Implements the Xcf image type matcher."""
+
+    MIME = 'image/x-xcf'
+    EXTENSION = 'xcf'
+
+    def __init__(self):
+        super(Xcf, self).__init__(
+            mime=Xcf.MIME,
+            extension=Xcf.EXTENSION
+        )
+
+    def match(self, buf):
+        return buf[:10] == bytearray([0x67, 0x69, 0x6d, 0x70, 0x20,
+                                      0x78, 0x63, 0x66, 0x20, 0x76])
+
+
+class Avif(IsoBmff):
+    """
+    Implements the AVIF image type matcher.
+    """
+    MIME = 'image/avif'
+    EXTENSION = 'avif'
+
+    def __init__(self):
+        super(Avif, self).__init__(
+            mime=Avif.MIME,
+            extension=Avif.EXTENSION
+        )
+
+    def match(self, buf):
+        if not self._is_isobmff(buf):
+            return False
+
+        major_brand, minor_version, compatible_brands = self._get_ftyp(buf)
+        if major_brand in ['avif', 'avis']:
+            return True
+        if major_brand in ['mif1', 'msf1'] and 'avif' in compatible_brands:
+            return True
+        return False
+
+
+class Qoi(Type):
+    """
+    Implements the QOI image type matcher.
+    """
+    MIME = 'image/qoi'
+    EXTENSION = 'qoi'
+
+    def __init__(self):
+        super(Qoi, self).__init__(
+            mime=Qoi.MIME,
+            extension=Qoi.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x71 and
+                buf[1] == 0x6F and
+                buf[2] == 0x69 and
+                buf[3] == 0x66)

--- a/scripts/filetypes/isobmff.py
+++ b/scripts/filetypes/isobmff.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import codecs
+
+from .base import Type
+
+
+class IsoBmff(Type):
+    """
+    Implements the ISO-BMFF base type.
+    """
+    def __init__(self, mime, extension):
+        super(IsoBmff, self).__init__(
+            mime=mime,
+            extension=extension
+        )
+
+    def _is_isobmff(self, buf):
+        if len(buf) < 16 or buf[4:8] != b'ftyp':
+            return False
+        if len(buf) < int(codecs.encode(buf[0:4], 'hex'), 16):
+            return False
+        return True
+
+    def _get_ftyp(self, buf):
+        ftyp_len = int(codecs.encode(buf[0:4], 'hex'), 16)
+        major_brand = buf[8:12].decode(errors='ignore')
+        minor_version = int(codecs.encode(buf[12:16], 'hex'), 16)
+        compatible_brands = []
+        for i in range(16, ftyp_len, 4):
+            compatible_brands.append(buf[i:i+4].decode(errors='ignore'))
+
+        return major_brand, minor_version, compatible_brands

--- a/scripts/filetypes/text.py
+++ b/scripts/filetypes/text.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+
+
+class XmlTextBase(Type):
+    """
+    Implements the XML base type.
+    """
+    def __init__(self, mime, extension):
+        super(XmlTextBase, self).__init__(
+            mime=mime,
+            extension=extension
+        )
+
+    def _is_xml(self, buf):
+        signature = b"\x3C\x3F\x78\x6D\x6C\x20\x76\x65\x72\x73\x69\x6F\x6E\x3D\x22\x31\x2E\x30\x22"
+        if len(buf) > 19 and buf[0:19] == signature:
+            return True
+        return False
+
+
+class Json(Type):
+    """Implements the Json text type matcher."""
+
+    MIME = 'application/json'
+    EXTENSION = 'json'
+
+    def __init__(self):
+        super(Json, self).__init__(
+            mime=Json.MIME,
+            extension=Json.EXTENSION
+        )
+
+    def match(self, buf):
+        if len(buf) > 4:
+            return ((buf[0] == 0x5B and buf[1] == 0x7B) or
+                (buf[0] == 0x7B and buf[1] == 0x22) or
+                (buf[0] == 0x7B and buf[1] == 0x0A and buf[2] == 0x20 and buf[3] == 0x20 and buf[4] == 0x22))
+
+
+class Html(Type):
+    """Implements the Html text type matcher."""
+
+    MIME = 'text/html'
+    EXTENSION = 'html'
+
+    def __init__(self):
+        super(Html, self).__init__(
+            mime=Html.MIME,
+            extension=Html.EXTENSION
+        )
+
+    def match(self, buf):
+        if len(buf) > 14:
+            return (buf[0] == 0x3C and 
+                    buf[1] == 0x21 and
+                    buf[2] == 0x44 or buf[2] == 0x64 and 
+                    buf[3] == 0x4F or buf[3] == 0x6F and
+                    buf[4] == 0x43 or buf[4] == 0x63 and 
+                    buf[5] == 0x54 or buf[5] == 0x74 and
+                    buf[6] == 0x59 or buf[6] == 0x79 and 
+                    buf[7] == 0x50 or buf[7] == 0x70 and
+                    buf[8] == 0x45 or buf[8] == 0x65 and 
+                    buf[9] == 0x20 and
+                    buf[10] == 0x68 and 
+                    buf[11] == 0x74 and
+                    buf[12] == 0x6D and 
+                    buf[13] == 0x6C and
+                    buf[14] == 0x3E)
+      
+
+
+class Plist(XmlTextBase):
+    """Implements the XML Property List type matcher."""
+
+    MIME = 'application/x-plist'
+    EXTENSION = 'plist'
+
+    def __init__(self):
+        super(Plist, self).__init__(
+            mime=Plist.MIME,
+            extension=Plist.EXTENSION
+        )
+
+    def match(self, buf):
+        if not self._is_xml(buf):
+            return False
+        return (len(buf) > 19 and
+                (b"\x3C\x21\x44\x4F\x43\x54\x59\x50\x45\x20\x70\x6C\x69\x73\x74\x20\x50\x55\x42\x4C\x49\x43"
+                in buf[19:80] or
+                b"\x3C\x70\x6C\x69\x73\x74\x20\x76\x65\x72\x73\x69\x6F\x6E\x3D\x22\x31\x2E\x30\x22\x3E"
+                in buf[19:64]))

--- a/scripts/filetypes/video.py
+++ b/scripts/filetypes/video.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+
+from .base import Type
+from .isobmff import IsoBmff
+
+
+class Mp4(IsoBmff):
+    """
+    Implements the MP4 video type matcher.
+    """
+    MIME = 'video/mp4'
+    EXTENSION = 'mp4'
+
+    def __init__(self):
+        super(Mp4, self).__init__(
+            mime=Mp4.MIME,
+            extension=Mp4.EXTENSION
+        )
+
+    def match(self, buf):
+        if not self._is_isobmff(buf):
+            return False
+
+        major_brand, minor_version, compatible_brands = self._get_ftyp(buf)
+        for brand in compatible_brands:
+            if brand in ['mp41', 'mp42', 'isom']:
+                return True
+        return major_brand in ['mp41', 'mp42', 'isom']
+
+
+class M4v(Type):
+    """
+    Implements the M4V video type matcher.
+    """
+    MIME = 'video/x-m4v'
+    EXTENSION = 'm4v'
+
+    def __init__(self):
+        super(M4v, self).__init__(
+            mime=M4v.MIME,
+            extension=M4v.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 10 and
+                buf[0] == 0x0 and buf[1] == 0x0 and
+                buf[2] == 0x0 and buf[3] == 0x1C and
+                buf[4] == 0x66 and buf[5] == 0x74 and
+                buf[6] == 0x79 and buf[7] == 0x70 and
+                buf[8] == 0x4D and buf[9] == 0x34 and
+                buf[10] == 0x56)
+
+
+class Mkv(Type):
+    """
+    Implements the MKV video type matcher.
+    """
+    MIME = 'video/x-matroska'
+    EXTENSION = 'mkv'
+
+    def __init__(self):
+        super(Mkv, self).__init__(
+            mime=Mkv.MIME,
+            extension=Mkv.EXTENSION
+        )
+
+    def match(self, buf):
+        contains_ebml_element = buf.startswith(b'\x1A\x45\xDF\xA3')
+        contains_doctype_element = buf.find(b'\x42\x82\x88matroska') > -1
+        return contains_ebml_element and contains_doctype_element
+
+
+class Webm(Type):
+    """
+    Implements the WebM video type matcher.
+    """
+    MIME = 'video/webm'
+    EXTENSION = 'webm'
+
+    def __init__(self):
+        super(Webm, self).__init__(
+            mime=Webm.MIME,
+            extension=Webm.EXTENSION
+        )
+
+    def match(self, buf):
+        contains_ebml_element = buf.startswith(b'\x1A\x45\xDF\xA3')
+        contains_doctype_element = buf.find(b'\x42\x82\x84webm') > -1
+        return contains_ebml_element and contains_doctype_element
+
+
+class Mov(IsoBmff):
+    """
+    Implements the MOV video type matcher.
+    """
+    MIME = 'video/quicktime'
+    EXTENSION = 'mov'
+
+    def __init__(self):
+        super(Mov, self).__init__(
+            mime=Mov.MIME,
+            extension=Mov.EXTENSION
+        )
+
+    def match(self, buf):
+        if not self._is_isobmff(buf):
+            return False
+
+        major_brand, minor_version, compatible_brands = self._get_ftyp(buf)
+        return major_brand == 'qt  '
+
+
+class Avi(Type):
+    """
+    Implements the AVI video type matcher.
+    """
+    MIME = 'video/x-msvideo'
+    EXTENSION = 'avi'
+
+    def __init__(self):
+        super(Avi, self).__init__(
+            mime=Avi.MIME,
+            extension=Avi.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 11 and
+                buf[0] == 0x52 and
+                buf[1] == 0x49 and
+                buf[2] == 0x46 and
+                buf[3] == 0x46 and
+                buf[8] == 0x41 and
+                buf[9] == 0x56 and
+                buf[10] == 0x49 and
+                buf[11] == 0x20)
+
+
+class Wmv(Type):
+    """
+    Implements the WMV video type matcher.
+    """
+    MIME = 'video/x-ms-wmv'
+    EXTENSION = 'wmv'
+
+    def __init__(self):
+        super(Wmv, self).__init__(
+            mime=Wmv.MIME,
+            extension=Wmv.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 9 and
+                buf[0] == 0x30 and
+                buf[1] == 0x26 and
+                buf[2] == 0xB2 and
+                buf[3] == 0x75 and
+                buf[4] == 0x8E and
+                buf[5] == 0x66 and
+                buf[6] == 0xCF and
+                buf[7] == 0x11 and
+                buf[8] == 0xA6 and
+                buf[9] == 0xD9)
+
+
+class Flv(Type):
+    """
+    Implements the FLV video type matcher.
+    """
+    MIME = 'video/x-flv'
+    EXTENSION = 'flv'
+
+    def __init__(self):
+        super(Flv, self).__init__(
+            mime=Flv.MIME,
+            extension=Flv.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x46 and
+                buf[1] == 0x4C and
+                buf[2] == 0x56 and
+                buf[3] == 0x01)
+
+
+class Mpeg(Type):
+    """
+    Implements the MPEG video type matcher.
+    """
+    MIME = 'video/mpeg'
+    EXTENSION = 'mpg'
+
+    def __init__(self):
+        super(Mpeg, self).__init__(
+            mime=Mpeg.MIME,
+            extension=Mpeg.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 3 and
+                buf[0] == 0x0 and
+                buf[1] == 0x0 and
+                buf[2] == 0x1 and
+                buf[3] >= 0xb0 and
+                buf[3] <= 0xbf)
+
+
+class M3gp(Type):
+    """Implements the 3gp video type matcher."""
+
+    MIME = 'video/3gpp'
+    EXTENSION = '3gp'
+
+    def __init__(self):
+        super(M3gp, self).__init__(
+            mime=M3gp.MIME,
+            extension=M3gp.EXTENSION
+        )
+
+    def match(self, buf):
+        return (len(buf) > 10 and
+                buf[4] == 0x66 and
+                buf[5] == 0x74 and
+                buf[6] == 0x79 and
+                buf[7] == 0x70 and
+                buf[8] == 0x33 and
+                buf[9] == 0x67 and
+                buf[10] == 0x70)

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -10,7 +10,7 @@ import sys
 from typing import Pattern
 
 import simplekml
-import magic
+from scripts.filetype import guess_mime
 import shutil
 from pathlib import Path
 
@@ -456,7 +456,9 @@ def media_to_html(media_path, files_found, report_folder):
             source = Path(locationfiles, filename)
             source = relative_paths(str(source), splitter)
             
-        mimetype = magic.from_file(match, mime=True)
+        mimetype = guess_mime(match)
+        if mimetype == None:
+            mimetype = ''
         
         if 'video' in mimetype:
             thumb = f'<video width="320" height="240" controls="controls" preload="none"><source src="{source}" type="video/mp4">Your browser does not support the video tag.</video>'

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -231,21 +231,23 @@ def get_file_content(path):
 
 def create_index_html(reportfolderbase, time_in_secs, time_HMS, extraction_type, image_input_path, nav_list_data, casedata):
     '''Write out the index.html page to the report folder'''
+    case_list = []
     content = '<br />'
     content += """
     <div class="card bg-white" style="padding: 20px;">
         <h2 class="card-title">Case Information</h2>
     """ # CARD start
     
-    case_list = [   ['Extraction location', image_input_path],
+    if len(casedata) > 0:
+        for key, value in casedata.items():
+            if value:
+                case_list.append([key, value])
+            
+    case_list += [   ['Extraction location', image_input_path],
                     ['Extraction type', extraction_type],
                     ['Report directory', reportfolderbase],
                     ['Processing time', f'{time_HMS} (Total {time_in_secs} seconds)']  ]
     
-    if len(casedata) > 0:
-        for key, value in casedata.items():
-            case_list.append([key, value])
-            
     tab1_content = generate_key_val_table_without_headings('', case_list) + \
     """         <p class="note note-primary mb-4">
                     All dates and times are in UTC unless noted otherwise!

--- a/zCaseDataExample.alprofile
+++ b/zCaseDataExample.alprofile
@@ -1,1 +1,0 @@
-{"Case Number": "0123-45-6789", "Agency": "The Justice League", "Examiner": "Victor Stone"}

--- a/zCaseDataExample.lcasedata
+++ b/zCaseDataExample.lcasedata
@@ -1,0 +1,1 @@
+{"leapp": "case_data", "case_data_values": {"Case Number": "0123-45-6789", "Agency": "The Justice League", "Examiner": "Victor Stone"}}

--- a/zProfileExample.rlprofile
+++ b/zProfileExample.rlprofile
@@ -1,0 +1,1 @@
+{"leapp": "rleapp", "format_version": 1, "plugins": ["iOSnotes", "reddit", "whatsappExportedchats"]}


### PR DESCRIPTION
**Replaced the python-magic module with filetype**
On Apple Silicon Macs and some Windows computers, python-magic cannot run without installing additional libraries.
It was removed from requirements.txt file and is no longer needed to run RLEAPP.
filetype.py, a small and dependency free Python package to infer file type and MIME type checking the magic numbers signature of a file or buffer, has been adapted to be directly integrated into RLEAPP (easier to add new mime types).

Code was fully updated to use this new package.

---
**Add Case Data management**
'Load Case Data' button was replaced with a 'Add Case Data' button in the GUI.
In the CLI:
- '-m' is used to load a RLEAPP profile file (.rlprofile)
- '-d' is used to load a LEAPP case data file
- -'c' is used to create a RLEAPP profile file and/or a LEAPP case data file

Two example files (zCaseDataExample.lcasedata & zProfileExample.rlprofile) are available at the root of the repo.

---
**Code updated to support the latest version of PySimpleGUI**
- remove in requirements.txt version number for PySimpleGUI to install the latest available one
- code updated to support the latest version of PySimpleGUI

If you want to use the latest version of PySimpleGUI, type `pip install PySimpleGUI --upgrade`