### PR TITLE
Instagram Archive: full LAVA modernization (context form, UTC, relative paths)

### DIFF
--- a/scripts/artifacts/instagramAdsviewed.py
+++ b/scripts/artifacts/instagramAdsviewed.py
@@ -15,10 +15,9 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 
 @artifact_processor
@@ -40,8 +39,7 @@ def instagramAdsviewed(context):
                 # Epoch seconds -> render as UTC (the legacy code used naive
                 # fromtimestamp, i.e. the parsing machine's local time).
                 if timestamp:
-                    timestamp = datetime.datetime.fromtimestamp(
-                        int(timestamp), tz=datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+                    timestamp = convert_unix_ts_to_utc(timestamp)
 
                 data_list.append((timestamp, author))
 

--- a/scripts/artifacts/instagramDevices.py
+++ b/scripts/artifacts/instagramDevices.py
@@ -15,14 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramDevices(files_found, report_folder, seeker, wrap_text):
+def instagramDevices(context):
+    files_found = context.get_files_found()
     
     for file_found in files_found:
         file_found = str(file_found)
@@ -41,11 +40,10 @@ def instagramDevices(files_found, report_folder, seeker, wrap_text):
                 else:
                     deviceid = ''
                 timestamp = (x['string_map_data']['Last Login'].get('timestamp', ''))
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 useragent = (x['string_map_data']['User Agent'].get('value', ''))
                     
                 data_list.append((timestamp, deviceid, useragent))
     
     data_headers = ('Last Login Timestamp', 'Device ID', 'User Agent')
-    return data_headers, data_list, file_found
+    return data_headers, data_list, context.get_relative_path(file_found)

--- a/scripts/artifacts/instagramFollowers.py
+++ b/scripts/artifacts/instagramFollowers.py
@@ -15,14 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramFollowers(files_found, report_folder, seeker, wrap_text):
+def instagramFollowers(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -31,17 +30,16 @@ def instagramFollowers(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('followers.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             for x in deserialized['relationships_followers']:
                 href = x['string_list_data'][0].get('href', '')
                 value = x['string_list_data'][0].get('value', '')
                 timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 
-                data_list.append((timestamp, value, href, filename))
+                data_list.append((timestamp, value, href, context.get_relative_path(file_found)))
     
     data_headers = (('Timestamp', 'datetime'),'Follower', 'Profile URL', 'File Source')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramFollowing.py
+++ b/scripts/artifacts/instagramFollowing.py
@@ -15,14 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramFollowing(files_found, report_folder, seeker, wrap_text):
+def instagramFollowing(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -31,17 +30,16 @@ def instagramFollowing(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('following.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             for x in deserialized['relationships_following']:
                 href = x['string_list_data'][0].get('href', '')
                 value = x['string_list_data'][0].get('value', '')
                 timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 
-                data_list.append((timestamp, value, href, file_found))
+                data_list.append((timestamp, value, href, context.get_relative_path(file_found)))
     
     data_headers = (('Timestamp', 'datetime'),'Following', 'Profile URL', 'Source File')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramLikedcomm.py
+++ b/scripts/artifacts/instagramLikedcomm.py
@@ -15,15 +15,14 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii
+from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, convert_unix_ts_to_utc
 
 @artifact_processor
 
-def instagramLikedcomm(files_found, report_folder, seeker, wrap_text):
+def instagramLikedcomm(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -32,7 +31,7 @@ def instagramLikedcomm(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('liked_comments.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             for x in deserialized['likes_comment_likes']:
@@ -41,10 +40,9 @@ def instagramLikedcomm(files_found, report_folder, seeker, wrap_text):
                 value = x['string_list_data'][0].get('value', '')
                 value = utf8_in_extended_ascii(value)[1]
                 timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                     
                 data_list.append((timestamp, title, href, value))
                 
     data_headers = (('Timestamp', 'datetime'),'Account Name', 'Post URL', 'Value')
-    return data_headers, data_list, file_found
+    return data_headers, data_list, context.get_relative_path(file_found)

--- a/scripts/artifacts/instagramLogout.py
+++ b/scripts/artifacts/instagramLogout.py
@@ -15,14 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramLogout(files_found, report_folder, seeker, wrap_text):
+def instagramLogout(context):
+    files_found = context.get_files_found()
     for file_found in files_found:
         file_found = str(file_found)
         
@@ -42,10 +41,9 @@ def instagramLogout(files_found, report_folder, seeker, wrap_text):
                 langagecode = (x['string_map_data']['Language Code'].get('value', ''))
                 timestamp = (x['string_map_data']['Time'].get('timestamp', ''))
                 useragent = (x['string_map_data']['User Agent'].get('value', ''))
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                     
                 data_list.append((timestamp, title, ipaddress, useragent, langagecode, cookiename))
     
     data_headers = (('Timestamp (Local)','datetime'), 'Timestamp (UTC)', 'IP Address', 'User Agent', 'Language Code', 'Cookie Name')
-    return data_headers, data_list, file_found
+    return data_headers, data_list, context.get_relative_path(file_found)

--- a/scripts/artifacts/instagramMessageReq.py
+++ b/scripts/artifacts/instagramMessageReq.py
@@ -16,14 +16,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path
 
-from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, check_in_media, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramMessageReq(files_found, report_folder, seeker, wrap_text):
+def instagramMessageReq(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -32,7 +31,7 @@ def instagramMessageReq(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('message_1.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             participants = deserialized.get('participants')
@@ -52,7 +51,8 @@ def instagramMessageReq(files_found, report_folder, seeker, wrap_text):
             
             for x in deserialized['messages']:
                 agregator_reac = ''
-                agregator = ''
+                media_items = []
+                share_info = ''
                 
                 sender_name = x.get('sender_name', '')
                 sender_name = utf8_in_extended_ascii(sender_name)[1]
@@ -60,18 +60,17 @@ def instagramMessageReq(files_found, report_folder, seeker, wrap_text):
                 timestamp = x.get('timestamp_ms', '')
                 
                 share = x.get('share','')
-                link =''
                 if share:
                     link = share.get('link','')
                     share_text = share.get('share_text','')
                     share_text = utf8_in_extended_ascii(share_text)[1]
                     content_owner = share.get('original_content_owner', '')
                     content_owner = utf8_in_extended_ascii(content_owner)[1]
-                    agregator = f'<a href={link} target="_blank" >{link}</><br><br>'
+                    share_info = f'Shared: {link}'
                     if share_text:
-                        agregator = agregator + f'Shared Text: {share_text}<br><br>'
+                        share_info = share_info + f'\nShared Text: {share_text}'
                     if content_owner:
-                        agregator = agregator + f'Original Content Owner: {content_owner}'
+                        share_info = share_info + f'\nOriginal Content Owner: {content_owner}'
                     
                 
                 reactions = x.get('reactions', '')
@@ -96,62 +95,33 @@ def instagramMessageReq(files_found, report_folder, seeker, wrap_text):
                         agregator_reac = agregator_reac + ('</tr>')
                     agregator_reac = agregator_reac + ('</table><br>')
                 
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)/1000).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 content = x.get('content', '' )
                 content = utf8_in_extended_ascii(content)[1]
+                if share_info:
+                    content = (content + '\n' + share_info).strip()
                 type = x.get('type', '')
                 is_unsent = x.get('is_unsent', '')
                 
                 photos = x.get('photos', '')
                 if photos:
-                    counter = 0
-                    agregator = agregator + ('<table>')
                     for pics in photos:
-                        if counter == 0:
-                            agregator = agregator +('<tr>')
-                        pictures = pics.get('uri', '')
-                        time = pics.get('creation_timestamp', '')
-                        if time > 0:
-                            time= (datetime.datetime.fromtimestamp(int(time)).strftime('%Y-%m-%d %H:%M:%S'))
-                        
-                        thumb = media_to_html(pictures, files_found, report_folder)
-                        
-                        counter = counter + 1
-                        agregator = agregator + f'<td>{thumb}</td>'
-                        #hacer uno que no tenga html
-                        if counter == 2:
-                            counter = 0
-                            agregator = agregator + ('</tr>')
-                    if counter == 1:
-                        agregator = agregator + ('</tr>')
-                    agregator = agregator + ('</table><br>')
+                        uri = pics.get('uri', '')
+                        if uri:
+                            ref = check_in_media(uri, os.path.basename(uri))
+                            if ref:
+                                media_items.append(ref)
                 
                 videos = x.get('videos', '')
                 if videos:
-                    counter = 0
-                    agregator = agregator + ('<table>')
                     for vids in videos:
-                        if counter == 0:
-                            agregator = agregator + ('<tr>')
-                        movie = vids.get('uri', '')
-                        time = vids.get('creation_timestamp', '')
-                        if time > 0:
-                            time= (datetime.datetime.fromtimestamp(int(time)).strftime('%Y-%m-%d %H:%M:%S'))
-                        
-                        thumb = media_to_html(movie, files_found, report_folder)
-                        
-                        counter = counter + 1
-                        agregator = agregator + f'<td>{thumb}</td>'
-                        #hacer uno que no tenga html
-                        if counter == 2:
-                            counter = 0
-                            agregator = agregator + ('</tr>')
-                    if counter == 1:
-                        agregator = agregator + ('</tr>')
-                    agregator = agregator + ('</table><br>')
+                        uri = vids.get('uri', '')
+                        if uri:
+                            ref = check_in_media(uri, os.path.basename(uri))
+                            if ref:
+                                media_items.append(ref)
                 
-                data_list.append((timestamp, title, names, sender_name, content, agregator, agregator_reac, is_unsent, type, thread_type, is_still_participant, file_found))
+                data_list.append((timestamp, title, names, sender_name, content, media_items, agregator_reac, is_unsent, type, thread_type, is_still_participant, context.get_relative_path(file_found)))
     
-    data_headers = (('Timestamp', 'datetime'), 'Party Account Name', 'Participants', 'Sender Account Name', 'Content', 'Media', 'Reactions', 'Is Unsent', 'Type', 'Thread Type', 'Is Still Participant','Source File')
+    data_headers = (('Timestamp', 'datetime'), 'Party Account Name', 'Participants', 'Sender Account Name', 'Content', ('Media','media'), 'Reactions', 'Is Unsent', 'Type', 'Thread Type', 'Is Still Participant','Source File')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramMessages.py
+++ b/scripts/artifacts/instagramMessages.py
@@ -16,14 +16,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, check_in_media, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramMessages(files_found, report_folder, seeker, wrap_text):
+def instagramMessages(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -32,7 +31,7 @@ def instagramMessages(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('message_1.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             participants = deserialized.get('participants')
@@ -44,7 +43,8 @@ def instagramMessages(files_found, report_folder, seeker, wrap_text):
             
             for x in deserialized['messages']:
                 agregator_reac = ''
-                agregator = ''
+                media_items = []
+                share_info = ''
                 
                 sender_name = x.get('sender_name', '')
                 sender_name = utf8_in_extended_ascii(sender_name)[1]
@@ -52,18 +52,17 @@ def instagramMessages(files_found, report_folder, seeker, wrap_text):
                 timestamp = x.get('timestamp_ms', '')
                 
                 share = x.get('share','')
-                link =''
                 if share:
                     link = share.get('link','')
                     share_text = share.get('share_text','')
                     share_text = utf8_in_extended_ascii(share_text)[1]
                     content_owner = share.get('original_content_owner', '')
                     content_owner = utf8_in_extended_ascii(content_owner)[1]
-                    agregator = f'<a href={link} target="_blank" >{link}</><br><br>'
+                    share_info = f'Shared: {link}'
                     if share_text:
-                        agregator = agregator + f'Shared Text: {share_text}<br><br>'
+                        share_info = share_info + f'\nShared Text: {share_text}'
                     if content_owner:
-                        agregator = agregator + f'Original Content Owner: {content_owner}'
+                        share_info = share_info + f'\nOriginal Content Owner: {content_owner}'
                     
                 
                 reactions = x.get('reactions', '')
@@ -88,62 +87,33 @@ def instagramMessages(files_found, report_folder, seeker, wrap_text):
                         agregator_reac = agregator_reac + ('</tr>')
                     agregator_reac = agregator_reac + ('</table><br>')
                 
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)/1000).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 content = x.get('content', '' )
                 content = utf8_in_extended_ascii(content)[1]
+                if share_info:
+                    content = (content + '\n' + share_info).strip()
                 type = x.get('type', '')
                 is_unsent = x.get('is_unsent', '')
                 
                 photos = x.get('photos', '')
                 if photos:
-                    counter = 0
-                    agregator = agregator + ('<table>')
                     for pics in photos:
-                        if counter == 0:
-                            agregator = agregator +('<tr>')
-                        pictures = pics.get('uri', '')
-                        time = pics.get('creation_timestamp', '')
-                        if time > 0:
-                            time= (datetime.datetime.fromtimestamp(int(time)).strftime('%Y-%m-%d %H:%M:%S'))
-                        
-                        thumb = media_to_html(pictures, files_found, report_folder)
-                        
-                        counter = counter + 1
-                        agregator = agregator + f'<td>{thumb}</td>'
-                        #hacer uno que no tenga html
-                        if counter == 2:
-                            counter = 0
-                            agregator = agregator + ('</tr>')
-                    if counter == 1:
-                        agregator = agregator + ('</tr>')
-                    agregator = agregator + ('</table><br>')
+                        uri = pics.get('uri', '')
+                        if uri:
+                            ref = check_in_media(uri, os.path.basename(uri))
+                            if ref:
+                                media_items.append(ref)
                 
                 videos = x.get('videos', '')
                 if videos:
-                    counter = 0
-                    agregator = agregator + ('<table>')
                     for vids in videos:
-                        if counter == 0:
-                            agregator = agregator + ('<tr>')
-                        movie = vids.get('uri', '')
-                        time = vids.get('creation_timestamp', '')
-                        if time > 0:
-                            time= (datetime.datetime.fromtimestamp(int(time)).strftime('%Y-%m-%d %H:%M:%S'))
+                        uri = vids.get('uri', '')
+                        if uri:
+                            ref = check_in_media(uri, os.path.basename(uri))
+                            if ref:
+                                media_items.append(ref)
                         
-                        thumb = media_to_html(movie, files_found, report_folder)
-                        
-                        counter = counter + 1
-                        agregator = agregator + f'<td>{thumb}</td>'
-                        #hacer uno que no tenga html
-                        if counter == 2:
-                            counter = 0
-                            agregator = agregator + ('</tr>')
-                    if counter == 1:
-                        agregator = agregator + ('</tr>')
-                    agregator = agregator + ('</table><br>')
-                        
-                data_list.append((timestamp, names, sender_name, content, agregator, agregator_reac, is_unsent, type, file_found))
+                data_list.append((timestamp, names, sender_name, content, media_items, agregator_reac, is_unsent, type, context.get_relative_path(file_found)))
     
-    data_headers = (('Timestamp','datetime'), 'Participants', 'Sender', 'Content', 'Media', 'Reactions', 'Is unsent', 'Type','Source File')
+    data_headers = (('Timestamp','datetime'), 'Participants', 'Sender', 'Content', ('Media','media'), 'Reactions', 'Is unsent', 'Type','Source File')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramPersinfo.py
+++ b/scripts/artifacts/instagramPersinfo.py
@@ -14,25 +14,19 @@ __artifacts_v2__ = {
     }
 }
 
-import datetime
-import inspect
 import json
 import os
-import shutil
-from pathlib import Path
 
-from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc
+from scripts.ilapfuncs import artifact_processor, check_in_media, convert_unix_ts_to_utc
 
 def timestamp_check(timestamp):
-    if timestamp > 0:
-        timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-    else:
-        timestamp = ''
-    return timestamp
+    if timestamp:
+        return convert_unix_ts_to_utc(timestamp)
+    return ''
 
 @artifact_processor
-def instagramPersinfo(files_found, report_folder, seeker, wrap_text):
-    artifact_info = inspect.stack()[0]
+def instagramPersinfo(context):
+    files_found = context.get_files_found()
     data_list = []
     sources = []
     
@@ -80,5 +74,5 @@ def instagramPersinfo(files_found, report_folder, seeker, wrap_text):
                                                    
     data_headers = (('Timestamp', 'datetime'), 'Key', 'Value', ('URI','media'), 'HREF')
     #('HREF/URI','media'))
-    source_files = "\n\n".join(sources)
+    source_files = "\n\n".join(context.get_relative_path(s) for s in sources)
     return data_headers, data_list, source_files

--- a/scripts/artifacts/instagramRemovedsug.py
+++ b/scripts/artifacts/instagramRemovedsug.py
@@ -15,15 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import artifact_processor 
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramRemovedsug(files_found, report_folder, seeker, wrap_text):
+def instagramRemovedsug(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -32,17 +30,16 @@ def instagramRemovedsug(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('removed_suggestions.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             for x in deserialized['relationships_dismissed_suggested_users']:
                 href = x['string_list_data'][0].get('href', '')
                 value = x['string_list_data'][0].get('value', '')
                 timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 
                 data_list.append((timestamp, value, href))
     
     data_headers = (('Timestamp','datetime'),'Removed Account Suggestion', 'Profile URL')
-    return data_headers, data_list, file_found
+    return data_headers, data_list, context.get_relative_path(file_found)

--- a/scripts/artifacts/instagramSavedposts.py
+++ b/scripts/artifacts/instagramSavedposts.py
@@ -15,14 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramSavedposts(files_found, report_folder, seeker, wrap_text):
+def instagramSavedposts(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -31,17 +30,16 @@ def instagramSavedposts(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('saved_posts.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             for x in deserialized['saved_saved_media']:
                 title = x['title']
                 href = x['string_map_data']['Saved on'].get('href', '')
                 timestamp = x['string_map_data']['Saved on'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                     
-                data_list.append((timestamp, title, href, filename))
+                data_list.append((timestamp, title, href, context.get_relative_path(file_found)))
     
     data_headers = (('Timestamp', 'datetime'),'Profile Name', 'URL', 'File Source')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramSearches.py
+++ b/scripts/artifacts/instagramSearches.py
@@ -15,14 +15,13 @@ __artifacts_v2__ = {
 }
 
 import os
-import datetime
 import json
-from pathlib import Path	
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 @artifact_processor
-def instagramSearches(files_found, report_folder, seeker, wrap_text):
+def instagramSearches(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -31,16 +30,15 @@ def instagramSearches(files_found, report_folder, seeker, wrap_text):
         
         if filename.startswith('account_searches.json'):
             
-            with open(file_found, "r") as fp:
+            with open(file_found, "r", encoding="utf-8") as fp:
                 deserialized = json.load(fp)
         
             for x in deserialized['searches_user']:
                 search = x['string_map_data']['Search'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 
                 data_list.append((timestamp, search))
     
     data_headers = (('Timestamp','datetime'), 'Search')
-    return data_headers, data_list, file_found
+    return data_headers, data_list, context.get_relative_path(file_found)


### PR DESCRIPTION
Full artifact-level modernization of the converted **Instagram Archive** artifacts (12 files), **entirely within `scripts/artifacts/`** — no framework code touched.

## Applied
- **Context form**: `def fn(context)` + `context.get_files_found()` (+ `get_report_folder()` only where used).
- **Timestamps → UTC datetime objects** via `convert_unix_ts_to_utc()`; **crash-safe** (dropped the `if x > 0:` guard, which raised `TypeError` on a missing `''`).
- **Path shortening**: `context.get_relative_path()` on every Source File column and source-path return.
- **Media → `check_in_media`** (Messages/MessageReq): removed legacy `media_to_html` (which copied files + built inline HTML tables). Photos+videos are now collected as a **list of `check_in_media` refs** in a typed `('Media','media')` column (the framework renders single ref or list uniformly). `check_in_media` resolves the URI itself, so no manual file search.
- **Cleanup**: removed unused imports; explicit `encoding='utf-8'`.

## Design note
In Messages/MessageReq the old `Media` column was **overloaded** — it held both shared-link HTML *and* media thumbnails. I split them: media → the typed `media` column; **shared-link info moved into the Content column as text**. (Easy to give shared content its own column instead if you'd prefer.)

## Validation
`py_compile` OK; **PluginLoader loads all 202**; **no pylint errors**. Pre-existing non-blocking warnings only (no CI): `W0631` (`file_found` after loop — loop always runs) ×5, `W0622` (`type` shadowing) ×2.

`media_to_html` is used in **88** RLEAPP artifacts total — the rest get converted per-artifact in their own batches.