### PR TITLE
Convert Google Takeout location artifacts (Location History + Records) to LAVA

### DIFF
--- a/scripts/artifacts/takeoutLocationHistory.py
+++ b/scripts/artifacts/takeoutLocationHistory.py
@@ -1,147 +1,63 @@
-# Module Description: Parses Google Takeout Location History.json file
-# Author: @KevinPagano3 & @Cheeky4n6Monkey
-# Date: 2021-09-21
-# Artifact version: 0.0.2
-# Requirements: none
-# Updated: 2022-02-28
-# Code completely reworked from https://github.com/cheeky4n6monkey/4n6-scripts/blob/master/Google_Takeout_Location_History/%23%20gLocationHistoryActivity.py
-# License: https://www.gnu.org/licenses/gpl-3.0.en.html
+__artifacts_v2__ = {
+    "takeoutLocationHistory": {
+        "name": "Google Location History - Location History",
+        "description": "Parses Google Takeout Location History.json (locations with detected activity)",
+        "author": "@KevinPagano3 & @Cheeky4n6Monkey",
+        "creation_date": "2021-09-21",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Reworked from cheeky4n6monkey/4n6-scripts Google_Takeout_Location_History.",
+        "paths": ('*/Location History/Location History.json', '*/Location History.json'),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    }
+}
 
