### PR TITLE
Convert Saved Links (Takeout) to LAVA: 4 lists -> 4 artifacts

### DIFF
--- a/scripts/artifacts/takeoutSavedLinks.py
+++ b/scripts/artifacts/takeoutSavedLinks.py
@@ -1,167 +1,99 @@
-import os
-import datetime
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_takeoutSavedLinks(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('Default list.csv'):
-            data_list = []
-
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                
-                next(delimited)
-                for item in delimited:
-                    if len(item) == 0:
-                        continue
-                    else:
-                        title = item[0]
-                        note = item[1]
-                        url = item[2]
-                        comment = item[3]
-                       
-                        data_list.append((title,note,url,comment))
-                    
-            if data_list:
-                description = 'Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.'
-                report = ArtifactHtmlReport('Saved Links - Default List')
-                report.start_artifact_report(report_folder, 'Saved Links - Default List', description)
-                html_report = report.get_report_file_path()
-                report.add_script()
-                data_headers = ('Title','Note','URL','Comment')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Saved Links - Default List'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Saved Links - Default List'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Saved Links - Default List data available')
-                
-        if filename.startswith('Favorite images.csv'):
-            data_list = []
-
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                
-                next(delimited)
-                for item in delimited:
-                    if len(item) == 0:
-                        continue
-                    else:
-                        title = item[0]
-                        note = item[1]
-                        url = item[2]
-                        comment = item[3]
-                       
-                        data_list.append((title,note,url,comment))
-                    
-            if data_list:
-                description = 'Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.'
-                report = ArtifactHtmlReport('Saved Links - Favorite Images')
-                report.start_artifact_report(report_folder, 'Saved Links - Favorite Images', description)
-                html_report = report.get_report_file_path()
-                report.add_script()
-                data_headers = ('Title','Note','URL','Comment')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Saved Links - Favorite Images'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Saved Links - Favorite Images'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Saved Links - Favorite Images data available')
-                
-        if filename.startswith('Favorite pages.csv'):
-            data_list = []
-
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                
-                next(delimited)
-                for item in delimited:
-                    if len(item) == 0:
-                        continue
-                    else:
-                        title = item[0]
-                        note = item[1]
-                        url = item[2]
-                        comment = item[3]
-                       
-                        data_list.append((title,note,url,comment))
-                    
-            if data_list:
-                description = 'Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.'
-                report = ArtifactHtmlReport('Saved Links - Favorite Pages')
-                report.start_artifact_report(report_folder, 'Saved Links - Favorite Pages', description)
-                report.add_script()
-                data_headers = ('Title','Note','URL','Comment')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Saved Links - Favorite Pages'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Saved Links - Favorite Pages'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Saved Links - Favorite Pages data available')
-                
-        if filename.startswith('Want to go.csv'):
-            data_list = []
-
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                
-                next(delimited)
-                for item in delimited:
-                    if len(item) == 0:
-                        continue
-                    else:
-                        title = item[0]
-                        note = item[1]
-                        url = item[2]
-                        comment = item[3]
-                       
-                        data_list.append((title,note,url,comment))
-                    
-            if data_list:
-                description = 'Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.'
-                report = ArtifactHtmlReport('Saved Links - Want To Go')
-                report.start_artifact_report(report_folder, 'Saved Links - Want To Go', description)
-                html_report = report.get_report_file_path()
-                report.add_script()
-                data_headers = ('Title','Note','URL','Comment')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Saved Links - Want To Go'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Saved Links - Want To Go'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Saved Links - Want To Go data available')
-
-__artifacts__ = {
-        "takeoutSavedLinks": (
-            "Google Takeout Archive",
-            ('*/Saved/*.csv'),
-            get_takeoutSavedLinks)
+__artifacts_v2__ = {
+    "takeoutSavedLinksDefault": {
+        "name": "Saved Links - Default List",
+        "description": "Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Saved/Default list.csv',),
+        "output_types": "standard",
+        "artifact_icon": "link",
+    },
+    "takeoutSavedLinksFavImages": {
+        "name": "Saved Links - Favorite Images",
+        "description": "Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Saved/Favorite images.csv',),
+        "output_types": "standard",
+        "artifact_icon": "link",
+    },
+    "takeoutSavedLinksFavPages": {
+        "name": "Saved Links - Favorite Pages",
+        "description": "Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Saved/Favorite pages.csv',),
+        "output_types": "standard",
+        "artifact_icon": "link",
+    },
+    "takeoutSavedLinksWantToGo": {
+        "name": "Saved Links - Want To Go",
+        "description": "Collections of saved links (images, places, web pages, etc.) from Google Search and Maps.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Saved/Want to go.csv',),
+        "output_types": "standard",
+        "artifact_icon": "link",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+
+
+def _parse_saved_links(context, basename_match):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith(basename_match):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)
+            for item in reader:
+                if len(item) < 4:
+                    continue
+                data_list.append((item[0], item[1], item[2], item[3]))
+
+    data_headers = ('Title', 'Note', 'URL', 'Comment')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def takeoutSavedLinksDefault(context):
+    return _parse_saved_links(context, 'Default list.csv')
+
+
+@artifact_processor
+def takeoutSavedLinksFavImages(context):
+    return _parse_saved_links(context, 'Favorite images.csv')
+
+
+@artifact_processor
+def takeoutSavedLinksFavPages(context):
+    return _parse_saved_links(context, 'Favorite pages.csv')
+
+
+@artifact_processor
+def takeoutSavedLinksWantToGo(context):
+    return _parse_saved_links(context, 'Want to go.csv')


### PR DESCRIPTION
Fifth **Google Takeout Archive** batch — Saved Links.

The legacy `takeoutSavedLinks` emitted **four** separate `ArtifactHtmlReport`s from one function (Default List, Favorite Images, Favorite Pages, Want To Go), all with identical columns. LAVA is one-table-per-artifact, so this splits into **four `@artifact_processor` artifacts** sharing a parser helper:

`takeoutSavedLinksDefault` · `takeoutSavedLinksFavImages` · `takeoutSavedLinksFavPages` · `takeoutSavedLinksWantToGo`

## Conventions applied (all artifact-level)
- `__artifacts__` funckey → `__artifacts_v2__`; attributed to **@KevinPagano3** (git author `stark4n6`); date preserved.
- Each artifact gets its **own precise path glob** (`*/Saved/<list>.csv`) so it only runs when its CSV exists; Context form; `context.get_relative_path(source)`; dropped the boilerplate and dead locals (`has_header`, `html_report`).
- No timestamps/media; columns `Title/Note/URL/Comment` (none reserved).
- Loader **203 → 206** (one legacy plugin → four).

## Judgment call
Kept the four lists as **separate artifacts** (faithful to the original's four reports). The alternative is one combined table with a `Collection` discriminator column — cleaner but a structural change. Happy to consolidate if you'd prefer that.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + dup-column audit clean; **PluginLoader** (4 new keys present, old `takeoutSavedLinks` key gone, total 206); **synthetic-data functional test** confirming each artifact reads only its own CSV.