### PR TITLE
Convert 8 Chrome (Google Takeout) artifacts to LAVA

### DIFF
--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -1,60 +1,45 @@
-# Module Description: Parses Google Chrome Autofill value information from Takeout
-# Author: @upintheairsheep & @KevinPagano3
-# Date: 2023-08-18
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "chromeAutofill": {
+        "name": "Chrome Autofill",
+        "description": "Parses Google Chrome Autofill value information from Takeout",
+        "author": "@upintheairsheep & @KevinPagano3",
+        "creation_date": "2023-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/Autofill.json'),
+        "output_types": "standard",
+        "artifact_icon": "edit-3",
+    }
+}
 
-import datetime
 import json
 import os
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_chromeAutofill(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def chromeAutofill(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Autofill.json': 
+        if os.path.basename(file_found) != 'Autofill.json':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
+        for site in data.get('Autofill', []):
+            name = site.get('name', '')
+            value = site.get('value', '')
+            for stamp in site.get('usage_timestamp', []):
+                # Chrome/WebKit epoch: microseconds since 1601-01-01 -> Unix seconds
+                timestamp = (int(stamp) / 1000000) - 11644473600 if stamp else ''
+                timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+                data_list.append((timestamp, name, value))
 
-        if 'Autofill' in data:
-            for site in data['Autofill']:
-                chromeautofill_name = site['name']
-                chromeautofill_value = site['value']
-                chromeautofill_usage = site['usage_timestamp']
-                count = len(chromeautofill_usage)
-
-                for stamp in chromeautofill_usage:
-                    timestamp = datetime.datetime.fromtimestamp((int(stamp)/1000000)-11644473600).strftime('%Y-%m-%d %H:%M:%S')
-                    data_list.append((timestamp, chromeautofill_name, textwrap.fill(chromeautofill_value, width=100)))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Autofill')
-            report.start_artifact_report(report_folder, 'Chrome Autofill')
-            report.add_script()
-            data_headers = ('Usage Timestamp','Field Type', 'Typed Value')
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome Autofill'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'Chrome Autofill'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Autofill data available')
-
-__artifacts__ = {
-        "chromeAutofill": (
-            "Google Takeout Archive",
-            ('*/Chrome/Autofill.json'),
-            get_chromeAutofill)
-}
+    data_headers = (('Usage Timestamp', 'datetime'), 'Field Type', 'Typed Value')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -1,97 +1,60 @@
-# Module Description: Parses Google Chrome bookmarks from Takeout
-# Author: @KevinPagano3
-# Date: 2023-08-21
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "chromeBookmarks": {
+        "name": "Chrome Bookmarks",
+        "description": "Parses Google Chrome bookmarks from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2023-08-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/Bookmarks.html'),
+        "output_types": "standard",
+        "artifact_icon": "bookmark",
+    }
+}
 