-import datetime
 import json
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, kmlgen
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_takeoutLocationHistory(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+@artifact_processor
+def takeoutLocationHistory(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Location History.json': # skip -journal and other files
+        if os.path.basename(file_found) != 'Location History.json':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-        data_list = []
-        count_element = 0
-        count_element_activity = 0
-        count_sub_total = 0
-        count_multiple_activitys = 0
-        folder_dict = {}
+        for element in data.get('locations', []):
+            timestamp = convert_unix_ts_to_utc(element['timestampMs']) if element.get('timestampMs') else ''
+            lat = element['latitudeE7'] / 10000000
+            lon = element['longitudeE7'] / 10000000
+            accuracy = element.get('accuracy', '')
+            altitude = float(element['altitude']) if 'altitude' in element else 'NOT_SPECIFIED'
+            vertical_accuracy = element.get('verticalAccuracy', 'NOT_SPECIFIED')
+            heading = element.get('heading', 'NOT_SPECIFIED')
+            velocity = element.get('velocity', 'NOT_SPECIFIED')
+            source = element.get('source', 'NOT_SPECIFIED')
+            device = str(element['deviceTag']) if 'deviceTag' in element else 'NOT_SPECIFIED'
+            platform = element.get('platformType', 'NOT_SPECIFIED')
 
-        with open(file_found, 'r') as f:
-            data = json.loads(f.read())
+            for activity in element.get('activity', []):
+                activity_ts = convert_unix_ts_to_utc(activity['timestampMs']) if activity.get('timestampMs') else ''
+                count_sub = 0
+                subactivity_str = ''
+                for subact in activity.get('activity', []):
+                    count_sub += 1
+                    subactivity_str += f"{subact['type']} [{subact['confidence']}], "
+                data_list.append((timestamp, source, device, platform, lat, lon, altitude,
+                                  heading, velocity, accuracy, vertical_accuracy, count_sub,
+                                  activity.get('timestampMs', ''), activity_ts, subactivity_str[:-2]))
 
-        for element in data["locations"]:
-            count_element += 1
-            #print(element["timestampMs"]) # parent element timestamp
-            element_timestamp = element["timestampMs"]
-            element_timestamp_str = datetime.datetime.utcfromtimestamp(int(element_timestamp)/1000).isoformat()
-            element_lat = float(element["latitudeE7"]/10000000)
-            element_llg = float(element["longitudeE7"]/10000000)
-            element_accuracy = element["accuracy"]
-
-            element_alt = "NOT_SPECIFIED"
-            if "altitude" in element: # altitude not always specified
-                element_alt = float(element["altitude"])
-
-            element_verticalaccuracy = "NOT_SPECIFIED"
-            if "verticalAccuracy" in element: # verticalAccuracy not always specified
-                element_verticalaccuracy = element["verticalAccuracy"]
-
-            element_heading = "NOT_SPECIFIED"
-            if "heading" in element: # heading not always specified
-                element_heading = element["heading"]
-
-            element_velocity = "NOT_SPECIFIED"
-            if "velocity" in element: # velocity not always specified
-                element_velocity = element["velocity"]
-            
-            element_source = "NOT_SPECIFIED"
-            if "source" in element:
-                element_source = element["source"]
-                
-            element_device = "NOT_SPECIFIED"
-            if "deviceTag" in element:
-                element_device = str(element["deviceTag"])
-
-            element_platform = "NOT_SPECIFIED"
-            if "platformType" in element: # platformType not always specified
-                element_platform = element["platformType"]
-
-            if "activity" in element: # parent activity list
-                count_element_activity += 1
-
-                if (len(element["activity"]) > 1):
-                    count_multiple_activitys += 1 
-
-                # Each element activity has at least one child activity which is represented as a list of type/confidence dicts
-                count_child = 0
-                for activity in element["activity"]:
-                    count_child += 1
-
-                    activity_timestamp = activity["timestampMs"]
-                    activity_timestamp_str = datetime.datetime.utcfromtimestamp(int(activity_timestamp)/1000).isoformat()
-
-                    # Each (sub)activity can have multiple types:
-                    # IN_VEHICLE	The device is in a vehicle, such as a car.
-                    # ON_BICYCLE	The device is on a bicycle.
-                    # ON_FOOT	The device is on a user who is walking or running.
-                    # RUNNING	The device is on a user who is running.
-                    # STILL	The device is still (not moving).
-                    # TILTING	The device angle relative to gravity changed significantly.
-                    # UNKNOWN	Unable to detect the current activity.
-                    # WALKING	The device is on a user who is walking.
-                    #
-                    # confidence    value from 0 to 100 indicating how likely it is that the user is performing this activity.
-                    #
-                    # Source: https://developers.google.com/android/reference/com/google/android/gms/location/DetectedActivity
-                    count_sub = 0
-                    subactivity_str = ""
-                    for subact in activity["activity"]:
-                        count_sub += 1
-                        subactivity_str += str(subact["type"] + " [" + str(subact["confidence"]) + "], ")
-
-                    # Store each activity & its subactivitys    
-                    folderid = element_timestamp_str.split("T")[0] # eg 2022-02-04T09:56:36.253Z
-                    element_timestamp_c = element_timestamp_str.replace('T', ' ')
-                    element_timestamp_c = element_timestamp_c.replace('Z', '')
-                    
-                    if folderid not in folder_dict.keys(): # add entry 1 if key has not been created before
-                        folder_dict[folderid] = [(element_timestamp_c, element_source, element_device, element_platform,  element_lat, element_llg, element_alt, element_heading, element_velocity, element_accuracy, element_verticalaccuracy, count_sub, activity_timestamp, activity_timestamp_str, subactivity_str[:-2])]
-                    else:
-                        # add n-th entry to existing folder
-                        folder_dict[folderid].append((element_timestamp_c, element_source, element_device, element_platform, element_lat, element_llg, element_alt, element_heading, element_velocity, element_accuracy, element_verticalaccuracy, count_sub, activity_timestamp, activity_timestamp_str, subactivity_str[:-2]))
-                count_sub_total += count_sub
-                     
-        for x, y in folder_dict.items():
-            for a in y:
-                data_list.append(a)                           
-
-    num_entries = len(data_list)
-    if num_entries > 0:
-        report = ArtifactHtmlReport('Google Location History - Location History')
-        report.start_artifact_report(report_folder, 'Google Location History - Location History')
-        report.add_script()
-        data_headers = ('Timestamp','Source','Device Tag','Platform','Latitude','Longitude','Altitude','Heading (Degrees)','Velocity','Accuracy','Vertical Accuracy','Activity','Sub-activity Types', 'Timestamp Activity', 'Detected Activity')
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Location History - Location History'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Location History - Location History'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'Google Location History - Location History'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers)            
-        
-    else:
-        logfunc('No Google Location History - Location History data available')
-
-__artifacts__ = {
-        "takeoutLocationHistory": (
-            "Google Takeout Archive",
-            ('*/Location History/Location History.json','*/Location History.json'),
-            get_takeoutLocationHistory)
-}
+    data_headers = (('Timestamp', 'datetime'), 'Source', 'Device Tag', 'Platform', 'Latitude',
+                    'Longitude', 'Altitude', 'Heading (Degrees)', 'Velocity', 'Accuracy',
+                    'Vertical Accuracy', 'Activity', 'Sub-activity Types',
+                    ('Timestamp Activity', 'datetime'), 'Detected Activity')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/takeoutRecords.py
+++ b/scripts/artifacts/takeoutRecords.py
@@ -1,160 +1,81 @@
-# Code edited from https://github.com/cheeky4n6monkey/4n6-scripts/blob/master/Google_Takeout_Records/gRecordsActivity_ijson_date.py
-#
-# Author: cheeky4n6monkey@gmail.com
-# License: https://www.gnu.org/licenses/gpl-3.0.en.html
-
-
-import datetime
-import ijson
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, kmlgen
-
-def get_takeoutRecords(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Records.json': # skip -journal and other files
-            continue
-
-        data_list = []
-        count_element = 0
-        count_element_activity = 0
-        count_multiple_activitys = 0
-        folder_dict = {} 
-    
-        with open(file_found, 'r') as f:
-            document = f.read()
-            
-        element_items = ijson.items(document, 'locations.item')
-    
-        for element in element_items: # each element
-            #print("\n" + str(element))
-            count_element += 1
-    
-            if 'activity' in element: # each element which has an activty
-                count_element_activity += 1
-    
-                element_lat = float(element["latitudeE7"]/10000000)
-                element_llg = float(element["longitudeE7"]/10000000)
-                element_accuracy = element["accuracy"]
-    
-                element_alt = "NOT_SPECIFIED"
-                if "altitude" in element: # altitude not always specified
-                    element_alt = float(element["altitude"])
-    
-                element_verticalaccuracy = "NOT_SPECIFIED"
-                if "verticalAccuracy" in element: # verticalAccuracy not always specified
-                    element_verticalaccuracy = element["verticalAccuracy"]
-    
-                element_heading = "NOT_SPECIFIED"
-                if "heading" in element: # heading not always specified
-                    element_heading = element["heading"]
-    
-                element_velocity = "NOT_SPECIFIED"
-                if "velocity" in element: # velocity not always specified
-                    element_velocity = element["velocity"]
-    
-                element_source = element["source"]
-                element_device = str(element["deviceTag"])
-    
-                element_platform = "NOT_SPECIFIED"
-                if "platformType" in element: # altitude not always specified
-                    element_platform = element["platformType"]
-    
-                element_formFactor = "NOT_SPECIFIED"
-                if "formFactor" in element: # formFactor not always specified
-                    element_formFactor = element["formFactor"]
-    
-                element_timestamp_str = element["timestamp"]
-    
-                element_serverTimestamp_str = "NOT_SPECIFIED"
-                if "serverTimestamp" in element: # serverTimestamp not always specified
-                    element_serverTimestamp_str = element["serverTimestamp"]      
-    
-                element_deviceTimestamp_str = "NOT_SPECIFIED"
-                if "deviceTimestamp" in element: # deviceTimestamp not always specified 
-                    element_deviceTimestamp_str = element["deviceTimestamp"]
-
-                if (len(element["activity"]) > 1):
-                    count_multiple_activitys += 1
-                    
-                count_activity = 0
-                for act in element["activity"]: # for each activity in element. multiple (sub)activitys can be in 1 element.
-                    count_activity += 1                    
-                    activity_timestamp_str = "Not found"
-                    if "timestamp" in act: # search for Activity Timestamp
-                        activity_timestamp_str = act["timestamp"]
-    
-                    # For each sub-activity listed, there can be multiple type/confidence pairs
-                    # (sub)activity type can be:
-                    # IN_VEHICLE	The device is in a vehicle, such as a car.
-                    # ON_BICYCLE	The device is on a bicycle.
-                    # ON_FOOT	The device is on a user who is walking or running.
-                    # RUNNING	The device is on a user who is running.
-                    # STILL	The device is still (not moving).
-                    # TILTING	The device angle relative to gravity changed significantly.
-                    # UNKNOWN	Unable to detect the current activity.
-                    # WALKING	The device is on a user who is walking.
-                    #
-                    # confidence    value from 0 to 100 indicating how likely it is that the user is performing this activity.
-                    #
-                    # Source: https://developers.google.com/android/reference/com/google/android/gms/location/DetectedActivity
-                    count_sub = 0
-                    subactivity_str = ""
-                    for subact in act["activity"]:
-                        count_sub += 1
-                        #print("subactivity no. = " + str(count_sub))
-                        #print("type: " + subact["type"])
-                        #print("conf: " + str(subact["confidence"]))
-                        subactivity_str += str(subact["type"] + " [" + str(subact["confidence"]) + "], ")
-                    
-    
-                    # Store each activity & its subactivitys    
-                    folderid = element_timestamp_str.split("T")[0] # eg 2022-02-04T09:56:36.253Z
-                    element_timestamp_c = element_timestamp_str.replace('T', ' ')
-                    element_timestamp_c = element_timestamp_c.replace('Z', '')
-                    
-                    if folderid not in folder_dict.keys(): # add entry 1 if key has not been created before
-                        folder_dict[folderid] = [(element_timestamp_c, element_source, element_device, element_platform, element_formFactor, element_serverTimestamp_str, element_deviceTimestamp_str, element_timestamp_str, element_lat, element_llg, element_alt, element_heading, element_velocity, element_accuracy, element_verticalaccuracy, count_sub, activity_timestamp_str, subactivity_str[:-2])]
-                    else:
-                        # add n-th entry to existing folder
-                        folder_dict[folderid].append((element_timestamp_c, element_source, element_device, element_platform, element_formFactor, element_serverTimestamp_str, element_deviceTimestamp_str, element_timestamp_str, element_lat, element_llg, element_alt, element_heading, element_velocity, element_accuracy, element_verticalaccuracy, count_sub, activity_timestamp_str, subactivity_str[:-2]))
-                        
-                # end for activity in element loop
-        # ends for element loop
-    
-        for x, y in folder_dict.items():
-            for a in y:
-                data_list.append(a)
-                
-        
-    num_entries = len(data_list)
-    if num_entries > 0:
-        report = ArtifactHtmlReport('Google Location History - Records')
-        report.start_artifact_report(report_folder, 'Google Location History - Records')
-        report.add_script()
-        data_headers = ('Timestamp', 'Source', 'Device', 'Platform', 'Form Factor', 'Timestamp Server', 'Timestamp Device', 'Timestamp Element', 'Latitude', 'Longitude', 'Altitude', 'Heading', 'Velocity', 'Accuracy', 'Vertical Accuracy', 'Sub-activity Types', 'Timestamp Activity', 'Detected Activity')
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Location History - Records'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Location History - Records'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'Google Location History - Records'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Google Location History - Records data available')
-
-__artifacts__ = {
-        "takeoutRecords": (
-            "Google Takeout Archive",
-            ('*/Location History*/Records.json'),
-            get_takeoutRecords)
+__artifacts_v2__ = {
+    "takeoutRecords": {
+        "name": "Google Location History - Records",
+        "description": "Parses Google Takeout Records.json location records with detected activity",
+        "author": "cheeky4n6monkey@gmail.com",
+        "creation_date": "2022-02-27",
+        "last_update_date": "2026-06-27",
+        "requirements": "ijson",
+        "category": "Google Takeout Archive",
+        "notes": "Edited from cheeky4n6monkey/4n6-scripts Google_Takeout_Records.",
+        "paths": ('*/Location History*/Records.json'),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    }
 }
+
+import os
+from datetime import datetime
+
+import ijson
+
+from scripts.ilapfuncs import artifact_processor
+
+
+def _iso_to_utc(value):
+    # Records timestamps are ISO-8601 strings (often Z-suffixed); leave placeholders untouched.
+    if not value or value in ('NOT_SPECIFIED', 'Not found'):
+        return value
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return value
+
+
+@artifact_processor
+def takeoutRecords(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'Records.json':
+            continue
+        source_path = file_found
+        with open(file_found, 'rb') as f:
+            for element in ijson.items(f, 'locations.item'):
+                if 'activity' not in element:
+                    continue
+                lat = element['latitudeE7'] / 10000000
+                lon = element['longitudeE7'] / 10000000
+                accuracy = element.get('accuracy', '')
+                altitude = float(element['altitude']) if 'altitude' in element else 'NOT_SPECIFIED'
+                vertical_accuracy = element.get('verticalAccuracy', 'NOT_SPECIFIED')
+                heading = element.get('heading', 'NOT_SPECIFIED')
+                velocity = element.get('velocity', 'NOT_SPECIFIED')
+                source = element.get('source', '')
+                device = str(element.get('deviceTag', ''))
+                platform = element.get('platformType', 'NOT_SPECIFIED')
+                form_factor = element.get('formFactor', 'NOT_SPECIFIED')
+                element_ts = element.get('timestamp', '')
+                server_ts = element.get('serverTimestamp', 'NOT_SPECIFIED')
+                device_ts = element.get('deviceTimestamp', 'NOT_SPECIFIED')
+
+                for act in element['activity']:
+                    activity_ts = act.get('timestamp', 'Not found')
+                    count_sub = 0
+                    subactivity_str = ''
+                    for subact in act.get('activity', []):
+                        count_sub += 1
+                        subactivity_str += f"{subact['type']} [{subact['confidence']}], "
+                    data_list.append((
+                        _iso_to_utc(element_ts), source, device, platform, form_factor,
+                        _iso_to_utc(server_ts), _iso_to_utc(device_ts), element_ts,
+                        lat, lon, altitude, heading, velocity, accuracy, vertical_accuracy,
+                        count_sub, _iso_to_utc(activity_ts), subactivity_str[:-2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Source', 'Device', 'Platform', 'Form Factor',
+                    ('Timestamp Server', 'datetime'), ('Timestamp Device', 'datetime'),
+                    'Timestamp Element', 'Latitude', 'Longitude', 'Altitude', 'Heading', 'Velocity',
+                    'Accuracy', 'Vertical Accuracy', 'Sub-activity Types',
+                    ('Timestamp Activity', 'datetime'), 'Detected Activity')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Second **Google Takeout Archive** batch — the two single-table location-activity parsers, converted to the LAVA `@artifact_processor` pipeline with KML. (Deliberately a focused 2-artifact batch: these are large and were worth getting exactly right; the multi-table Semantic Location History + Settings + by-month parsers follow in their own batches.)

| Artifact | Source | Timestamps | Parser |
|---|---|---|---|
| Location History | Location History.json | **ms epoch** | json |
| Records | Records.json | **ISO-8601 strings** | **ijson** (streaming) |

## Conventions applied (all artifact-level)
- `__artifacts__` funckey → `__artifacts_v2__`; **preserved original authors** (@KevinPagano3 & @Cheeky4n6Monkey; cheeky4n6monkey@gmail.com) and dates.
- **Context form**, `context.get_relative_path(source)`, dropped the `ArtifactHtmlReport`/tsv/timeline boilerplate.
- **KML** enabled via explicit `output_types` incl `'kml'`; the `Latitude`/`Longitude` columns feed the framework `kmlgen` (rows without coords skipped).
- **Timestamps → UTC**: Location History ms-epoch via `convert_unix_ts_to_utc`; Records ISO strings parsed to aware-UTC datetimes (`fromisoformat`, `Z`→`+00:00`), with placeholders like `NOT_SPECIFIED` kept as text. Makes the output UTC-consistent (the originals mixed `utcfromtimestamp` with raw strings).
- Records keeps **ijson streaming** (now from a binary handle). Removed the redundant `folder_dict` date-grouping (rows identical, now source-order).

## ⚠️ Pre-existing quirk preserved (flagging for your call)
In both originals the **`Sub-activity Types`** column does **not** hold activity-type text — it holds a **count** (Records) or a **raw-ms activity timestamp** (Location History). I kept the value→column mapping **identical** to the originals rather than silently relabel. Say the word and I'll rename these columns to match their contents in a follow-up.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + duplicate-column audit clean; **PluginLoader loads all (203)**; and a **synthetic-data functional test** asserting aware-UTC datetimes (incl. Records sub-seconds + server/device stamps), lat/lon, activity parsing, and KML-column presence for both. Net **−163 lines**.