### PR TITLE
Update gooReturnsrec.py

### DIFF
--- a/scripts/artifacts/gooReturnsrec.py
+++ b/scripts/artifacts/gooReturnsrec.py
@@ -155,6 +155,6 @@ def get_gooReturnsrec(files_found, report_folder, seeker, wrap_text, time_offset
 __artifacts__ = {
         "gooReturnsrec": (
             "Google Returns",
-            ('*/Location History/Records.json'),
+            ('*/Location History*/Records.json'),
             get_gooReturnsrec)
 }


### PR DESCRIPTION
Fix for newer Google Takeouts with directory name changes of "Location History" to "Location History (Timeline)".