### PR TITLE
Convert 8 Instagram Archive artifacts to LAVA (context form)

### DIFF
--- a/scripts/artifacts/instagramAdsclicked.py
+++ b/scripts/artifacts/instagramAdsclicked.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramAdsclicked": {
+        "name": "Instagram Archive - Ads Clicked",
+        "description": "Parses ads clicked from an Instagram data archive (ads_clicked.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/ads_clicked.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramAdsclicked(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramAdsclicked(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('ads_clicked.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('ads_clicked.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_ads_clicked']:
                 title = x.get('title', '')
                 timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, title))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Ads Clicked')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Ads Clicked')
-        report.add_script()
-        data_headers = ('Timestamp','Title')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Ads Clicked'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Ads Clicked'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Ads Clicked')
-                
-__artifacts__ = {
-        "instagramAdsclicked": (
-            "Instagram Archive",
-            ('*/ads_and_content/ads_clicked.json'),
-            get_instagramAdsclicked)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Title')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramInterests.py
+++ b/scripts/artifacts/instagramInterests.py
@@ -1,48 +1,39 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_instagramInterests(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('ads_interests.json'):
-            
-            with open(file_found, "r") as fp:
-                deserialized = json.load(fp)
-        
-            for x in deserialized['inferred_data_ig_interest']:
-                interest = x['string_map_data']['Interest'].get('value', '')      
-                
-                data_list.append((interest,))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Interests')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Interests')
-        report.add_script()
-        data_headers = ('Interests',)
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Interests'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        
-    else:
-        logfunc('No Instagram Archive - Interests')
-                
-__artifacts__ = {
-        "instagramInterests": (
-            "Instagram Archive",
-            ('*/information_about_you/ads_interests.json'),
-            get_instagramInterests)
+__artifacts_v2__ = {
+    "instagramInterests": {
+        "name": "Instagram Archive - Interests",
+        "description": "Parses inferred advertising interests from an Instagram data archive (ads_interests.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-30",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/information_about_you/ads_interests.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def instagramInterests(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('ads_interests.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['inferred_data_ig_interest']:
+                interest = x['string_map_data']['Interest'].get('value', '')
+                data_list.append((interest,))
+
+    data_headers = ('Interests',)
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramMusicheard.py
+++ b/scripts/artifacts/instagramMusicheard.py
@@ -1,54 +1,42 @@
+__artifacts_v2__ = {
+    "instagramMusicheard": {
+        "name": "Instagram Archive - Music Heard In Stories",
+        "description": "Parses music heard in stories from an Instagram data archive (music_heard_in_stories.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/music_heard_in_stories.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramMusicheard(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramMusicheard(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('music_heard_in_stories.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('music_heard_in_stories.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_music_heard_in_stories']:
                 song = x['string_map_data']['Song'].get('value', '')
                 artist = x['string_map_data']['Artist'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                    
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, song, artist))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Ads Music Heard')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Ads Music Heard')
-        report.add_script()
-        data_headers = ('Timestamp','Song', 'Artist')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Ads Music Heard'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Ads Music Heard'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Ads Music Heard')
-                
-__artifacts__ = {
-        "instagramMusicheard": (
-            "Instagram Archive",
-            ('*/ads_and_content/music_heard_in_stories.json'),
-            get_instagramMusicheard)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Song', 'Artist')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramNointerest.py
+++ b/scripts/artifacts/instagramNointerest.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramNointerest": {
+        "name": "Instagram Archive - Accounts No Interest",
+        "description": "Parses accounts the user marked as not interested from an Instagram data archive",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/*re_not_interested_in.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramNointerest(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramNointerest(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith("accounts_you're_not_interested_in.json"):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith("accounts_you're_not_interested_in.json"):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_recs_hidden_authors']:
                 value = x['string_map_data']['Username'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, value))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Accounts No Interest')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Accounts No Interest')
-        report.add_script()
-        data_headers = ('Timestamp','Username')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Accounts No Interest'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Accounts No Interest'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Accounts No Interest')
-                
-__artifacts__ = {
-        "instagramNointerest": (
-            "Instagram Archive",
-            ('*/ads_and_content/*re_not_interested_in.json'),
-            get_instagramNointerest)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Username')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramPolls.py
+++ b/scripts/artifacts/instagramPolls.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramPolls": {
+        "name": "Instagram Archive - Polls",
+        "description": "Parses story poll interactions from an Instagram data archive (polls.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/story_sticker_interactions/polls.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramPolls(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramPolls(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('polls.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('polls.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['story_activities_polls']:
                 user = x.get('title', '')
                 timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))             
-                
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, user))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Polls')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Polls')
-        report.add_script()
-        data_headers = ('Timestamp','User')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Polls'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Polls'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Polls')
-                
-__artifacts__ = {
-        "instagramPolls": (
-            "Instagram Archive",
-            ('*/story_sticker_interactions/polls.json'),
-            get_instagramPolls)
-}
+    data_headers = (('Timestamp', 'datetime'), 'User')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramPostsviewed.py
+++ b/scripts/artifacts/instagramPostsviewed.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramPostsviewed": {
+        "name": "Instagram Archive - Posts Viewed",
+        "description": "Parses posts viewed from an Instagram data archive (posts_viewed.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/posts_viewed.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramPostsviewed(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramPostsviewed(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('posts_viewed.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('posts_viewed.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_posts_seen']:
                 author = x['string_map_data']['Author'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                    
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, author))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Posts Viewed')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Posts Viewed')
-        report.add_script()
-        data_headers = ('Timestamp','Author')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Posts Viewed'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Posts Viewed'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Posts Viewed')
-                
-__artifacts__ = {
-        "instagramPostsviewed": (
-            "Instagram Archive",
-            ('*/ads_and_content/posts_viewed.json'),
-            get_instagramPostsviewed)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Author')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramPrivacychange.py
+++ b/scripts/artifacts/instagramPrivacychange.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramPrivacychange": {
+        "name": "Instagram Archive - Privacy Change",
+        "description": "Parses account privacy changes from an Instagram data archive (account_privacy_changes.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/login_and_account_creation/account_privacy_changes.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramPrivacychange(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramPrivacychange(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('account_privacy_changes.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('account_privacy_changes.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['account_history_account_privacy_history']:
                 title = x.get('title', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, title))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Privacy Change')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Privacy Change')
-        report.add_script()
-        data_headers = ('Timestamp','Title')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Privacy Change'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Privacy Change'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Privacy Change data available')
-                
-__artifacts__ = {
-        "instagramPrivacychange": (
-            "Instagram Archive",
-            ('*/login_and_account_creation/account_privacy_changes.json'),
-            get_instagramPrivacychange)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Title')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramSuggestedviewed.py
+++ b/scripts/artifacts/instagramSuggestedviewed.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramSuggestedviewed": {
+        "name": "Instagram Archive - Suggested Accounts Viewed",
+        "description": "Parses suggested accounts viewed from an Instagram data archive (suggested_accounts_viewed.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/suggested_accounts_viewed.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramSuggestedviewed(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramSuggestedviewed(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('suggested_accounts_viewed.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('suggested_accounts_viewed.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_chaining_seen']:
                 username = x['string_map_data']['Username'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))                    
-                
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, username))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Suggested Accounts Viewed')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Suggested Accounts Viewed')
-        report.add_script()
-        data_headers = ('Timestamp','Username')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Suggested Accounts Viewed'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Suggested Accounts Viewed'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Suggested Accounts Viewed')
-                
-__artifacts__ = {
-        "instagramSuggestedviewed": (
-            "Instagram Archive",
-            ('*/ads_and_content/suggested_accounts_viewed.json'),
-            get_instagramSuggestedviewed)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Username')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Full conversion of **8 legacy** `ArtifactHtmlReport` (v1 funckey) Instagram Archive artifacts to the modern LAVA pipeline — the first chunk of the remaining ~22.

| Artifact | Source JSON |
|---|---|
| Interests | ads_interests.json |
| Ads Clicked | ads_clicked.json |
| Accounts No Interest | accounts_you're_not_interested_in.json |
| Polls | polls.json |
| Posts Viewed | posts_viewed.json |
| Privacy Change | account_privacy_changes.json |
| Suggested Accounts Viewed | suggested_accounts_viewed.json |
| Music Heard In Stories | music_heard_in_stories.json |

## Conventions applied (all artifact-level, no framework changes)
- `__artifacts__` funckey → `__artifacts_v2__` (key == function name); **preserved** original author (@AlexisBrignoni) + creation dates.
- **Context form**: `def fn(context)`, `context.get_files_found()`, return `(headers, data, context.get_relative_path(source_path))`.
- **Timestamps → `convert_unix_ts_to_utc()`** (aware UTC datetime objects); **crash-safe** (dropped the `if x > 0:` guard that raised `TypeError` on a missing `''`).
- Dropped the `ArtifactHtmlReport`/`tsv`/`timeline` boilerplate (the wrapper emits html/tsv/timeline/lava) and the unused legacy imports.

## Validation
`py_compile` OK; **pylint clean (no W/E)**; **PluginLoader loads all 202**; **reserved-word column audit clean** (16 columns — none sanitize to a SQLite keyword).

Net **−93 lines**. (`instagramLikedposts.py`, the stale misnamed dup, is intentionally untouched per your flag-only call.)