### PR TITLE
Convert Google Profile + Google Chat (Takeout) to LAVA (check_in_media)

### DIFF
--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -1,168 +1,107 @@
-# Module Description: Parses Google Chat messages from Takeout
-# Author: @KevinPagano3 & John Hyla {jfhyla@gmail.com}
-# Date: 2022-03-08
-# Updated: 2022-08-01 (Added Group Members to data)
-# Artifact version: 0.0.2
-# Requirements: none
+__artifacts_v2__ = {
+    "googleChat": {
+        "name": "Google Chat - Messages",
+        "description": "Parses Google Chat messages from Takeout",
+        "author": "@KevinPagano3 & John Hyla {jfhyla@gmail.com}",
+        "creation_date": "2022-03-08",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Google Chat/Groups/*/**',),
+        "output_types": "standard",
+        "html_columns": ["Group Members"],
+        "artifact_icon": "message-square",
+    }
+}
 
-import datetime
 import json
 import os
-
+from datetime import datetime, timezone
 from pathlib import Path
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
 
-def get_googleChat(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    data_list_tsv = []
-    monthDict={'January':1, 
-           'February':2,
-           'March':3,
-           'April':4,
-           'May':5,
-           'June':6,
-           'July':7,
-           'August':8,
-           'September':9,
-           'October':10,
-           'November':11,
-           'December':12}
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if not os.path.basename(file_found) == 'messages.json': # skip -journal and other files
-            continue
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        
-        group_info_file = os.path.dirname(file_found) + os.path.sep + 'group_info.json'
-        if Path(group_info_file).is_file():
-            with open(group_info_file, encoding = 'utf-8', mode = 'r') as fg:
-                group_data = json.loads(fg.read())
-            
-            members = []
-            for member in group_data["members"]:
-                members.append(member.get('name', '') + ' - ' + member.get('email',''))
-                
-            members_html = '<br>'.join(members)
-            members_tsv = '\n'.join(members)
+_MONTHS = {'January': 1, 'February': 2, 'March': 3, 'April': 4, 'May': 5, 'June': 6,
+           'July': 7, 'August': 8, 'September': 9, 'October': 10, 'November': 11, 'December': 12}
+
+
+def _parse_gchat_date(value):
+    # Two Google formats, both UTC:
+    #   "Tuesday, 7 February 2021 at 17:13:43 UTC"      (24h, no AM/PM)
+    #   "Wednesday, January 4, 2023 at 10:59:50 AM UTC" (12h with AM/PM)
+    value = value.strip()
+    try:
+        parts = value.split(', ')
+        if len(parts) == 3:
+            month_name, day = parts[1].split(' ')[0], parts[1].split(' ')[1]
+            tail = parts[2].split(' ')
+            year, time_token = tail[0], tail[2]
+            ampm = tail[3] if len(tail) > 3 else ''
+        elif len(parts) == 2:
+            left, right = parts[1].split(' at ')
+            day, month_name, year = left.split(' ')[0], left.split(' ')[1], left.split(' ')[2]
+            rtok = right.split(' ')
+            time_token = rtok[0]
+            ampm = rtok[1] if len(rtok) > 1 and rtok[1] in ('AM', 'PM') else ''
         else:
-            members_html = ''
-            members_tsv = ''
-        
-        for chat_message in data['messages']:
-            month = ''
-            #Possible to have deleted messages. created_date, creator doesn't exists for this messages.
-            #example: {"message_state": "DELETED", 
-            #          "deleted_date": "Wednesday, 4 January 2023 at 10:59:50 UTC", 
-            #          "topic_id": "0o-KXA8ap5g,
-            #          "deletion_metadata": {"deletion_type": "CREATOR"}
-            #         }
-            created_date = chat_message.get('created_date','')
-            deleted_date = chat_message.get('deleted_date','')
-            if created_date == '' and deleted_date == '':
+            return value
+        hour, minute, second = (int(x) for x in time_token.split(':'))
+        if ampm == 'PM' and hour < 12:
+            hour += 12
+        elif ampm == 'AM' and hour == 12:
+            hour = 0
+        return datetime(int(year), _MONTHS[month_name], int(day), hour, minute, second,
+                        tzinfo=timezone.utc)
+    except (ValueError, KeyError, IndexError):
+        return value
+
+
+@artifact_processor
+def googleChat(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'messages.json':
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
+
+        members = []
+        group_info_file = os.path.join(os.path.dirname(file_found), 'group_info.json')
+        if Path(group_info_file).is_file():
+            with open(group_info_file, encoding='utf-8') as fg:
+                group_data = json.load(fg)
+            for member in group_data.get('members', []):
+                members.append(member.get('name', '') + ' - ' + member.get('email', ''))
+        members_html = '<br>'.join(members)
+
+        for chat_message in data.get('messages', []):
+            created_date = chat_message.get('created_date', '')
+            deleted_date = chat_message.get('deleted_date', '')
+            date_str = created_date or deleted_date
+            if not date_str:
                 continue
+            creator = chat_message.get('creator', {})
+            sender_name = creator.get('name', '') if created_date else 'deleted'
+            sender_email = creator.get('email', '')
+            sender_user_type = creator.get('user_type', '')
+            created_dt = _parse_gchat_date(date_str)
+            message_text = chat_message.get('text', '')
 
-            if created_date == '':
-                created_data = deleted_date;
-                chat_message['creator']={}
-                chat_message['creator']['name']='deleted'
+            attachments = []
+            for att in chat_message.get('attached_files', []):
+                export_name = att.get('export_name', '')
+                if export_name:
+                    ref = check_in_media(export_name, export_name)
+                    if ref:
+                        attachments.append(ref)
 
-            sender_name = chat_message['creator'].get('name','')
-            sender_email = chat_message['creator'].get('email','')
-            sender_user_type = chat_message['creator'].get('user_type','')
-            
-            #checks for empty date field
-            created_date_split = created_date.split(', ')
-            if len(created_date_split)==3:
-                created_month = str(created_date_split[1].split(' ')[0])
-                created_day = created_date_split[1].split(' ')[1]
-                created_year = created_date_split[2].split(' ')[0]
-                created_time = created_date_split[2].split(' ')[2]
-                time_flag = str(created_date_split[2].split(' ')[3])
-            else: 
-                if (len (created_date_split))==2:
-                    #Example: Tuesday, 7 February 2021 at 17:13:43 UTC
-                    #Probably other formats are exposed by Google. Need to transform all dates,
-                    #in a standard format.
-                    created_date_split2 = created_date_split[1].split(' at ')
-                    created_month = str(created_date_split2[0].split(' ')[1])
-                    created_day = created_date_split2[0].split(' ')[0]
-                    created_year = created_date_split2[0].split(' ')[2]
-                    created_time = created_date_split2[1]
-                    time_flag = ""
-                    
-            time_hour = created_time.split(':')[0]
-            time_minute = created_time.split(':')[1]
-            time_second = created_time.split(':')[2]
-            
-            if time_flag == 'PM' and int(time_hour) < 12:
-                time_hour = str(int(time_hour) + 12)
-            else: time_hour = str(time_hour)
-            
-            if time_flag == 'AM' and int(time_hour) == 12:
-                time_hour = '00'
+            data_list.append((created_dt, sender_name, sender_email, sender_user_type,
+                              members_html, message_text, attachments))
 
-            if len(time_hour) < 2:
-                time_hour = '0' + time_hour
-            
-            if created_month in monthDict.keys():
-                month = str(monthDict[created_month])
-            
-            if len(month) < 2:
-                month = '0' + month
-            
-            if len(created_day) < 2:
-                created_day = '0' + created_day
-            
-            datestamp = created_year + '-' + month + '-' + created_day
-            timestamp = time_hour + ':' + time_minute + ':' + time_second
-            
-            datetime_stamp = datestamp + ' ' + timestamp
-            
-            message_text = chat_message.get('text','')
-            message_text_tsv = chat_message.get('text','').encode("ascii", errors="backslashreplace")
-            message_text_tsv = message_text_tsv.decode('ascii')
-            message_text_tsv = message_text_tsv.replace(u'\xa0',u' ')    
-            
-            if 'attached_files' in chat_message:
-                if len(chat_message['attached_files']) == 0:
-                    attachments = '' 
-                else:
-                    attachments = chat_message['attached_files'][0].get('export_name','')
-                    attachments = media_to_html(attachments, files_found, report_folder)
-            else: 
-                attachments = ''
-            data_list.append((datetime_stamp,sender_name,sender_email,sender_user_type,members_html,message_text,attachments))
-            data_list_tsv.append((datetime_stamp,sender_name,sender_email,sender_user_type,members_tsv,message_text_tsv,attachments,))
-    
-    
-    directory = os.path.dirname(file_found)
-    num_entries = len(data_list)
-    if num_entries > 0:
-        report = ArtifactHtmlReport('Google Chat - Messages')
-        report.start_artifact_report(report_folder, 'Google Chat - Messages')
-        report.add_script()
-        data_headers = ('Created Timestamp','Sender Name','Sender Email','Sender Type','Group Members','Message','Attachment')
-
-        report.write_artifact_data_table(data_headers, data_list, directory, html_no_escape=['Group Members','Attachment'])
-        report.end_artifact_report()
-        
-        tsvname = f'Google Chat - Messages'
-        tsv(report_folder, data_headers, data_list_tsv, tsvname)
-        
-        tlactivity = f'Google Chat - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Google Chat - Messages data available')
-
-__artifacts__ = {
-        "googleChat": (
-            "Google Takeout Archive",
-            ('*/Google Chat/Groups/*/**'),
-            get_googleChat)
-}
+    data_headers = (('Created Timestamp', 'datetime'), 'Sender Name', 'Sender Email', 'Sender Type',
+                    'Group Members', 'Message', ('Attachment', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleProfile.py
+++ b/scripts/artifacts/googleProfile.py
@@ -1,77 +1,51 @@
-# Module Description: Parses Google profile information from Takeout
-# Author: @KevinPagano3
-# Date: 2021-08-23
-# Artifact version: 0.0.2
-# Requirements: none
+__artifacts_v2__ = {
+    "googleProfile": {
+        "name": "Google Profile",
+        "description": "Parses Google profile information from Takeout",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-08-23",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Profile/Profile.json', '*/Profile/ProfilePhoto.jpg'),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
+}
 
-import datetime
 import json
 import os
-import shutil
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
-def get_googleProfile(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googleProfile(context):
+    data_list = []
+    source_path = ''
+    files_found = context.get_files_found()
+
+    photo_ref = None
+    for file_found in files_found:
+        if os.path.basename(str(file_found)) == 'ProfilePhoto.jpg':
+            photo_ref = check_in_media(str(file_found), 'ProfilePhoto.jpg')
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Profile.json': # skip -journal and other files
+        if os.path.basename(file_found) != 'Profile.json':
             continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
 
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = json.loads(f.read())
-        data_list = []
-        emails = []
-        addresses = ''
-        gender=''
-        formattedName = data['name'].get('formattedName','')
-        displayName = data.get('displayName','')
-        birthday = data.get('birthday','')
-        _gender = data.get('gender','')
-        if (_gender):
-            gender = _gender.get('type','')
+        name = data.get('name', {}).get('formattedName', '')
+        display_name = data.get('displayName', '')
+        birthday = data.get('birthday', '')
+        gender = data.get('gender', {}).get('type', '') if data.get('gender') else ''
+        emails = '; '.join(e.get('value', '') for e in data.get('emails', []))
+        data_list.append((name, display_name, emails, birthday, gender, photo_ref))
 
-        if len(data['emails'])>0:
-            for x in data['emails']:
-                emails.append((x['value']))
-
-            for y in emails:
-                addresses += str(y) + "; "
-            addresses = addresses[:-2]
-        
-    thumb = ''
-    ProfilePhoto = 'ProfilePhoto.jpg'
-            
-    for match in files_found:
-        if ProfilePhoto in match:
-            shutil.copy2(match, report_folder)
-            thumb = media_to_html(match, files_found, report_folder)
-            #thumb = f'<img src="{report_folder}/{ProfilePhoto}" width="300"></img>'
-    
-    data_list.append((formattedName, displayName, addresses, birthday, gender, thumb))
-
-    num_entries = len(data_list)
-    if num_entries > 0:
-        report = ArtifactHtmlReport('Google Profile')
-        report.start_artifact_report(report_folder, 'Google Profile')
-        report.add_script()
-        data_headers = ('Name','Display Name','Email Address(s)','Birthday','Gender','Profile Pic')
-
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Profile Pic'])
-        report.end_artifact_report()
-        
-        tsvname = f'Google Profile'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Profile'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Google Profile data available')
- 
-__artifacts__ = {
-        "googleProfile": (
-            "Google Takeout Archive",
-            (('*/Profile/Profile.json','*/Profile/ProfilePhoto.jpg')),
-            get_googleProfile)
-}
+    data_headers = ('Name', 'Display Name', 'Email Address(s)', 'Birthday', 'Gender',
+                    ('Profile Pic', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Fourth **Google Takeout Archive** batch — the two JSON-based **media** artifacts, converted with `check_in_media`.

| Artifact | Media | Timestamps |
|---|---|---|
| Google Profile | ProfilePhoto.jpg | — |
| Google Chat | message attachments | custom Google date strings → UTC |

## Conventions applied (all artifact-level)
- `__artifacts__` funckey → `__artifacts_v2__`; **preserved authors** (@KevinPagano3; & John Hyla) and dates.
- Context form, `context.get_relative_path(source)`, dropped boilerplate + the duplicate html/tsv data lists + the `shutil` copy.
- **`media_to_html` → `check_in_media`** (typed `('Col','media')`): Profile resolves the matched `ProfilePhoto.jpg`; Chat checks in **all** `attached_files` as a media **list** (the original kept only the first).
- **Google Chat dates → UTC**: both Google formats parsed — 24h (`... at 17:13:43 UTC`) and 12h (`... at 10:59:50 AM/PM UTC`) — to aware UTC datetimes, with a safe fallback to the raw string on any unrecognized format.
- Group members kept as a `<br>`-joined cell via `html_columns`.

## 🐞 Bug fix
**Deleted Google Chat messages would crash the original**: when `created_date` is empty (only `deleted_date` present), it fell through to parsing the empty `created_date`, leaving date variables unset → exception. Now the `deleted_date` is used and the sender is labelled `deleted`. Verified by the functional test (row: `2023-01-09 08:00:00 UTC`, sender `deleted`).

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + dup-column audit clean; **PluginLoader loads all (203)**; **synthetic-data functional test** asserting UTC datetimes (24h/AM/PM), the deleted-message path, member/email joining, and media-column detection for both. Net **−87 lines**.