### PR TITLE
Convert final 5 Instagram Archive artifacts to LAVA (media + KML)

### DIFF
--- a/scripts/artifacts/instagramPosts.py
+++ b/scripts/artifacts/instagramPosts.py
@@ -1,79 +1,63 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, media_to_html
-
-def get_instagramPosts(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('posts_1.json'):
-            data_list =[]
-            with open(file_found, "rb") as fp:
-                deserialized = json.load(fp)
-                
-            for x in deserialized:
-                timestamp = title = uri = latitude = longitude = deviceid = sourcetype = scenecapturetype = software = datatimeexif = ''
-                for a, b in x.items():
-                    if a == 'media':
-                        for y in b:
-                            #print(y)
-                            
-                            for c, d in y.items():
-                                if c == 'media_metadata':
-                                    #print(c, d)
-                                    
-                                    for f, g in d.items():
-                                        metadata_type = (f) #string video_metadata o photo_metadata
-                                        deviceid = (g['exif_data'][0].get('device_id', ''))
-                                        sourcetype = (g['exif_data'][0].get('source_type', ''))
-                                        scenecapturetype = (g['exif_data'][0].get('scene_capture_type', ''))
-                                        software = (g['exif_data'][0].get('software', ''))
-                                        datatimeexif =(g['exif_data'][0].get('date_time_original', ''))
-                                        latitude = (g['exif_data'][0].get('latitude', ''))
-                                        longitude = (g['exif_data'][0].get('longitude', ''))
-                                if c == 'title':
-                                    title = d
-                                if c == 'uri':
-                                    uri = d
-                                    thumb = media_to_html(uri, files_found, report_folder)
-                                    
-                                if c == 'creation_timestamp':
-                                    if d > 0:
-                                        timestamp = (datetime.datetime.fromtimestamp(int(d)).strftime('%Y-%m-%d %H:%M:%S'))
-                                        
-                            data_list.append((timestamp, title, thumb, uri, latitude, longitude, deviceid, sourcetype, scenecapturetype, software, datatimeexif))
-                    
-                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Posts')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Posts')
-                report.add_script()
-                data_headers = ('Timestamp', 'Title', 'Content', 'URI', 'Latitude', 'Longitude', 'Device ID', 'Source Type', 'Scene Capture type', 'Software', 'Date Time EXIF')
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Content'])
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Posts'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Instagram Archive - Posts'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-                kmlactivity = 'Instagram Archive - Posts'
-                kmlgen(report_folder, kmlactivity, data_list, data_headers)
-            else:
-                logfunc('No Instagram Archive - Posts data available')
-                
-__artifacts__ = {
-        "instagramPosts": (
-            "Instagram Archive",
-            ('*/content/posts_1.json', '*/media/*'),
-            get_instagramPosts)
+__artifacts_v2__ = {
+    "instagramPosts": {
+        "name": "Instagram Archive - Posts",
+        "description": "Parses posts, post media, and EXIF/GPS metadata from an Instagram data archive (posts_1.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/content/posts_1.json', '*/media/*'),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+@artifact_processor
+def instagramPosts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('posts_1.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for post in deserialized:
+                for media_item in post.get('media', []):
+                    title = media_item.get('title', '')
+                    uri = media_item.get('uri', '')
+                    timestamp = media_item.get('creation_timestamp', '')
+                    timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                    media_ref = check_in_media(uri, title) if uri else None
+
+                    deviceid = sourcetype = scenecapturetype = ''
+                    software = datetimeexif = latitude = longitude = ''
+                    metadata = media_item.get('media_metadata') or {}
+                    for meta in metadata.values():
+                        exif_list = meta.get('exif_data') or []
+                        if exif_list:
+                            exif = exif_list[0]
+                            deviceid = exif.get('device_id', '')
+                            sourcetype = exif.get('source_type', '')
+                            scenecapturetype = exif.get('scene_capture_type', '')
+                            software = exif.get('software', '')
+                            datetimeexif = exif.get('date_time_original', '')
+                            latitude = exif.get('latitude', '')
+                            longitude = exif.get('longitude', '')
+
+                    data_list.append((timestamp, title, media_ref, uri, latitude, longitude,
+                                      deviceid, sourcetype, scenecapturetype, software, datetimeexif))
+
+    data_headers = (('Timestamp', 'datetime'), 'Title', ('Content', 'media'), 'URI',
+                    'Latitude', 'Longitude', 'Device ID', 'Source Type',
+                    'Scene Capture type', 'Software', 'Date Time EXIF')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramProfchanges.py
+++ b/scripts/artifacts/instagramProfchanges.py
@@ -1,75 +1,52 @@
+__artifacts_v2__ = {
+    "instagramProfchanges": {
+        "name": "Instagram Archive - Profile Changes",
+        "description": "Parses profile changes from an Instagram data archive (profile_changes.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-20",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/account_information/profile_changes.json'),
+        "output_types": "standard",
+        "html_columns": ["Items"],
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramProfchanges(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+@artifact_processor
+def instagramProfchanges(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('profile_changes.json'):
-            data_list = []
-            
-            with open(file_found, "rb") as fp:
+        if os.path.basename(file_found).startswith('profile_changes.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-                
-            for x in deserialized['profile_profile_change']:
-                aggregator = ''
-                if x.get('title'):
-                    #print(x)
-                    for a, b in x.items():
-                        
-                        if a == 'title':
-                            title = b
-                        if a == 'media_map_data':
-                            if b:
-                                for y, z in b.items():
-                                    for c, d in z.items():
-                                        if d:
-                                            if 'timestamp' in c:
-                                                if d > 0:
-                                                    d = (datetime.datetime.fromtimestamp(int(d)).strftime('%Y-%m-%d %H:%M:%S'))
-                                        ''' use seek function in the future
-                                        if c == 'uri':
-                                            thumb = 'get file to show'
-                                        else:
-                                            thumb = ''
-                                        '''
-                                        aggregator = aggregator + f'{y} - {c} - {d} <br>'
-                        if a == 'string_map_data':
-                            for y, z in b.items():
-                                for c, d in z.items():
-                                    if d:
-                                        if 'timestamp' in c:
-                                            if d > 0:
-                                                d = (datetime.datetime.fromtimestamp(int(d)).strftime('%Y-%m-%d %H:%M:%S'))
-                                        aggregator = aggregator + f'{y} - {c} - {d} <br>'
-                                        
-                data_list.append((title, aggregator))
-                                
-            if data_list:
-                report = ArtifactHtmlReport('Instagram Archive - Profile Changes')
-                report.start_artifact_report(report_folder, 'Instagram Archive - Profile Changes')
-                report.add_script()
-                data_headers = ('Title', 'Items')
 
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Items'])
-                report.end_artifact_report()
-                
-                tsvname = f'Instagram Archive - Profile Changes'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-            else:
-                logfunc('No Instagram Archive - Profile Changes data available')
-                
-__artifacts__ = {
-        "instagramProfchanges": (
-            "Instagram Archive",
-            ('*/account_information/profile_changes.json'),
-            get_instagramProfchanges)
-}
+            for x in deserialized['profile_profile_change']:
+                if not x.get('title'):
+                    continue
+                title = x.get('title', '')
+                aggregator = ''
+                for section in ('media_map_data', 'string_map_data'):
+                    block = x.get(section)
+                    if not block:
+                        continue
+                    for y, z in block.items():
+                        for c, d in z.items():
+                            if d and 'timestamp' in c:
+                                d = convert_unix_ts_to_utc(d)
+                            aggregator += f'{y} - {c} - {d} <br>'
+                data_list.append((title, aggregator))
+
+    data_headers = ('Title', 'Items')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramRecentreq.py
+++ b/scripts/artifacts/instagramRecentreq.py
@@ -1,54 +1,43 @@
-import os
-import datetime
-import json
-import shutil
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_instagramRecentreq(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('recent_follow_requests.json'):
-            
-            with open(file_found, "r") as fp:
-                deserialized = json.load(fp)
-        
-            for x in deserialized['relationships_permanent_follow_requests']:
-                href = x['string_list_data'][0].get('href', '')
-                value = x['string_list_data'][0].get('value', '')
-                timestamp = x['string_list_data'][0].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                
-                data_list.append((timestamp, value, href))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Recent Follow Req')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Recent Follow Req')
-        report.add_script()
-        data_headers = ('Timestamp','Following', 'Href')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Recent Follow Req'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Recent Follow Req'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Instagram Archive - Recent Follow Req')
-                
-__artifacts__ = {
-        "instagramRecentreq": (
-            "Instagram Archive",
-            ('*/followers_and_following/recent_follow_requests.json'),
-            get_instagramRecentreq)
+__artifacts_v2__ = {
+    "instagramRecentreq": {
+        "name": "Instagram Archive - Recent Follow Req",
+        "description": "Parses permanent/recent follow requests from an Instagram data archive (recent_follow_requests.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/followers_and_following/recent_follow_requests.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
 }
+
+import os
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def instagramRecentreq(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('recent_follow_requests.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
+                deserialized = json.load(fp)
+
+            for x in deserialized['relationships_permanent_follow_requests']:
+                entry = x['string_list_data'][0]
+                href = entry.get('href', '')
+                value = entry.get('value', '')
+                timestamp = entry.get('timestamp', '')
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                data_list.append((timestamp, value, href))
+
+    data_headers = (('Timestamp', 'datetime'), 'Following', 'Href')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramStories.py
+++ b/scripts/artifacts/instagramStories.py
@@ -1,55 +1,43 @@
+__artifacts_v2__ = {
+    "instagramStories": {
+        "name": "Instagram Archive - Stories",
+        "description": "Parses stories and their media from an Instagram data archive (stories.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/content/stories.json', '*/media/stories/*'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
 
-def get_instagramStories(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramStories(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('stories.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('stories.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['ig_stories']:
                 title = x.get('title', '')
                 uri = x.get('uri', '')
                 timestamp = x.get('creation_timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))
-                thumb = media_to_html(uri, files_found, report_folder)
-                
-                data_list.append((timestamp, title, thumb))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Stories')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Stories')
-        report.add_script()
-        data_headers = ('Timestamp','Title', 'Media')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Sotries'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Stories'
-        timeline(report_folder, tlactivity, data_list, data_headers)
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                media_ref = check_in_media(uri, title) if uri else None
+                data_list.append((timestamp, title, media_ref))
 
-    else:
-        logfunc('No Instagram Archive - Stories')
-                
-__artifacts__ = {
-        "instagramStories": (
-            "Instagram Archive",
-            ('*/content/stories.json', '*/media/stories/*'),
-            get_instagramStories)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Title', ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/instagramVideoswatched.py
+++ b/scripts/artifacts/instagramVideoswatched.py
@@ -1,53 +1,41 @@
+__artifacts_v2__ = {
+    "instagramVideoswatched": {
+        "name": "Instagram Archive - Videos Watched",
+        "description": "Parses videos watched from an Instagram data archive (videos_watched.json)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Instagram Archive",
+        "notes": "",
+        "paths": ('*/ads_and_content/videos_watched.json'),
+        "output_types": "standard",
+        "artifact_icon": "instagram",
+    }
+}
+
 import os
-import datetime
 import json
-import shutil
-from pathlib import Path	
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_instagramVideoswatched(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def instagramVideoswatched(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('videos_watched.json'):
-            
-            with open(file_found, "r") as fp:
+        if os.path.basename(file_found).startswith('videos_watched.json'):
+            source_path = file_found
+            with open(file_found, 'r', encoding='utf-8') as fp:
                 deserialized = json.load(fp)
-        
+
             for x in deserialized['impressions_history_videos_watched']:
                 author = x['string_map_data']['Author'].get('value', '')
                 timestamp = x['string_map_data']['Time'].get('timestamp', '')
-                if timestamp > 0:
-                    timestamp = (datetime.datetime.fromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S'))             
-                
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
                 data_list.append((timestamp, author))
-    
-                
-    if data_list:
-        report = ArtifactHtmlReport('Instagram Archive - Videos Watched')
-        report.start_artifact_report(report_folder, 'Instagram Archive - Videos Watched')
-        report.add_script()
-        data_headers = ('Timestamp','Author')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Instagram Archive - Videos Watched'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Instagram Archive - Videos Watched'
-        timeline(report_folder, tlactivity, data_list, data_headers)
 
-    else:
-        logfunc('No Instagram Archive - Videos Watched')
-                
-__artifacts__ = {
-        "instagramVideoswatched": (
-            "Instagram Archive",
-            ('*/ads_and_content/videos_watched.json'),
-            get_instagramVideoswatched)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Author')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Final chunk — completes the **Instagram Archive** conversion (30/30 live artifacts now on LAVA).

| Artifact | Source JSON | Notes |
|---|---|---|
| Recent Follow Req | recent_follow_requests.json | simple |
| Videos Watched | videos_watched.json | simple |
| Profile Changes | profile_changes.json | `<br>` aggregation kept via `html_columns` |
| **Stories** | stories.json + media/stories/* | **media** → `check_in_media` (`Media` col) |
| **Posts** | posts_1.json + media/* | **media** + **KML** (EXIF GPS) |

## Conventions applied (all artifact-level, no framework changes)
- `__artifacts__` funckey → `__artifacts_v2__`; **preserved** original author + creation dates.
- **Context form**, `convert_unix_ts_to_utc()` (aware UTC datetime objects), crash-safe guards, `.get()` on optional fields, `context.get_relative_path(source)`.
- **`media_to_html` → `check_in_media`** for the two artifacts that actually render media (Stories, Posts), typed `('Col','media')`. The dead `media_to_html` imports on Recent Follow Req / Videos Watched were dropped.
- **Posts → KML**: `output_types` now includes `'kml'` (note: `"standard"` intentionally *excludes* kml). The `Latitude`/`Longitude` columns feed the framework `kmlgen`, which only plots rows where **both** coords are present and writes no file if a post set has zero GPS — so the many non-geo posts are skipped cleanly.
- **Profile Changes**: preserved the original `<br>`-separated `Items` cell via `"html_columns": ["Items"]` (framework passes that to `html_no_escape`); timestamps inside the aggregation are now UTC.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader loads all 202**; reserved-word/whitespace audit clean (16 headers); **media columns detected** by `get_media_header_info` (Stories→`Media`, Posts→`Content`).

Net **−74 lines**.