### PR TITLE
Update takeoutRecords.py

### DIFF
--- a/scripts/artifacts/takeoutRecords.py
+++ b/scripts/artifacts/takeoutRecords.py
@@ -155,6 +155,6 @@ def get_takeoutRecords(files_found, report_folder, seeker, wrap_text, time_offse
 __artifacts__ = {
         "takeoutRecords": (
             "Google Takeout Archive",
-            ('*/Location History/Records.json'),
+            ('*/Location History*/Records.json'),
             get_takeoutRecords)
 }


### PR DESCRIPTION
Fix for newer Google Takeouts with directory name changes of "Location History" to "Location History (Timeline)".