-import datetime
-import os
-import textwrap
 import bs4
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_chromeBookmarks(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+def _bookmark_add_date(value):
+    # add_date: 13-digit value = ms epoch; otherwise Chrome/WebKit microseconds since 1601
+    if not value or value == '0':
+        return ''
+    if len(value) == 13:
+        return convert_unix_ts_to_utc(int(value))
+    return convert_unix_ts_to_utc((int(value) / 1000000) - 11644473600)
+
+
+def _bookmark_ms(value):
+    if not value or value == '0':
+        return ''
+    return convert_unix_ts_to_utc(int(value))
+
+
+@artifact_processor
+def chromeBookmarks(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        filename = os.path.basename(file_found)
-
+        source_path = file_found
         with open(file_found, encoding='utf-8') as fp:
             soup = bs4.BeautifulSoup(fp.read(), 'html.parser')
-            
-        data_list = []
-        dt = soup.find_all('dt')
-        
-        add_date = ''
-        last_modified = ''
-        title = ''
-        url = ''
+
         folder_name = ''
-        
-        for i in dt:
+        for i in soup.find_all('dt'):
             n = i.find_next()
+            add_date = _bookmark_add_date(n.get('add_date', ''))
+            last_modified = _bookmark_ms(n.get('last_modified', ''))
             if n.name == 'h3':
                 folder_name = n.text
-                title = n.text
-                add_date = n.get('add_date','')
-                if add_date == '0' or len(add_date) == 0:
-                    add_date = ''
-                else:
-                    if len(add_date) == 13:
-                        add_date = datetime.datetime.utcfromtimestamp(int(add_date)/1000).strftime('%Y-%m-%d %H:%M:%S')  
-                    else:
-                        add_date = datetime.datetime.utcfromtimestamp((int(add_date)/1000000)-11644473600).strftime('%Y-%m-%d %H:%M:%S')
-                
-                last_modified = n.get('last_modified','')
-                if last_modified == '0' or len(last_modified) == 0:
-                    last_modified = ''
-                else:    
-                    last_modified = datetime.datetime.utcfromtimestamp(int(last_modified)/1000).strftime('%Y-%m-%d %H:%M:%S')
-                
-                data_list.append((add_date,last_modified,title,'',''))
-                add_date = ''
-                last_modified = ''
-                title = ''
-                continue
+                data_list.append((add_date, last_modified, n.text, '', ''))
             else:
-                url = n.get('href','')
-                title = n.text
-                add_date = n.get('add_date','')
-                if len(add_date) == 13:
-                    add_date = datetime.datetime.utcfromtimestamp(int(add_date)/1000).strftime('%Y-%m-%d %H:%M:%S')  
-                else:
-                    add_date = datetime.datetime.utcfromtimestamp((int(add_date)/1000000)-11644473600).strftime('%Y-%m-%d %H:%M:%S')
-                last_modified = n.get('last_modified','')
-                if last_modified == '0' or len(last_modified) == 0:
-                    last_modified = ''
-                else:    
-                    last_modified = datetime.datetime.utcfromtimestamp(int(last_modified)/1000).strftime('%Y-%m-%d %H:%M:%S')  
-                
-                data_list.append((add_date,last_modified,title,url,folder_name))
+                data_list.append((add_date, last_modified, n.text, n.get('href', ''), folder_name))
 
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Bookmarks')
-            report.start_artifact_report(report_folder, 'Chrome Bookmarks')
-            report.add_script()
-            data_headers = ('Added Timestamp','Last Modified','Title','URL','Parent Folder Name')
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome Bookmarks'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'Chrome Bookmarks'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Bookmarks data available')
-
-__artifacts__ = {
-        "chromeBookmarks": (
-            "Google Takeout Archive",
-            ('*/Chrome/Bookmarks.html'),
-            get_chromeBookmarks)
-}
+    data_headers = (('Added Timestamp', 'datetime'), ('Last Modified', 'datetime'),
+                    'Title', 'URL', 'Parent Folder Name')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeDeviceInfo.py
+++ b/scripts/artifacts/chromeDeviceInfo.py
@@ -1,63 +1,48 @@
-# Module Description: Parses Google Chrome synced device information from Takeout
-# Author: @KevinPagano3
-# Date: 2023-08-24
-# Artifact version: 0.0.1
-# Requirements: none
-
-import datetime
-import json
-import os
-import textwrap
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_chromeDeviceInfo(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
-        
-        if 'Device Info' in data:
-            for device in data['Device Info']:
-                last_updated_timestamp = device.get('last_updated_timestamp','')
-                last_updated_timestamp = datetime.datetime.utcfromtimestamp((int(last_updated_timestamp)/1000)).strftime('%Y-%m-%d %H:%M:%S')
-                
-                manufacturer = device.get('manufacturer','')
-                model = device.get('model','')
-                client_name = device.get('client_name','')
-                os_type = device.get('os_type','')[8:]
-                device_type = device.get('device_type','')[5:]
-                chrome_version = device.get('chrome_version','')
-                sync_user_agent = device.get('sync_user_agent','')
-                signin_scoped_device_id = device.get('signin_scoped_device_id','')
-                
-                data_list.append((last_updated_timestamp,manufacturer,model,client_name,os_type,device_type,chrome_version,sync_user_agent,textwrap.fill(signin_scoped_device_id,width=100)))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Device Info')
-            report.start_artifact_report(report_folder, 'Chrome Device Info')
-            report.add_script()
-            data_headers = ('Last Updated Timestamp','Manufacturer','Model','Client Name','OS Type','Device Type','Chrome Version','User Agent','Device ID')
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome Device Info'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'Chrome Device Info'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Device Info data available')
-
-__artifacts__ = {
-        "chromeDeviceInfo": (
-            "Google Takeout Archive",
-            ('*/Chrome/Device Information.json'),
-            get_chromeDeviceInfo)
+__artifacts_v2__ = {
+    "chromeDeviceInfo": {
+        "name": "Chrome Device Info",
+        "description": "Parses Google Chrome synced device information from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2023-08-24",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/Device Information.json'),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    }
 }
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def chromeDeviceInfo(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
+
+        for device in data.get('Device Info', []):
+            last_updated = device.get('last_updated_timestamp', '')
+            last_updated = convert_unix_ts_to_utc(last_updated) if last_updated else ''
+            manufacturer = device.get('manufacturer', '')
+            model = device.get('model', '')
+            client_name = device.get('client_name', '')
+            os_type = device.get('os_type', '')[8:]
+            device_type = device.get('device_type', '')[5:]
+            chrome_version = device.get('chrome_version', '')
+            sync_user_agent = device.get('sync_user_agent', '')
+            signin_scoped_device_id = device.get('signin_scoped_device_id', '')
+            data_list.append((last_updated, manufacturer, model, client_name, os_type,
+                              device_type, chrome_version, sync_user_agent, signin_scoped_device_id))
+
+    data_headers = (('Last Updated Timestamp', 'datetime'), 'Manufacturer', 'Model', 'Client Name',
+                    'OS Type', 'Device Type', 'Chrome Version', 'User Agent', 'Device ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeExtensions.py
+++ b/scripts/artifacts/chromeExtensions.py
@@ -1,59 +1,41 @@
-# Module Description: Parses Google Chrome Extensions from Takeout
-# Author: @KevinPagano3
-# Date: 2021-08-20
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "chromeExtensions": {
+        "name": "Chrome Extensions",
+        "description": "Parses Google Chrome Extensions from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-08-20",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/Extensions.json'),
+        "output_types": "standard",
+        "artifact_icon": "package",
+    }
+}
 
-import datetime
 import json
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_chromeExtensions(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+@artifact_processor
+def chromeExtensions(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Extensions.json': # skip -journal and other files
+        if os.path.basename(file_found) != 'Extensions.json':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
+        for site in data.get('Extensions', []):
+            data_list.append((site.get('name', ''), site.get('version', ''), site.get('id', ''),
+                              site.get('enabled', ''), site.get('incognito_enabled', ''),
+                              site.get('remote_install', '')))
 
-        for site in data['Extensions']:
-            
-            ext_name = site.get('name','')
-            ext_version = site.get('version','')
-            ext_ID = site.get('id','')
-            ext_enabled = site.get('enabled','')
-            incoginito_enabled = site.get('incognito_enabled','')
-            remote_install = site.get('remote_install','')
-               
-            data_list.append((ext_name, ext_version, ext_ID, ext_enabled, incoginito_enabled, remote_install))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Extensions')
-            report.start_artifact_report(report_folder, 'Chrome Extensions')
-            report.add_script()
-            data_headers = ('Name','Version','ID','Enabled','Incognito Enabled','Remote Install')
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Chrome Extensions'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Chrome Extensions'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Extensions data available')
-
-__artifacts__ = {
-        "chromeExtensions": (
-            "Google Takeout Archive",
-            ('*/Chrome/Extensions.json'),
-            get_chromeExtensions)
-}
+    data_headers = ('Name', 'Version', 'ID', 'Enabled', 'Incognito Enabled', 'Remote Install')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeHistory.py
+++ b/scripts/artifacts/chromeHistory.py
@@ -1,61 +1,42 @@
-# Module Description: Parses Google Chrome History from Takeout
-# Author: @KevinPagano3
-# Date: 2021-08-20
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "chromeHistory": {
+        "name": "Chrome Web History",
+        "description": "Parses Google Chrome History from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-08-20",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/BrowserHistory.json'),
+        "output_types": "standard",
+        "artifact_icon": "chrome",
+    }
+}
 
-import datetime
 import json
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_chromeHistory(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+@artifact_processor
+def chromeHistory(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'BrowserHistory.json': # skip -journal and other files
+        if os.path.basename(file_found) != 'BrowserHistory.json':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
-        url = ''
-        title = ''
-        timestamp = ''
-        page_transition = ''
+        for site in data.get('Browser History', []):
+            timestamp = site.get('time_usec', '')
+            timestamp = convert_unix_ts_to_utc(timestamp) if timestamp else ''
+            data_list.append((timestamp, site.get('title', ''), site.get('url', ''),
+                              site.get('page_transition', '')))
 
-        for site in data['Browser History']:
-            
-            url = site['url']
-            title = site['title']
-            timestamp = datetime.datetime.fromtimestamp(int(site['time_usec'])/1000000).strftime('%Y-%m-%d %H:%M:%S.%f')
-            page_transition = site['page_transition']
-
-            data_list.append((timestamp, title, url, page_transition))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Web History')
-            report.start_artifact_report(report_folder, 'Chrome Web History')
-            report.add_script()
-            data_headers = ('Timestamp','Webpage Title','URL','Page Transition') 
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Chrome Web History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Chrome Web History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Web History data available')
-
-__artifacts__ = {
-        "chromeHistory": (
-            "Google Takeout Archive",
-            ('*/Chrome/BrowserHistory.json'),
-            get_chromeHistory)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Webpage Title', 'URL', 'Page Transition')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeOSSettings.py
+++ b/scripts/artifacts/chromeOSSettings.py
@@ -1,94 +1,81 @@
-# Module Description: Parses OS Settings from Google Takeout
-# Author: @upintheairsheep & @KevinPagano3
-# Date: 2023-08-18
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "chromeArcPackages": {
+        "name": "Chrome ARC Packages",
+        "description": "Parses ARC (Android) package backup info from Google Takeout OS Settings.json",
+        "author": "@upintheairsheep & @KevinPagano3",
+        "creation_date": "2023-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/OS Settings.json'),
+        "output_types": "standard",
+        "artifact_icon": "package",
+    },
+    "chromeOSSettings": {
+        "name": "Chrome OS Settings",
+        "description": "Parses user OS priority preferences (gender, birth year) from Google Takeout OS Settings.json",
+        "author": "@upintheairsheep & @KevinPagano3",
+        "creation_date": "2023-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/OS Settings.json'),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    }
+}
 
-import datetime
 import json
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_chromeOSSettings(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def chromeArcPackages(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'OS Settings.json': # skip -journal and other files
+        if os.path.basename(file_found) != 'OS Settings.json':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
-        data_list2 = []
+        for package in data.get('Arc Package', []):
+            last_backup = package.get('last_backup_time', '')
+            last_backup = convert_unix_ts_to_utc(last_backup) if last_backup else ''
+            data_list.append((last_backup, package.get('package_name', ''),
+                              package.get('package_version', ''),
+                              package.get('last_backup_android_id', '')))
 
-        for package in data['Arc Package']:
-            chromeARC_lastBack = package['last_backup_time']
-            if chromeARC_lastBack == 0:
-                chromeARC_lastBack = ''
-            else:
-                chromeARC_lastBack = datetime.datetime.fromtimestamp(int(chromeARC_lastBack)/1000000).strftime('%Y-%m-%d %H:%M:%S.%f')
-            chromeARC_name = package.get('package_name','')
-            chromeARC_ver = package.get('package_version','')
-            chromeARC_bkID = package.get('last_backup_android_id','')
+    data_headers = (('Last Backed Up Timestamp', 'datetime'), 'Package Name',
+                    'Package Version', 'Last Backup Android ID')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
-            data_list.append((chromeARC_lastBack, chromeARC_name, chromeARC_ver, chromeARC_bkID))
 
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome ARC Packages')
-            report.start_artifact_report(report_folder, 'Chrome ARC Packages')
-            report.add_script()
-            data_headers = ('Last Backed Up Timestamp','Package Name','Package Version','Last Backup Android ID')
+@artifact_processor
+def chromeOSSettings(context):
+    data_list = []
+    source_path = ''
+    genders = {0: 'Female', 1: 'Male', 2: 'Rather not say'}
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'OS Settings.json':
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome ARC Packages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'Chrome ARC Packages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome ARC Packages data available')
-
-        for pref in data['OS Priority Preference']:
+        for pref in data.get('OS Priority Preference', []):
             pref_name = pref['preference']['name']
-            pref_value = pref['preference']['value']
-            preference_value = json.loads(pref_value)
-            gender = preference_value['gender']
-            if gender == 0:
-                gender = 'Female'
-            elif gender == 1:
-                gender = 'Male'
-            elif gender == 2:
-                gender = 'Rather not say'
-            else:
-                gender = 'Other'
-            birth_year = preference_value['birth_year']
+            preference_value = json.loads(pref['preference']['value'])
+            gender = genders.get(preference_value.get('gender'), 'Other')
+            birth_year = preference_value.get('birth_year', '')
+            data_list.append((pref_name, gender, birth_year))
 
-            data_list2.append((pref_name,gender,birth_year))
-            
-        num_entries = len(data_list2)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome OS Settings')
-            report.start_artifact_report(report_folder, 'Chrome OS Settings')
-            report.add_script()
-            data_headers = ('Preference Name','User Gender','User Birth Year')
-
-            report.write_artifact_data_table(data_headers, data_list2, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome OS Settings'
-            tsv(report_folder, data_headers, data_list2, tsvname)
-
-        else:
-            logfunc('No Chrome OS Settings data available')
-
-__artifacts__ = {
-        "chromeOSSettings": (
-            "Google Takeout Archive",
-            ('*/Chrome/OS Settings.json'),
-            get_chromeOSSettings)
-}
+    data_headers = ('Preference Name', 'User Gender', 'User Birth Year')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeReadingList.py
+++ b/scripts/artifacts/chromeReadingList.py
@@ -1,59 +1,39 @@
-# Module Description: Parses Google Chrome reading list from Takeout
-# Author: @KevinPagano3
-# Date: 2023-08-24
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "chromeReadingList": {
+        "name": "Chrome Reading List",
+        "description": "Parses Google Chrome reading list from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2023-08-24",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/ReadingList.html'),
+        "output_types": "standard",
+        "artifact_icon": "list",
+    }
+}
 
-import datetime
-import os
-import textwrap
 import bs4
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_chromeReadingList(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def chromeReadingList(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        filename = os.path.basename(file_found)
-
+        source_path = file_found
         with open(file_found, encoding='utf-8') as fp:
             soup = bs4.BeautifulSoup(fp.read(), 'html.parser')
-            
-        data_list = []
-        dt = soup.find_all('dt')
-        
-        for i in dt:
+
+        for i in soup.find_all('dt'):
             n = i.find_next()
-            url = n.get('href','')
-            title = n.text
-            add_date = n.get('add_date','')
-            add_date = datetime.datetime.utcfromtimestamp((int(add_date)/1000000)).strftime('%Y-%m-%d %H:%M:%S')
-                
-            data_list.append((add_date,title,url))
-            
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Reading List')
-            report.start_artifact_report(report_folder, 'Chrome Reading List')
-            report.add_script()
-            data_headers = ('Added Timestamp','Title','URL')
+            add_date = n.get('add_date', '')
+            add_date = convert_unix_ts_to_utc(add_date) if add_date else ''
+            data_list.append((add_date, n.text, n.get('href', '')))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome Reading List'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'Chrome Reading List'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Reading List data available')
-
-__artifacts__ = {
-        "chromeReadingList": (
-            "Google Takeout Archive",
-            ('*/Chrome/ReadingList.html'),
-            get_chromeReadingList)
-}
+    data_headers = (('Added Timestamp', 'datetime'), 'Title', 'URL')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chromeSearchEngines.py
+++ b/scripts/artifacts/chromeSearchEngines.py
@@ -1,76 +1,50 @@
-# Module Description: Parses Google Chrome Search Engines from Takeout
-# Author: @upintheairsheep & @KevinPagano3
-# Date: 2023-08-17
-# Artifact version: 0.0.1
-# Requirements: none
-
-import datetime
-import json
-import os
-import textwrap
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_chromeSearchEngines(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
-
-        for site in data['Search Engines']:
-            sEng_date = site.get('date_created','')
-            if sEng_date == 0:
-                sEng_date = ''
-            else:
-                sEng_date = datetime.datetime.fromtimestamp(int(sEng_date)/1000000).strftime('%Y-%m-%d %H:%M:%S.%f')
-            sEng_lastModified = site.get('last_modified','')
-            if sEng_lastModified == 0:
-                sEng_lastModified = ''
-            else:
-                sEng_lastModified = datetime.datetime.fromtimestamp(int(sEng_lastModified)/1000000).strftime('%Y-%m-%d %H:%M:%S.%f')
-            sEng_suggestions_url = site.get('suggestions_url','')
-            sEng_favicon_url = site.get('favicon_url','')
-            sEng_safeAreplace = site.get('safe_for_autoreplace','')
-            sEng_url = site.get('url','')
-            sEng_ntpurl = site.get('new_tab_url','')
-            sEng_originUrl = site.get('originating_url','')
-            sEng_syncGUID = site.get('sync_guid','')
-            sEng_shortName = site.get('short_name','')
-            sEng_kWord = site.get('keyword','')
-            sEng_inputEnc = site.get('input_encodings','')
-            sEng_prePopID = site.get('prepopulate_id','')
-            sEng_imageurlpostparams = site.get('image_url_post_params','')
-            sEng_isActive = site.get('is_active','')
-            sEng_imageurl = site.get('image_url','')
-            sEng_starterpackID = site.get('starter_pack_id','')
-
-            data_list.append((sEng_date, sEng_lastModified, sEng_shortName, sEng_kWord, textwrap.fill(sEng_url, width=100), sEng_originUrl, sEng_syncGUID, sEng_favicon_url, sEng_suggestions_url, sEng_ntpurl, sEng_inputEnc, sEng_safeAreplace, sEng_prePopID, sEng_imageurlpostparams, sEng_isActive, sEng_imageurl, sEng_starterpackID))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Chrome Search Engines')
-            report.start_artifact_report(report_folder, 'Chrome Search Engines')
-            report.add_script()
-            data_headers = ('Date Created','Date Last Modified','(Short) Name','Keyword','URL Syntax','API URL', 'Sync GUID', 'Favicon URL', 'Suggestions URL', 'New Tab URL', 'Input Encodings', 'Safe Autoreplace?', 'Pre-populate ID', 'Image URL Post Parameters', 'Is Active?', 'Image URL', 'Starter Pack ID')
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            tsvname = f'Chrome Search Engines'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'Chrome Search Engines'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Chrome Search Engines data available')
-
-__artifacts__ = {
-        "chromeSearchEngines": (
-            "Google Takeout Archive",
-            ('*/Chrome/SearchEngines.json'),
-            get_chromeSearchEngines)
+__artifacts_v2__ = {
+    "chromeSearchEngines": {
+        "name": "Chrome Search Engines",
+        "description": "Parses Google Chrome Search Engines from Takeout",
+        "author": "@upintheairsheep & @KevinPagano3",
+        "creation_date": "2023-08-17",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/SearchEngines.json'),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    }
 }
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+@artifact_processor
+def chromeSearchEngines(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
+
+        for site in data.get('Search Engines', []):
+            date_created = site.get('date_created', '')
+            date_created = convert_unix_ts_to_utc(date_created) if date_created else ''
+            last_modified = site.get('last_modified', '')
+            last_modified = convert_unix_ts_to_utc(last_modified) if last_modified else ''
+            data_list.append((
+                date_created, last_modified, site.get('short_name', ''), site.get('keyword', ''),
+                site.get('url', ''), site.get('originating_url', ''), site.get('sync_guid', ''),
+                site.get('favicon_url', ''), site.get('suggestions_url', ''), site.get('new_tab_url', ''),
+                site.get('input_encodings', ''), site.get('safe_for_autoreplace', ''),
+                site.get('prepopulate_id', ''), site.get('image_url_post_params', ''),
+                site.get('is_active', ''), site.get('image_url', ''), site.get('starter_pack_id', '')))
+
+    data_headers = (('Date Created', 'datetime'), ('Date Last Modified', 'datetime'),
+                    '(Short) Name', 'Keyword', 'URL Syntax', 'API URL', 'Sync GUID', 'Favicon URL',
+                    'Suggestions URL', 'New Tab URL', 'Input Encodings', 'Safe Autoreplace?',
+                    'Pre-populate ID', 'Image URL Post Parameters', 'Is Active?', 'Image URL',
+                    'Starter Pack ID')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
First **Google Takeout Archive** batch (22 in the category) — all 8 Chrome artifacts converted from the legacy funckey/`ArtifactHtmlReport` form to the LAVA `@artifact_processor` pipeline.

| Artifact | Source | Epoch encoding |
|---|---|---|
| Autofill | Autofill.json | **WebKit** µs since 1601 |
| Device Info | Device Information.json | ms |
| Extensions | Extensions.json | — |
| Web History | BrowserHistory.json | Unix µs |
| OS Settings | OS Settings.json | µs (ARC backup) |
| Search Engines | SearchEngines.json | Unix µs ×2 |
| Bookmarks | Bookmarks.html (bs4) | ms **or** WebKit µs |
| Reading List | ReadingList.html (bs4) | Unix µs |

## Conventions applied (all artifact-level, no framework changes)
- `__artifacts__` funckey → `__artifacts_v2__`; **preserved original authors** (@KevinPagano3, @upintheairsheep) and creation dates.
- **Context form**, `context.get_relative_path(source)`, dropped the `ArtifactHtmlReport`/tsv/timeline boilerplate, `textwrap` HTML-wrapping, and unused imports.
- **Timestamps → UTC** via `convert_unix_ts_to_utc` (aware datetime objects). This also **fixes a latent bug**: the originals inconsistently mixed local-time `datetime.fromtimestamp` with `utcfromtimestamp` — now all UTC, per the standing directive. Three encodings handled:
  - ms / Unix-µs → passed straight to the helper (it truncates by digit count).
  - **Chrome/WebKit µs since 1601** → precomputed to Unix seconds `((v/1000000)-11644473600)` *before* the helper, since digit-truncation alone lands them in 2012 (verified empirically).
- **`chromeOSSettings` emitted two reports** from one function (ARC packages + OS priority prefs). LAVA is one-table-per-artifact, so it's split into **two artifacts**: `chromeArcPackages` + `chromeOSSettings`. Loader **202 → 203** (expected).

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader loads all (203)**; per-table reserved-word **and duplicate-column** audit clean (9 tables — Search Engines has 17 columns).

Net **−163 lines**.