### PR TITLE
Convert 4 Google Takeout single-table artifacts to LAVA

### DIFF
--- a/scripts/artifacts/googleFi_UserInfoRecords.py
+++ b/scripts/artifacts/googleFi_UserInfoRecords.py
@@ -1,70 +1,62 @@
-# Module Description: Parses Google Fi user info records from Takeout
-# Author: @KevinPagano3
-# Date: 2022-02-28
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googleFi_UserInfoRecords": {
+        "name": "Google Fi - User Info Records",
+        "description": "Parses Google Fi user info records from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2022-02-28",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Google Fi/User Info*/GoogleFi.UserInfo.Records.txt'),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+    }
+}
 
 import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_googleFi_UserInfoRecords(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+def _utc_label_to_dt(value):
+    # Source values are labelled " UTC"; strip the label and parse to an aware UTC datetime.
+    value = value.replace(' UTC', '').strip()
+    if not value:
+        return value
+    try:
+        return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def googleFi_UserInfoRecords(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'GoogleFi.UserInfo.Records.txt': # skip -journal and other files
+        if os.path.basename(file_found) != 'GoogleFi.UserInfo.Records.txt':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            lines = f.readlines()[1:]
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.readlines()[1:]
-            
-        data_list = []
-        
-        for line in data:
+        for line in lines:
             entry = line.split('\t')
-            
-            user_phone = entry[0]
-            usage_type = entry[1].replace('USAGE_TYPE_','').title()
-            start_ts = entry[2].replace(' UTC','')
-            end_ts = entry[3].replace(' UTC','')
-            direction = entry[4].replace('DIRECTION_','').title()
-            duration = entry[5].replace('Duration:','')
-            user_country = entry[6]
-            remote_country = entry[7]
-            remote_phone = entry[8]
-            equipment_id = entry[9]
-            carrier = entry[10]
-            network_carrier = entry[11]
-            network_carrier_start_ts = entry[12].replace(' UTC','')
-            is_wifi = entry[13].title()
-            is_hosted_voice = entry[14].title()
-            is_hangouts = entry[15].title()
-            is_voicemail = entry[16].strip().title()
+            if len(entry) < 17:
+                continue
+            data_list.append((
+                _utc_label_to_dt(entry[2]), _utc_label_to_dt(entry[3]),
+                entry[0], entry[1].replace('USAGE_TYPE_', '').title(),
+                entry[4].replace('DIRECTION_', '').title(), entry[5].replace('Duration:', ''),
+                entry[8], entry[9], entry[10], entry[11], _utc_label_to_dt(entry[12]),
+                entry[13].title(), entry[14].title(), entry[15].title(), entry[16].strip().title()))
 
-            data_list.append((start_ts,end_ts,user_phone,usage_type,direction,duration,remote_phone,equipment_id,carrier,network_carrier,network_carrier_start_ts,is_wifi,is_hosted_voice,is_hangouts,is_voicemail))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport('Google Fi - User Info Records')
-            report.start_artifact_report(report_folder, 'Google Fi - User Info Records')
-            report.add_script()
-            data_headers = ('Start Timestamp','End Timestamp','User Phone Number','Usage Type','Direction','Duration (Minutes)','Remote Phone Number','Equipment ID','Carrier','Network Carrier','Network Carrier Start Timestamp','Is Wifi?','Is Hosted Voice?','Is Hangouts?','Is Voicemail?')
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Fi - User Info Records'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Fi - User Info Records'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Google Fi - User Info Records data available')
-
-__artifacts__ = {
-        "googleFi_UserInfoRecords": (
-            "Google Takeout Archive",
-            ('*/Google Fi/User Info*/GoogleFi.UserInfo.Records.txt'),
-            get_googleFi_UserInfoRecords)
-}
+    data_headers = (('Start Timestamp', 'datetime'), ('End Timestamp', 'datetime'),
+                    'User Phone Number', 'Usage Type', 'Direction', 'Duration (Minutes)',
+                    'Remote Phone Number', 'Equipment ID', 'Carrier', 'Network Carrier',
+                    ('Network Carrier Start Timestamp', 'datetime'), 'Is Wifi?', 'Is Hosted Voice?',
+                    'Is Hangouts?', 'Is Voicemail?')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googlePayTransactions.py
+++ b/scripts/artifacts/googlePayTransactions.py
@@ -1,66 +1,42 @@
-# Module Description: Parses Google Pay transactions from Takeout
-# Author: @KevinPagano3
-# Date: 2021-09-25
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import datetime
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_googlePayTransactions(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('transactions'):
-            data_list = []
-
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                
-                next(delimited)
-                for item in delimited:
-                    if len(item) == 0:
-                        continue
-                    else:
-                        trans_time = item[0]
-                        trans_id = item[1]
-                        description = item[2]
-                        product = item[3]
-                        payment_method = item[4]
-                        payment_status = item[5]
-                        payment_amount = item[6]
-                       
-                        data_list.append((trans_time,trans_id,description,product,payment_method,payment_status,payment_amount))
-                    
-            if data_list:
-                description = 'Purchases on Google like Play and YouTube, and purchases made using Google Pay balance.'
-                report = ArtifactHtmlReport('Google Pay - Transactions')
-                report.start_artifact_report(report_folder, 'Google Pay Transactions', description)
-                html_report = report.get_report_file_path()
-                report.add_script()
-                data_headers = ('Transaction Timestamp','Transaction ID','Description','Product','Payment Method','Payment Status','Amount')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Google Pay - Transactions'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Google Pay - Transactions'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Google Pay - Transactions data available')
-                
-__artifacts__ = {
-        "googlePayTransactions": (
-            "Google Takeout Archive",
-            ('*/Google Pay/Google transactions/transactions_*.csv'),
-            get_googlePayTransactions)
+__artifacts_v2__ = {
+    "googlePayTransactions": {
+        "name": "Google Pay Transactions",
+        "description": "Purchases on Google like Play and YouTube, and purchases made using Google Pay balance.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Transaction Timestamp is preserved as the raw source value (Takeout CSV format is locale-dependent; not normalized to UTC).",
+        "paths": ('*/Google Pay/Google transactions/transactions_*.csv'),
+        "output_types": "standard",
+        "artifact_icon": "dollar-sign",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def googlePayTransactions(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('transactions'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)
+            for item in reader:
+                if len(item) == 0:
+                    continue
+                data_list.append((item[0], item[1], item[2], item[3], item[4], item[5], item[6]))
+
+    data_headers = ('Transaction Timestamp', 'Transaction ID', 'Description', 'Product',
+                    'Payment Method', 'Payment Status', 'Amount')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/playStoreInstalls.py
+++ b/scripts/artifacts/playStoreInstalls.py
@@ -1,63 +1,59 @@
-# Module Description: Parses Google Play Store application installations from Takeout
-# Author: @KevinPagano3
-# Date: 2021-08-22
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "playStoreInstalls": {
+        "name": "Google Play Store Installs",
+        "description": "List of your Google Play app installs.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-08-22",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Google Play Store/Installs.json'),
+        "output_types": "standard",
+        "artifact_icon": "download",
+    }
+}
 
-import datetime
 import json
 import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_playStoreInstalls(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+def _iso_to_utc(value):
+    if not value:
+        return value
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00')).astimezone(timezone.utc)
+    except (ValueError, AttributeError):
+        return value
+
+
+@artifact_processor
+def playStoreInstalls(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Installs.json': # skip -journal and other files
+        if os.path.basename(file_found) != 'Installs.json':
             continue
-
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
         for x in data:
-            docType = x['install']['doc'].get('documentType','')
-            title = x['install']['doc'].get('title','')
-            firstInstallationTime = x['install'].get('firstInstallationTime','')
-            firstInstallationTime = firstInstallationTime.replace('T', ' ').replace('Z', '')
-            lastUpdateTime = x['install'].get('lastUpdateTime','')
-            lastUpdateTime = lastUpdateTime.replace('T', ' ').replace('Z', '')
-            model = x['install']['deviceAttribute'].get('model','')
-            carrier  = x['install']['deviceAttribute'].get('carrier','')
-            manufacturer = x['install']['deviceAttribute'].get('manufacturer','')
-            deviceDisplayName = x['install']['deviceAttribute'].get('deviceDisplayName','')
-            
-            data_list.append((firstInstallationTime, lastUpdateTime, title, docType, manufacturer, model, carrier, deviceDisplayName))
-    
-        num_entries = len(data_list)
-        if num_entries > 0:
-            description = 'List of your Google Play app installs.'
-            report = ArtifactHtmlReport('Google Play Store Installs')
-            report.start_artifact_report(report_folder, 'Google Play Store Installs',description)
-            report.add_script()
-            data_headers = ('First Install Timestamp','Last Update Timestamp','Title','Type','Device Manufacturer','Device Model','Carrier','Device Display Name')
+            install = x.get('install', {})
+            doc = install.get('doc', {})
+            device_attr = install.get('deviceAttribute', {})
+            data_list.append((
+                _iso_to_utc(install.get('firstInstallationTime', '')),
+                _iso_to_utc(install.get('lastUpdateTime', '')),
+                doc.get('title', ''), doc.get('documentType', ''),
+                device_attr.get('manufacturer', ''), device_attr.get('model', ''),
+                device_attr.get('carrier', ''), device_attr.get('deviceDisplayName', '')))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Play Store Installs'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Play Store Installs'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Google Play Store Installs data available')
-
-__artifacts__ = {
-        "playStoreInstalls": (
-            "Google Takeout Archive",
-            ('*/Google Play Store/Installs.json'),
-            get_playStoreInstalls)
-}
+    data_headers = (('First Install Timestamp', 'datetime'), ('Last Update Timestamp', 'datetime'),
+                    'Title', 'Type', 'Device Manufacturer', 'Device Model', 'Carrier',
+                    'Device Display Name')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/youtubeSubscriptions.py
+++ b/scripts/artifacts/youtubeSubscriptions.py
@@ -1,62 +1,41 @@
-# Module Description: Parses YouTube subscriptions from Takeout
-# Author: @KevinPagano3
-# Date: 2021-09-25
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import datetime
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_youtubeSubscriptions(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('subscriptions.csv'):
-            data_list = []
-
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                
-                next(delimited)
-                for item in delimited:
-                    if len(item) == 0:
-                        continue
-                    else:
-                        channel_id = item[0]
-                        channel_url = item[1]
-                        channel_title = item[2]
-                       
-                        data_list.append((channel_id,channel_url,channel_title))
-                    
-            if data_list:
-                description = 'User channel subscriptions for YouTube.'
-                report = ArtifactHtmlReport('YouTube Subscriptions')
-                report.start_artifact_report(report_folder, 'YouTube Subscriptions', description)
-                html_report = report.get_report_file_path()
-                report.add_script()
-                data_headers = ('Channel ID','Channel URL','Channel Title')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'YouTube Subscriptions'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'YouTube Subscriptions'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No YouTube Subscriptions data available')
-
-__artifacts__ = {
-        "youtubeSubscriptions": (
-            "Google Takeout Archive",
-            ('*/YouTube and YouTube Music/subscriptions/subscriptions.csv'),
-            get_youtubeSubscriptions)
+__artifacts_v2__ = {
+    "youtubeSubscriptions": {
+        "name": "YouTube Subscriptions",
+        "description": "User channel subscriptions for YouTube.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/YouTube and YouTube Music/subscriptions/subscriptions.csv'),
+        "output_types": "standard",
+        "artifact_icon": "youtube",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def youtubeSubscriptions(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('subscriptions.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)
+            for item in reader:
+                if len(item) == 0:
+                    continue
+                data_list.append((item[0], item[1], item[2]))
+
+    data_headers = ('Channel ID', 'Channel URL', 'Channel Title')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Third **Google Takeout Archive** batch — the clean single-table parsers (JSON/CSV/TSV).

| Artifact | Source | Notes |
|---|---|---|
| Play Store Installs | Installs.json | ISO timestamps → UTC |
| YouTube Subscriptions | subscriptions.csv | no timestamps |
| Google Pay Transactions | transactions_*.csv | raw timestamp kept (see below) |
| Google Fi User Info Records | GoogleFi.UserInfo.Records.txt | TSV; ` UTC`-labelled timestamps → UTC |

## Conventions applied (all artifact-level)
- `__artifacts__` funckey → `__artifacts_v2__`; **preserved author** (@KevinPagano3) and dates.
- Context form, `context.get_relative_path(source)`, dropped the `ArtifactHtmlReport`/tsv/timeline boilerplate and dead locals (`has_header`, `html_report`).
- **Timestamps → aware UTC** where the source format is known: Play Store (ISO-8601 via `fromisoformat`), Google Fi (` UTC`-labelled, parsed + tagged UTC). Both verified by functional test.

## Two deliberate, verified judgment calls
- **Google Pay `Transaction Timestamp` kept as the raw source string.** The Takeout CSV timestamp format is locale-dependent; typing it `datetime` risks mislabeling a local time as UTC. Preserved faithfully + noted in the artifact `notes`. If you can confirm the format, I'll normalize it.
- **Google Fi phone columns kept as plain text** — RLEAPP's LAVA framework has **no `phonenumber` column type** (verified by grepping `lavafuncs`/`ilapfuncs`; nothing uses it), unlike ALEAPP/iLEAPP.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + duplicate-column audit clean (4 tables); **PluginLoader loads all (203)**; **synthetic-data functional test** asserting aware-UTC datetimes + field parsing for Play Store and Google Fi. Net **−57 lines**.