### PR TITLE
Convert Access Log Activity (Takeout) to LAVA: 2 tables -> 2 artifacts

### DIFF
--- a/scripts/artifacts/takeoutAccessLogActivity.py
+++ b/scripts/artifacts/takeoutAccessLogActivity.py
@@ -1,159 +1,118 @@
-# Module Description: Parses Google services accessed by your device from Takeout
-# Author: @KevinPagano3
-# Date: 2021-09-25
-# Changelog: 2023-09-25 - Add support for new versioning (headers) of files
-# Artifact version: 0.0.3
-# Requirements: none
-
-import os
-import datetime
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, ipgen
-
-def get_takeoutAccessLogActivity(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('Activities - A list of Google services accessed by.csv'):
-            data_list = []
-            ipaddress_list = []
-            description = 'A list of Google services accessed by your devices (for example every time your phone synchronizes with your Gmail)'
-            report = ArtifactHtmlReport('Google Access Log Activities')
-            report.start_artifact_report(report_folder, 'Google Access Log Activities', description)
-            html_report = report.report_file_path
-            report.add_script()
-            has_header = True
-            
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                flag = False
-                header_row = next(delimited)
-                if 'Referer Product Name' in header_row:
-                    flag == True
-                if flag == True:
-                    for item in delimited:
-                        gaia_id = item[0]
-                        timestamp = item[1]
-                        ip_address = item[2]
-                        proxied_host_ip = item[3]
-                        is_nonroutable = item[4]
-                        activity_country = item[5]
-                        activity_region = item[6]
-                        activity_city = item[7]
-                        user_agent_str = item[8]
-                        product = item[9]
-                        sub_product = item[10]
-                        referer_product = item[11]
-                        referer_sub_product = item[12]
-                        activity_type = item[13]
-                        gmail_access_channel = item[14]
-                        android_webview_package = item[15]
-                        data_list.append((timestamp,ip_address,proxied_host_ip,is_nonroutable,activity_country,activity_region,activity_city,user_agent_str,product,sub_product,referer_product,referer_sub_product,activity_type,gmail_access_channel,android_webview_package,gaia_id))
-                        if ip_address != None:
-                            ipaddress_list.append((ip_address, 'Google Access Log Activities', 'Takeout_Ipaddress_logins', html_report, None))
-                else:
-                    for item in delimited:
-                        gaia_id = item[0]
-                        timestamp = item[1]
-                        ip_address = item[2]
-                        proxied_host_ip = item[3]
-                        is_nonroutable = item[4]
-                        activity_country = item[5]
-                        activity_region = item[6]
-                        activity_city = item[7]
-                        user_agent_str = item[8]
-                        product = item[9]
-                        sub_product = item[10]
-                        activity_type = item[11]
-                        gmail_access_channel = item[12]
-                        data_list.append((timestamp,ip_address,proxied_host_ip,is_nonroutable,activity_country,activity_region,activity_city,user_agent_str,product,sub_product,'','',activity_type,gmail_access_channel,'',gaia_id))
-                        if ip_address != None:
-                            ipaddress_list.append((ip_address, 'Google Access Log Activities', 'Takeout_Ipaddress_logins', html_report, None))
-                
-            if data_list:
-                
-                data_headers = ('Timestamp','IP Address','Proxied Host IP Address','Is Non-routable IP Address','Activity Country','Activity Region','Activity City','User Agent String','Product Name','Sub-Product Name','Referer Product Name','Referer Sub-Product Name','Activity Type','Gmail Access Channel','Android Webview Package Name','GAIA ID')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Google Access Log Activities'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                ipgen(report_folder,ipaddress_list)
-
-                tlactivity = f'Google Access Log Activities'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Google Access Log Activities data available')
-                
-        if filename.startswith('Devices - A list of devices (i.e. Nest, Pixel, iPh.csv'):
-            data_list = []
-            
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                flag = False
-                header_row = next(delimited)
-                if 'Country' in header_row:
-                    flag == True
-                if flag == True:
-                    for item in delimited:
-                        gaia_id = item[0]
-                        device_type = item[1]
-                        brand_name = item[2]
-                        device_model = item[3]
-                        device_os = item[4]
-                        device_last_country = item[5]
-                        device_last_location_ts = item[6]
-                        device_first_activity_ts = item[7]
-                        device_last_activity_ts = item[8]
-
-                        data_list.append((device_first_activity_ts,device_last_activity_ts,device_type,brand_name,device_model,device_os,'',device_last_country,device_last_location_ts,gaia_id))
-                        
-                else: 
-                    for item in delimited:
-                        device_country = ''
-                        device_type = item[0]
-                        brand_name = item[1]
-                        marketing_name = item[2]
-                        device_os = item[3]
-                        os_version = item[4]
-                        device_model = item[5]
-                        device_name = item[6]
-                        device_last_location = item[7].replace('\n',' ')
-                        device_last_country = device_last_location[device_last_location.find("Country ISO: ") + 12:device_last_location.find("Country ISO: ") + 15]
-                        device_last_activity_ts = device_last_location[device_last_location.find("Last Activity Time:") + 20:device_last_location.find("Last Activity Time:") + 39]
-                        gaia_id = item[8]
-                
-                        data_list.append(('',device_last_activity_ts,device_type,brand_name,device_model,device_os,os_version,device_last_country,'',gaia_id))
-            
-            if data_list:
-                description = 'A list of devices (i.e. Nest, Pixel, iPhone, Galaxy, etc) which have accessed your Google account over the last 30 days'
-                report = ArtifactHtmlReport('Google Access Log Devices')
-                report.start_artifact_report(report_folder, 'Google Access Log Devices', description)
-                html_report = report.report_file_path
-                report.add_script()
-                
-                data_headers = ('First Activity Timestamp','Last Activity Timestamp','Device Type','Device Brand','Device Model','Device OS','OS Version','Device Last Country','Device Last Location Timestamp','GAIA ID')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Google Access Log Devices'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Google Access Log Devices'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Google Access Log Devices data available')
-
-__artifacts__ = {
-        "takeoutAccessLogActivity": (
-            "Google Takeout Archive",
-            ('*/Access Log Activity/*.csv'),
-            get_takeoutAccessLogActivity)
+__artifacts_v2__ = {
+    "takeoutAccessLogActivities": {
+        "name": "Google Access Log Activities",
+        "description": "A list of Google services accessed by your devices (e.g. each time a phone syncs with Gmail).",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Access Log Activity/Activities*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    },
+    "takeoutAccessLogDevices": {
+        "name": "Google Access Log Devices",
+        "description": "A list of devices (Nest, Pixel, iPhone, Galaxy, etc.) that accessed your Google account in the last 30 days.",
+        "author": "@KevinPagano3",
+        "creation_date": "2021-09-25",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Old-format exports store last country/activity-time inside a free-text field; that legacy string slicing is preserved as-is.",
+        "paths": ('*/Access Log Activity/Devices*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    }
 }
+
+import csv
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, ipgen
+
+
+def _iso_to_utc(value):
+    if not value:
+        return value
+    try:
+        return datetime.fromisoformat(value.strip().replace('Z', '+00:00')).astimezone(timezone.utc)
+    except (ValueError, AttributeError):
+        return value
+
+
+@artifact_processor
+def takeoutAccessLogActivities(context):
+    data_list = []
+    ip_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('Activities - A list of Google services accessed by'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            reader = csv.reader(f, delimiter=',')
+            header_row = next(reader, [])
+            is_new = 'Referer Product Name' in header_row   # was a no-op 'flag == True' in the original
+            for item in reader:
+                if len(item) < (16 if is_new else 13):
+                    continue
+                if is_new:
+                    referer_product, referer_sub = item[11], item[12]
+                    activity_type, gmail_channel, android_webview = item[13], item[14], item[15]
+                else:
+                    referer_product = referer_sub = android_webview = ''
+                    activity_type, gmail_channel = item[11], item[12]
+                data_list.append((_iso_to_utc(item[1]), item[2], item[3], item[4], item[5], item[6],
+                                  item[7], item[8], item[9], item[10], referer_product, referer_sub,
+                                  activity_type, gmail_channel, android_webview, item[0]))
+                if item[2]:
+                    ip_list.append((item[2], 'Google Access Log Activities',
+                                    'Takeout_Ipaddress_logins', '', None))
+
+    if ip_list:
+        ipgen(context.get_report_folder(), ip_list)
+
+    data_headers = (('Timestamp', 'datetime'), 'IP Address', 'Proxied Host IP Address',
+                    'Is Non-routable IP Address', 'Activity Country', 'Activity Region',
+                    'Activity City', 'User Agent String', 'Product Name', 'Sub-Product Name',
+                    'Referer Product Name', 'Referer Sub-Product Name', 'Activity Type',
+                    'Gmail Access Channel', 'Android Webview Package Name', 'GAIA ID')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def takeoutAccessLogDevices(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('Devices - A list of devices'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            reader = csv.reader(f, delimiter=',')
+            header_row = next(reader, [])
+            is_new = 'Country' in header_row   # was a no-op 'flag == True' in the original
+            for item in reader:
+                if len(item) < 9:
+                    continue
+                if is_new:
+                    data_list.append((_iso_to_utc(item[7]), _iso_to_utc(item[8]), item[1], item[2],
+                                      item[3], item[4], '', item[5], _iso_to_utc(item[6]), item[0]))
+                else:
+                    last_loc = item[7].replace('\n', ' ')
+                    ci = last_loc.find('Country ISO: ')
+                    last_country = last_loc[ci + 12:ci + 15].strip() if ci != -1 else ''
+                    ai = last_loc.find('Last Activity Time:')
+                    last_activity = last_loc[ai + 20:ai + 39].strip() if ai != -1 else ''
+                    data_list.append(('', _iso_to_utc(last_activity), item[0], item[1], item[5],
+                                      item[3], item[4], last_country, '', item[8]))
+
+    data_headers = (('First Activity Timestamp', 'datetime'), ('Last Activity Timestamp', 'datetime'),
+                    'Device Type', 'Device Brand', 'Device Model', 'Device OS', 'OS Version',
+                    'Device Last Country', ('Device Last Location Timestamp', 'datetime'), 'GAIA ID')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Ninth **Google Takeout Archive** batch — Access Log Activity (Activities + Devices), each with old/new export-format branches → two `@artifact_processor` artifacts: `takeoutAccessLogActivities`, `takeoutAccessLogDevices`.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @KevinPagano3; date kept.
- Context form, `context.get_relative_path(source)`, precise per-table path globs.
- Timestamps → aware UTC (best-effort ISO parse; raw value kept if a row isn't ISO).
- **IP geolocation preserved**: `ipgen()` is called with `context.get_report_folder()` to build the `_IPAddress DB` for the Activities table (verified it runs and creates the DB).

## 🐞 Bug fix
The new-vs-old format selector was `flag == True` (a **no-op comparison**) instead of `flag = True`, so `flag` stayed `False` and **every** file was parsed with the OLD column layout — corrupting new-format exports (e.g. the *Referer Product* column was read as *Activity Type*). Now the format is detected straight from the header row (`Referer Product Name` / `Country`). **Verified by functional test on both layouts** (new format now routes `RefProd`→Referer and `LOGIN`→Activity Type correctly).

## Flagged
Old-format Devices store last country / activity-time inside a free-text field; that legacy string slicing is preserved (now whitespace-stripped). Timestamp formats are parsed best-effort (no sample of every export version).

Loader **208 → 209**.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + dup-column audit clean (2 tables); **PluginLoader** (2 new keys, old key gone, total 209); **synthetic-data functional test** (old + new Activities layouts proving the flag fix; `ipgen` DB creation; Devices UTC timestamps).