### PR TITLE
Convert Instagram Ads Viewed to LAVA @artifact_processor (context form) — RLEAPP conversion template

### DIFF
--- a/scripts/artifacts/instagramAdsviewed.py
+++ b/scripts/artifacts/instagramAdsviewed.py
@@ -1,53 +1,49 @@
+__artifacts_v2__ = {
+    "instagramAdsviewed": {  # must match the function name exactly
+        "name": "Instagram Archive - Ads Viewed",
+        "description": "Parses ads viewed from an Instagram data archive (ads_viewed.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-26",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/ads_viewed.json'),
+        "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
 import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_instagramAdsviewed(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramAdsviewed(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('ads_viewed.json'):
-            
-            with open(file_found, "r") as fp:
+
+        if os.path.basename(file_found).startswith('ads_viewed.json'):
+            source_path = file_found
+
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_ads_seen']:
                 author = x['string_map_data']['Author'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                    
-                data_list.append((timestamp, author))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Ads Viewed')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Ads Viewed')
-        report.add_script()
-        data_headers = ('Timestamp','Author')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Ads Viewed'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Ads Viewed'
-        timeline(report_folder, tlactivity, data_list, data_headers)
+                # Epoch seconds -> render as UTC (the legacy code used naive
+                # fromtimestamp, i.e. the parsing machine's local time).
+                if timestamp:
+                    timestamp = datetime.datetime.fromtimestamp(
+                        int(timestamp), tz=datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
-    else:
-        logfunc('No Instagram Archive - Ads Clicked')
-                
-__artifacts__ = {
-        "instagramAdsviewed": (
-            "Instagram Archive",
-            ('*/ads_and_content/ads_viewed.json'),
-            get_instagramAdsviewed)
-}
+                data_list.append((timestamp, author))
+
+    data_headers = (('Timestamp', 'datetime'), 'Author')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
First RLEAPP artifact converted to the modern LAVA pipeline. **This is the template** for the broader ~143-artifact conversion — please sanity-check the pattern before I batch the rest.

## Pattern established
- **v1 funckey** `__artifacts__` → **`__artifacts_v2__`** (dict key must equal the function name).
- **Context form** (your call to modernize past the existing 4-arg converts): `def instagramAdsviewed(context)`, iterate `context.get_files_found()`, return `(data_headers, data_list, context.get_relative_path(source_path))`.
  - Bonus: the context form unlocks `get_relative_path` (clean in-extraction source path) that the 4-arg converts can't access.
- **Typed header**: `('Timestamp','datetime')`.
- **UTC fix**: the legacy code (and even the existing "converted" Instagram artifacts) used `datetime.fromtimestamp(ts)` — naive **local** time, machine-dependent. Now `datetime.fromtimestamp(ts, tz=timezone.utc)` so epoch seconds render as true UTC.
- **Drop boilerplate**: removed the hand-rolled `ArtifactHtmlReport`/`tsv`/`timeline` block — the `@artifact_processor` wrapper emits html/tsv/timeline/lava from the returned tuple.
- **Attribution preserved**: original author (@AlexisBrignoni) and creation_date (2021-08-27, from git); bumped last_update_date.

## Validation
pylint 10.00/10, `py_compile` OK, PluginLoader loads it (202 artifacts total, no name collision), inner signature confirmed as the 1-arg context form.

No CI in RLEAPP, so nothing to wait on.