### PR TITLE
Convert Semantic Location History (Takeout) to LAVA: 2 tables -> 2 artifacts

### DIFF
--- a/scripts/artifacts/takeoutSemanticLocationHistory.py
+++ b/scripts/artifacts/takeoutSemanticLocationHistory.py
@@ -1,189 +1,121 @@
-# Module Description: Parses Google Takeout Semantic Location History .json files
-# Author: @KevinPagano3
-# Date: 2022-09-15
-# Artifact version: 0.0.1
+__artifacts_v2__ = {
+    "takeoutSemanticPlaceVisits": {
+        "name": "Google Semantic Location History - Place Visits",
+        "description": "Parses placeVisit entries from Google Takeout Semantic Location History JSON files",
+        "author": "@KevinPagano3",
+        "creation_date": "2022-09-15",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Semantic Location History/*/*.json',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    },
+    "takeoutSemanticActivitySegments": {
+        "name": "Google Semantic Location History - Activity Segments",
+        "description": "Parses activitySegment entries from Google Takeout Semantic Location History JSON files",
+        "author": "@KevinPagano3",
+        "creation_date": "2022-09-15",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Start/End coordinates are separate columns; the framework auto-KML (which needs exact Latitude/Longitude columns) is not emitted for this table.",
+        "paths": ('*/Semantic Location History/*/*.json',),
+        "output_types": "standard",
+        "artifact_icon": "navigation",
+    }
+}
 
-import datetime
 import json
 import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, kmlgen
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_takeoutSemanticLocationHistory(files_found, report_folder, seeker, wrap_text):
-    
-    data_list_visits = []
-    data_list_segments = []
-    data_list_segments_kml = []
-    timestamp_hit = 'T'
-    count_activity = 0
-    count_multiple_activitys = 0
-    
-    for file_found in files_found:
+
+def _iso_to_utc(value):
+    if not value:
+        return value
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00')).astimezone(timezone.utc)
+    except (ValueError, AttributeError):
+        return value
+
+
+def _duration_ts(duration, base):
+    # Old archives use '<base>TimestampMs' (ms epoch); new ones use '<base>Timestamp' (ISO).
+    ms_value = duration.get(f'{base}TimestampMs')
+    if ms_value:
+        return convert_unix_ts_to_utc(ms_value)
+    return _iso_to_utc(duration.get(f'{base}Timestamp', ''))
+
+
+@artifact_processor
+def takeoutSemanticPlaceVisits(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
+        if not file_found.endswith('.json'):
+            continue
+        source_path = file_found
         file_name = os.path.basename(file_found)
-        
-        if file_name.endswith('.json'):
-            with open(file_found, 'r', encoding='utf-8-sig') as f:
-                data = json.loads(f.read())
+        with open(file_found, encoding='utf-8-sig') as f:
+            data = json.load(f)
 
-                for element in data['timelineObjects']:
-                    if 'placeVisit' in element:
-                        visit_lat = float(element['placeVisit']['location'].get('latitudeE7','0')/10000000)
-                        visit_long = float(element['placeVisit']['location'].get('longitudeE7','0')/10000000)
-                        visit_placeID = element['placeVisit']['location'].get('placeId','')
-                        visit_address = element['placeVisit']['location'].get('address','')
-                        visit_name = element['placeVisit']['location'].get('name','')
-                        visit_locationConfidence = element['placeVisit']['location'].get('locationConfidence','')
-                        
-                        #Check placeVisit start timestamps for old format
-                        if 'startTimestampMs' in element['placeVisit']['duration']:
-                            visit_start_TS = element['placeVisit']['duration'].get('startTimestampMs','')
-                            if visit_start_TS != '':
-                                if timestamp_hit in visit_start_TS:
-                                    continue
-                                else:
-                                    visit_start_TS = datetime.datetime.utcfromtimestamp(int(visit_start_TS)/1000).strftime('%Y-%m-%d %H:%M:%S')
-                            else:
-                                visit_start_TS = ''
-                        
-                        #Check placeVisit start timestamp for new format
-                        elif 'startTimestamp' in element['placeVisit']['duration']:
-                            visit_start_TS = element['placeVisit']['duration'].get('startTimestamp','')
-                            visit_start_TS = visit_start_TS.replace('T', ' ').replace('Z', '')
-                        
-                        #Check placeVisit end timestamp for old format
-                        if 'endTimestampMs' in element['placeVisit']['duration']:
-                            visit_end_TS = element['placeVisit']['duration'].get('endTimestampMs','')
-                            if visit_end_TS != '':
-                                if timestamp_hit in visit_end_TS:
-                                    continue
-                                else:
-                                    visit_end_TS = datetime.datetime.utcfromtimestamp(int(visit_end_TS)/1000).strftime('%Y-%m-%d %H:%M:%S')
-                            else:
-                                visit_end_TS = ''
-                        
-                        #Check placeVisit end timestamp for new format
-                        elif 'endTimestamp' in element['placeVisit']['duration']:
-                            visit_end_TS = element['placeVisit']['duration'].get('endTimestamp','')
-                            visit_end_TS = visit_end_TS.replace('T', ' ').replace('Z', '')
-                        
-                        data_list_visits.append((visit_start_TS,visit_end_TS,visit_name,visit_address,visit_lat,visit_long,visit_placeID,file_name))
-                        
-                    if 'activitySegment' in element:
-                        segment_start_lat = 'NOT_SPECIFIED'
-                        segment_start_long = 'NOT_SPECIFIED'
-                        
-                        if 'startLocation' in element['activitySegment']:
-                            segment_start_lat = float(element['activitySegment']['startLocation'].get('latitudeE7','0'))/10000000
-                            segment_start_long = float(element['activitySegment']['startLocation'].get('longitudeE7','0'))/10000000
-                            
-                        segment_end_lat = 'NOT_SPECIFIED'
-                        segment_end_long = 'NOT_SPECIFIED'
-                        if 'endLocation' in element['activitySegment']:
-                            segment_end_lat = float(element['activitySegment']['endLocation'].get('latitudeE7','0'))/10000000
-                            segment_end_long = float(element['activitySegment']['endLocation'].get('longitudeE7','0'))/10000000
-                        
-                        #Check activitySegment start timestamp for old format
-                        if 'startTimestampMs' in element['activitySegment']['duration']:
-                            segment_start_TS = element['activitySegment']['duration'].get('startTimestampMs','')
-                            if segment_start_TS != '':
-                                if timestamp_hit in segment_start_TS:
-                                    continue
-                                else:
-                                    segment_start_TS = datetime.datetime.utcfromtimestamp(int(segment_start_TS)/1000).strftime('%Y-%m-%d %H:%M:%S')
-                            else:
-                                segment_start_TS = ''
-                        
-                        #Check activitySegment start timestamp for new format
-                        elif 'startTimestamp' in element['activitySegment']['duration']:
-                            segment_start_TS = element['activitySegment']['duration'].get('startTimestamp','')
-                            segment_start_TS = segment_start_TS.replace('T', ' ').replace('Z', '')
-                        
-                        #Check activitySegment end timestamp for old format
-                        if 'endTimestampMs' in element['activitySegment']['duration']:
-                            segment_end_TS = element['activitySegment']['duration'].get('endTimestampMs','')
-                            if segment_end_TS != '':
-                                if timestamp_hit in segment_end_TS:
-                                    continue
-                                else:
-                                    segment_end_TS = datetime.datetime.utcfromtimestamp(int(segment_end_TS)/1000).strftime('%Y-%m-%d %H:%M:%S')
-                            else:
-                                segment_end_TS = ''
-                        
-                        #Check activitySegment end timestamp for new format
-                        elif 'endTimestamp' in element['activitySegment']['duration']:
-                            segment_end_TS = element['activitySegment']['duration'].get('endTimestamp','')
-                            segment_end_TS = segment_end_TS.replace('T', ' ').replace('Z', '')
-                            
-                        segment_activity_type = element['activitySegment'].get('activityType','')
-                        segment_confidence = element['activitySegment'].get('confidence','')
-                        segment_distance = element['activitySegment'].get('distance','')
-                        
-                        if "activities" in element['activitySegment']: # parent activity list
-                            count_activity += 1
+        for element in data.get('timelineObjects', []):
+            if 'placeVisit' not in element:
+                continue
+            pv = element['placeVisit']
+            location = pv.get('location', {})
+            lat = location.get('latitudeE7', 0) / 1e7
+            lon = location.get('longitudeE7', 0) / 1e7
+            duration = pv.get('duration', {})
+            data_list.append((_duration_ts(duration, 'start'), _duration_ts(duration, 'end'),
+                              location.get('name', ''), location.get('address', ''), lat, lon,
+                              location.get('placeId', ''), file_name))
 
-                            if (len(element['activitySegment']["activities"]) > 1):
-                                count_multiple_activitys += 1 
+    data_headers = (('Visit Start Timestamp', 'datetime'), ('Visit End Timestamp', 'datetime'),
+                    'Name', 'Address', 'Latitude', 'Longitude', 'PlaceID', 'File Name')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
-                            count_child = 0
-                            subactivity_str = ''
-                            for activity in element['activitySegment']['activities']:
-                                count_child += 1
-                                subactivity_str += str(activity["activityType"] + " [" + str(activity["probability"]) + "], ")
-                        
-                        data_list_segments_kml.append((segment_start_TS,segment_start_lat,segment_start_long))
-                        data_list_segments_kml.append((segment_end_TS,segment_end_lat,segment_end_long))
-                        
-                        data_list_segments.append((segment_start_TS,segment_end_TS,segment_start_lat,segment_start_long,segment_end_lat,segment_end_long,segment_activity_type,segment_distance,segment_confidence,subactivity_str[:-2],file_name))
 
-    if len(data_list_visits) > 0:
-        report = ArtifactHtmlReport('Google Semantic Location History - Place Visits')
-        report.start_artifact_report(report_folder, 'Google Semantic Location History - Place Visits')
-        report.add_script()
-        data_headers = ('Visit Start Timestamp','Visit End Timestamp','Name','Address','Latitude','Longitude','PlaceID','File Name')
+@artifact_processor
+def takeoutSemanticActivitySegments(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.json'):
+            continue
+        source_path = file_found
+        file_name = os.path.basename(file_found)
+        with open(file_found, encoding='utf-8-sig') as f:
+            data = json.load(f)
 
-        report.write_artifact_data_table(data_headers, data_list_visits, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Semantic Location History - Place Visits'
-        tsv(report_folder, data_headers, data_list_visits, tsvname)
-        
-        tlactivity = f'Google Semantic Location History - Place Visits'
-        timeline(report_folder, tlactivity, data_list_visits, data_headers)
-        
-        data_headers_kml = ('Timestamp','Visit End Timestamp','Name','Address','Latitude','Longitude','PlaceID','File Name')
-        kmlactivity = 'Google Semantic Location History - Place Visits'
-        kmlgen(report_folder, kmlactivity, data_list_visits, data_headers_kml)            
-        
-    else:
-        logfunc('No Google Location History - Place Visits data available')
-        
-    if len(data_list_segments) > 0:
-        report = ArtifactHtmlReport('Google Semantic Location History - Activity Segments')
-        report.start_artifact_report(report_folder, 'Google Semantic Location History - Activity Segments')
-        report.add_script()
-        data_headers = ('Activity Start Timestamp','Activity End Timestamp','Start Latitude','Start Longitude','End Latitude','End Longitude','Activity Type','Distance (Meters)','Confidence','Activities','File Name')
+        for element in data.get('timelineObjects', []):
+            if 'activitySegment' not in element:
+                continue
+            seg = element['activitySegment']
+            start_lat = start_lon = 'NOT_SPECIFIED'
+            if 'startLocation' in seg:
+                start_lat = seg['startLocation'].get('latitudeE7', 0) / 1e7
+                start_lon = seg['startLocation'].get('longitudeE7', 0) / 1e7
+            end_lat = end_lon = 'NOT_SPECIFIED'
+            if 'endLocation' in seg:
+                end_lat = seg['endLocation'].get('latitudeE7', 0) / 1e7
+                end_lon = seg['endLocation'].get('longitudeE7', 0) / 1e7
+            duration = seg.get('duration', {})
+            subactivity_str = ''
+            for activity in seg.get('activities', []):
+                subactivity_str += f"{activity['activityType']} [{activity['probability']}], "
+            data_list.append((_duration_ts(duration, 'start'), _duration_ts(duration, 'end'),
+                              start_lat, start_lon, end_lat, end_lon, seg.get('activityType', ''),
+                              seg.get('distance', ''), seg.get('confidence', ''),
+                              subactivity_str[:-2], file_name))
 
-        report.write_artifact_data_table(data_headers, data_list_segments, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Semantic Location History - Activity Segments'
-        tsv(report_folder, data_headers, data_list_segments, tsvname)
-        
-        tlactivity = f'Google Semantic Location History - Activity Segments'
-        timeline(report_folder, tlactivity, data_list_segments, data_headers)
-        
-        data_headers_segments_kml = ('Timestamp','Latitude','Longitude')
-        kmlactivity = 'Google Location History - Activity Segments'
-        kmlgen(report_folder, kmlactivity, data_list_segments_kml, data_headers_segments_kml)            
-        
-    else:
-        logfunc('No Google Semantic Location History - Activity Segments data available')
-
-__artifacts__ = {
-        'takeoutSemanticLocationHistory': (
-            'Google Takeout Archive',
-            ('*/Semantic Location History/*/*.json'),
-            get_takeoutSemanticLocationHistory)
-}
+    data_headers = (('Activity Start Timestamp', 'datetime'), ('Activity End Timestamp', 'datetime'),
+                    'Start Latitude', 'Start Longitude', 'End Latitude', 'End Longitude',
+                    'Activity Type', 'Distance (Meters)', 'Confidence', 'Activities', 'File Name')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Sixth **Google Takeout Archive** batch — Semantic Location History.

The legacy `takeoutSemanticLocationHistory` emitted two reports (Place Visits + Activity Segments) from one function → split into two `@artifact_processor` artifacts sharing parse helpers: `takeoutSemanticPlaceVisits`, `takeoutSemanticActivitySegments`.

## Conventions applied (all artifact-level)
- `__artifacts__` funckey → `__artifacts_v2__`; preserved author (@KevinPagano3) and date.
- Context form, `context.get_relative_path(source)`, dropped boilerplate.
- **Timestamps → aware UTC**, handling **both archive formats**: old `<base>TimestampMs` (ms epoch → `convert_unix_ts_to_utc`) and new `<base>Timestamp` (ISO-8601 → `fromisoformat`). Verified by functional test.
- **Place Visits: KML enabled** (`Latitude`/`Longitude` columns).
- Loader **206 → 207** (one legacy plugin → two).

## KML note (flagged)
The original built a *separate* start/end point list to KML the activity segments. The framework auto-KML only runs on a table's own `Latitude`/`Longitude` columns, and Activity Segments keeps **Start/End** Latitude/Longitude as distinct columns — so that segment-endpoint KML is **not auto-emitted** (the coordinates remain in the table). Noted in the artifact `notes`; I can add a dedicated points artifact if you want that KML back.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + dup-column audit clean (2 tables); **PluginLoader** (2 new keys, old key gone, total 207); **synthetic-data functional test** (ISO + ms timestamps → UTC, lat/lon, activity string, KML-column presence).