### PR TITLE
Convert 8 more Instagram Archive artifacts to LAVA (context form)

### DIFF
--- a/scripts/artifacts/instagramAccinfo.py
+++ b/scripts/artifacts/instagramAccinfo.py
@@ -1,60 +1,46 @@
+__artifacts_v2__ = {
+    "instagramAccinfo": {
+        "name": "Instagram Archive - Account Info",
+        "description": "Parses profile account insights from an Instagram data archive (account_information.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-20",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/account_information/account_information.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramAccinfo(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+@artifact_processor
+def instagramAccinfo(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('account_information.json'):
-            data_list =[]
-            data_list_timeline = []
-            with open(file_found, "rb") as fp:
+        if os.path.basename(file_found).startswith('account_information.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
+
             for x in deserialized['profile_account_insights']:
-                for key, values in x.items():
-                    if values:
-                        for a, b in values.items():
-                            insightsCat = a
-                            for c, d in b.items():
-                                if c == 'href':
-                                    href = d
-                                if c == 'value':
-                                    value = d
-                                if c == 'timestamp':
-                                    timestamp = d
-                                    if timestamp > 0:
-                                        timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                            data_list.append((insightsCat,timestamp,value,href))
-                            data_list_timeline.append((timestamp, insightsCat, href, value))
-                    
-                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Account Info')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Account Info')
-                report.add_script()
-                data_headers = ('Insights Category', 'Timestamp', 'Value', 'Href')
-                data_headers_timeline = ( 'Timestamp','Insights Category', 'Href', 'Value')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Account Info'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Instagram Archive - Account Info'
-                timeline(report_folder, tlactivity, data_list_timeline, data_headers_timeline)
-            else:
-                logfunc('No Instagram Archive - Account Info data available')
-                
-__artifacts__ = {
-        "instagramAccinfo": (
-            "Instagram Archive",
-            ('*/account_information/account_information.json'),
-            get_instagramAccinfo)
-}
+                for values in x.values():
+                    if not values:
+                        continue
+                    for insights_cat, b in values.items():
+                        href = b.get('href', '')
+                        value = b.get('value', '')
+                        timestamp = b.get('timestamp', '')
+                        timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                        data_list.append((insights_cat, timestamp, value, href))
+
+    data_headers = ('Insights Category', ('Timestamp', 'datetime'), 'Value', 'Href')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramBlocked.py
+++ b/scripts/artifacts/instagramBlocked.py
@@ -1,54 +1,43 @@
+__artifacts_v2__ = {
+    "instagramBlocked": {
+        "name": "Instagram Archive - Blocked",
+        "description": "Parses blocked accounts from an Instagram data archive (blocked_accounts.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/followers_and_following/blocked_accounts.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramBlocked(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramBlocked(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('blocked_accounts.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('blocked_accounts.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
-            for x in deserialized['relationships_blocked_users']:
-                href = x['string_list_data'][0].get('href', '')
-                value = x['string_list_data'][0].get('value', '')
-                timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                
-                data_list.append((timestamp, value, href))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Blocked')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Blocked')
-        report.add_script()
-        data_headers = ('Timestamp','Following', 'Href')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Blocked'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Blocked'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Blocked')
-                
-__artifacts__ = {
-        "instagramBlocked": (
-            "Instagram Archive",
-            ('*/followers_and_following/blocked_accounts.json'),
-            get_instagramBlocked)
-}    
+            for x in deserialized['relationships_blocked_users']:
+                entry = x['string_list_data'][0]
+                href = entry.get('href', '')
+                value = entry.get('value', '')
+                timestamp = entry.get('timestamp', '')
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                data_list.append((timestamp, value, href))
+
+    data_headers = (('Timestamp', 'datetime'), 'Following', 'Href')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramDevicescam.py
+++ b/scripts/artifacts/instagramDevicescam.py
@@ -1,56 +1,43 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows
-
-def get_instagramDevicescam(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('camera_information.json'):
-            data_list =[]
-            with open(file_found, "rb") as fp:
-                deserialized = json.load(fp)
-                
-            devices = (deserialized['devices_camera'])
-            for x in devices:
-                
-                deviceid = (x['string_map_data']['Device ID'].get('value', ''))
-                compression = (x['string_map_data']['Compression'].get('value', ''))
-                ftversion = (x['string_map_data']['Face Tracker Version'].get('value', ''))
-                sdksup = (x['string_map_data']['Supported SDK Versions'].get('value', ''))
-                
-                    
-                data_list.append((deviceid, compression, ftversion, sdksup))
-                
-                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Camera Info')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Camera Info')
-                report.add_script()
-                data_headers = ('Device ID', 'Compression', 'Face Tracker Version', 'Supported SDK Versions')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Camera Info'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Instagram Archive - Camera Info'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Instagram Archive - Camera Info data available')
-                
-__artifacts__ = {
-        "instagramDevicescam": (
-            "Instagram Archive",
-            ('*/device_information/camera_information.json'),
-            get_instagramDevicescam)
+__artifacts_v2__ = {
+    "instagramDevicescam": {
+        "name": "Instagram Archive - Camera Info",
+        "description": "Parses camera device information from an Instagram data archive (camera_information.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/device_information/camera_information.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def instagramDevicescam(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('camera_information.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['devices_camera']:
+                smd = x['string_map_data']
+                deviceid = smd['Device ID'].get('value', '')
+                compression = smd['Compression'].get('value', '')
+                ftversion = smd['Face Tracker Version'].get('value', '')
+                sdksup = smd['Supported SDK Versions'].get('value', '')
+                data_list.append((deviceid, compression, ftversion, sdksup))
+
+    data_headers = ('Device ID', 'Compression', 'Face Tracker Version', 'Supported SDK Versions')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramInfotoadv.py
+++ b/scripts/artifacts/instagramInfotoadv.py
@@ -1,51 +1,40 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows
-
-def get_instagramInfotoadv(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith("information_you've_submitted_to_advertisers.json"):
-            data_list =[]
-            with open(file_found, "rb") as fp:
-                deserialized = json.load(fp)
-                
-            devices = (deserialized['ig_lead_gen_info'])
-            for x in devices:
-                label = x['label']
-                value = x['value']
-                    
-                data_list.append((label, value))
-                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Info Submitted to Adv ')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Info Submitted to Adv')
-                report.add_script()
-                data_headers = ('Label', 'Value')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Info Submitted to Adv'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Instagram Archive - Info Submitted to Adv'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Instagram Archive - Info Submitted to Adv data available')
-                
-__artifacts__ = {
-        "instagramInfotoadv": (
-            "Instagram Archive",
-            ("*/ads_and_businesses/information_you've_submitted_to_advertisers.json"),
-            get_instagramInfotoadv)
+__artifacts_v2__ = {
+    "instagramInfotoadv": {
+        "name": "Instagram Archive - Info Submitted to Adv",
+        "description": "Parses information submitted to advertisers from an Instagram data archive",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ("*/ads_and_businesses/information_you've_submitted_to_advertisers.json"),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def instagramInfotoadv(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith("information_you've_submitted_to_advertisers.json"):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['ig_lead_gen_info']:
+                label = x.get('label', '')
+                value = x.get('value', '')
+                data_list.append((label, value))
+
+    data_headers = ('Label', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramLogin.py
+++ b/scripts/artifacts/instagramLogin.py
@@ -1,59 +1,46 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows
-
-def get_instagramLogin(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith("login_activity.json"):
-            data_list =[]
-            with open(file_found, "rb") as fp:
-                deserialized = json.load(fp)
-                
-            login = (deserialized['account_history_login_history'])
-            for x in login:
-                
-                title = (x.get('title', ''))
-                cookiename = (x['string_map_data']['Cookie Name'].get('value', ''))
-                ipaddress = (x['string_map_data']['IP Address'].get('value', ''))
-                langagecode = (x['string_map_data']['Language Code'].get('value', ''))
-                timestamp = (x['string_map_data']['Time'].get('timestamp', ''))
-                useragent = (x['string_map_data']['User Agent'].get('value', ''))
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                    
-                data_list.append((timestamp, title, ipaddress, useragent, langagecode, cookiename))
-                
-                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Login Activity')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Login Activity')
-                report.add_script()
-                data_headers = ('Timestamp', 'Title', 'IP Address', 'User Agent', 'Language Code', 'Cookie Name')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Login Activity'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Instagram Archive - Login Activity'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Instagram Archive - Login Activity data available')
-                
-__artifacts__ = {
-        "instagramLogin": (
-            "Instagram Archive",
-            ('*/login_and_account_creation/login_activity.json'),
-            get_instagramLogin)
+__artifacts_v2__ = {
+    "instagramLogin": {
+        "name": "Instagram Archive - Login Activity",
+        "description": "Parses login activity from an Instagram data archive (login_activity.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/login_and_account_creation/login_activity.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def instagramLogin(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('login_activity.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['account_history_login_history']:
+                smd = x['string_map_data']
+                title = x.get('title', '')
+                cookiename = smd['Cookie Name'].get('value', '')
+                ipaddress = smd['IP Address'].get('value', '')
+                langagecode = smd['Language Code'].get('value', '')
+                timestamp = smd['Time'].get('timestamp', '')
+                useragent = smd['User Agent'].get('value', '')
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                data_list.append((timestamp, title, ipaddress, useragent, langagecode, cookiename))
+
+    data_headers = (('Timestamp', 'datetime'), 'Title', 'IP Address', 'User Agent', 'Language Code', 'Cookie Name')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramPasswordchange.py
+++ b/scripts/artifacts/instagramPasswordchange.py
@@ -1,52 +1,40 @@
+__artifacts_v2__ = {
+    "instagramPasswordchange": {
+        "name": "Instagram Archive - Password Change",
+        "description": "Parses password change activity from an Instagram data archive (password_change_activity.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/login_and_account_creation/password_change_activity.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramPasswordchange(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramPasswordchange(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('password_change_activity.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('password_change_activity.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['account_history_password_change_history']:
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp,))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Password Change')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Password Change')
-        report.add_script()
-        data_headers = ('Timestamp',)
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Password Change'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Password Change'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Password Change data available')
-                
-__artifacts__ = {
-        "instagramPasswordchange": (
-            "Instagram Archive",
-            ('*/login_and_account_creation/password_change_activity.json'),
-            get_instagramPasswordchange)
-}
+    data_headers = (('Timestamp', 'datetime'),)
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramPending.py
+++ b/scripts/artifacts/instagramPending.py
@@ -1,54 +1,43 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_instagramPending(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('pending_follow_requests.json'):
-            
-            with open(file_found, "r") as fp:
-                deserialized = json.load(fp)
-        
-            for x in deserialized['relationships_follow_requests_sent']:
-                href = x['string_list_data'][0].get('href', '')
-                value = x['string_list_data'][0].get('value', '')
-                timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                
-                data_list.append((timestamp, value, href))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Pending Follow Req')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Pending Follow Req')
-        report.add_script()
-        data_headers = ('Timestamp','User', 'Href')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Pending Follow Req'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Pending Follow Req'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Instagram Archive - Pending Follow Req')
-                
-__artifacts__ = {
-        "instagramPending": (
-            "Instagram Archive",
-            ('*/followers_and_following/pending_follow_requests.json'),
-            get_instagramPending)
+__artifacts_v2__ = {
+    "instagramPending": {
+        "name": "Instagram Archive - Pending Follow Req",
+        "description": "Parses pending follow requests sent from an Instagram data archive (pending_follow_requests.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/followers_and_following/pending_follow_requests.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def instagramPending(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('pending_follow_requests.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['relationships_follow_requests_sent']:
+                entry = x['string_list_data'][0]
+                href = entry.get('href', '')
+                value = entry.get('value', '')
+                timestamp = entry.get('timestamp', '')
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                data_list.append((timestamp, value, href))
+
+    data_headers = (('Timestamp', 'datetime'), 'User', 'Href')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramPostcom.py
+++ b/scripts/artifacts/instagramPostcom.py
@@ -1,55 +1,42 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows
-
-def get_instagramPostcom(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith("post_comments.json"):
-            data_list =[]
-            with open(file_found, "rb") as fp:
-                deserialized = json.load(fp)
-                
-            items = (deserialized['comments_media_comments'])
-            for x in items:
-                #print(x)
-                title = (x.get('title', ''))
-                hrefval = (x['string_list_data'][0].get('value', ''))
-                timestamp = (x['string_list_data'][0].get('timestamp', ''))
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                    
-                data_list.append((timestamp, title, hrefval))
-                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Post Comments')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Post Comments')
-                report.add_script()
-                data_headers = ('Timestamp', 'Title', 'Comment')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Post Comments'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Instagram Archive - Post Comments'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Instagram Archive - Post Comments data available')
-                
-__artifacts__ = {
-        "instagramPostcom": (
-            "Instagram Archive",
-            ('*/comments/post_comments.json'),
-            get_instagramPostcom)
+__artifacts_v2__ = {
+    "instagramPostcom": {
+        "name": "Instagram Archive - Post Comments",
+        "description": "Parses post comments from an Instagram data archive (post_comments.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/comments/post_comments.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def instagramPostcom(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('post_comments.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['comments_media_comments']:
+                title = x.get('title', '')
+                comment = x['string_list_data'][0].get('value', '')
+                timestamp = x['string_list_data'][0].get('timestamp', '')
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                data_list.append((timestamp, title, comment))
+
+    data_headers = (('Timestamp', 'datetime'), 'Title', 'Comment')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Second chunk — **8 legacy** `ArtifactHtmlReport` (v1 funckey) Instagram Archive artifacts converted to the modern LAVA pipeline.

| Artifact | Source JSON | Columns |
|---|---|---|
| Account Info | account_information.json | Insights Category, **Timestamp**, Value, Href |
| Blocked | blocked_accounts.json | **Timestamp**, Following*, Href |
| Camera Info | camera_information.json | Device ID, Compression, Face Tracker Version, Supported SDK Versions |
| Info Submitted to Adv | information_you've_submitted_to_advertisers.json | Label, Value |
| Login Activity | login_activity.json | **Timestamp**, Title, IP Address, User Agent, Language Code, Cookie Name |
| Password Change | password_change_activity.json | **Timestamp** |
| Pending Follow Req | pending_follow_requests.json | **Timestamp**, User, Href |
| Post Comments | post_comments.json | **Timestamp**, Title, Comment |

## Conventions applied (all artifact-level, no framework changes)
- `__artifacts__` funckey → `__artifacts_v2__` (key == function name); **preserved** original author + creation dates.
- **Context form**: `def fn(context)`, `context.get_files_found()`, return `(headers, data, context.get_relative_path(source_path))`.
- **Timestamps → `convert_unix_ts_to_utc()`** (aware UTC datetime objects); **crash-safe** (dropped the `if x > 0:` guard that raised `TypeError` on missing `''`).
- `.get()` on optional fields; dropped the **dead** `media_to_html`/`kmlgen` imports (none of these 8 actually rendered media) and the `ArtifactHtmlReport`/`tsv`/`timeline` boilerplate.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader loads all 202**; **reserved-word + whitespace `CREATE TABLE` audit clean** (17 distinct headers — confirmed `sanitize_sql_name` underscores spaces, e.g. `IP Address`→`ip_address`).

Net **−98 lines**.

> *\* **Heads-up — `Blocked` keeps its original `Following` column header**, which is a copy-paste leftover (the value is the *blocked* account's username, not someone followed). I preserved it verbatim rather than silently renaming. Say the word and I'll change it to `Username` here or in a follow-up.