### PR TITLE
Convert Google Takeout Mail (MBOX) to LAVA — completes Google Takeout Archive

### DIFF
--- a/scripts/artifacts/takeoutGoogleMail.py
+++ b/scripts/artifacts/takeoutGoogleMail.py
@@ -1,152 +1,84 @@
-import os
-import datetime
-import csv
+__artifacts_v2__ = {
+    "takeoutGoogleMail": {
+        "name": "Google Takeout - Mail (MBOX)",
+        "description": "Parses MBOX mailboxes (All Mail, Deleted) from a Google Takeout export, including attachments.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-01-19",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Mail/All mail Including Spam and Trash.mbox', '*/Deleted.mbox'),
+        "output_types": "standard",
+        "artifact_icon": "mail",
+    }
+}
+
 import mailbox
-import email
+from datetime import timezone
+from email.utils import parsedate_to_datetime
 
-from scripts.filetype import guess_extension
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media
 
-def getbody(message): #getting plain text 'email body'
-    body = None
+
+def _get_body(message):
+    """Return the first text/plain body of an email message, or '' if none."""
     if message.is_multipart():
         for part in message.walk():
-            if part.is_multipart():
-                for subpart in part.walk():
-                    if subpart.get_content_type() == 'text/plain':
-                        body = subpart.get_payload(decode=True).decode('Latin_1')
-            elif part.get_content_type() == 'text/plain':
-                body = part.get_payload(decode=True).decode('Latin_1')
+            if part.get_content_type() == 'text/plain' and not part.is_multipart():
+                payload = part.get_payload(decode=True)
+                if payload is not None:
+                    return payload.decode('Latin_1')
     elif message.get_content_type() == 'text/plain':
-        body = message.get_payload(decode=True).decode('Latin_1')
-    return body
-    
-def get_takeoutGoogleMail(files_found, report_folder, seeker, wrap_text):
-    
-    platform = is_platform_windows()
-    if platform:
-        splitter = '\\'
-    else:
-        splitter = '/'
-    
-    for a, file_found in enumerate(files_found):
-        file_found = str(file_found)
-        
-        mailboxid = str(a + 1)
-        data_list = []
-        
-        mbox = mailbox.mbox(file_found)
-        
-        for i, message in enumerate(mbox):
-            emailid = str(i)
-            mfrom = message['from']
-            mto = message['to']
-            msubject = str(message['Subject'])
-            
-            msentdate = message['date']
-            if msentdate:
-                msentdate = msentdate.replace('Sun, ','').replace('Mon, ','').replace('Tue, ','').replace('Wed, ','').replace('Thu, ','').replace('Fri, ','').replace('Sat, ','')
-                msentdate_split = msentdate.split(' ')
-            
-            day = msentdate_split[0]
-            if len(day) < 2:
-                day = "0" + day
-            
-            month = msentdate_split[1]
-            year = msentdate_split[2]
-            time = msentdate_split[3]
-            
-            offset = msentdate_split[4]
-            if offset == 'GMT':
-                offset = '+0000'
+        payload = message.get_payload(decode=True)
+        if payload is not None:
+            return payload.decode('Latin_1')
+    return ''
 
-            if month == 'Jan':
-                month = '01'
-            elif month == 'Feb':
-                month = '02'
-            elif month == 'Mar':
-                month = '03'
-            elif month == 'Apr':
-                month = '04'
-            elif month == 'May':
-                month = '05'
-            elif month == 'Jun':
-                month = '06'
-            elif month == 'Jul':
-                month = '07'
-            elif month == 'Aug':
-                month = '08'
-            elif month == 'Sep':
-                month = '09'
-            elif month == 'Oct':
-                month = '10'
-            elif month == 'Nov':
-                month = '11'
-            elif month == 'Dec':
-                month = '12'
-                
-            msentdate_formatted = year + "-" + month + "-" + day + " " + time + " " + offset
-            
-            msgtype = message.get_content_type()
-            thebody = getbody(message)
-            if thebody is None:
-                thebody = 'Check source data.'
-            
-            attachmentnumber = 0
-            attachments = ''
-            filename = None
+
+def _parse_date(value):
+    if not value:
+        return ''
+    try:
+        dt = parsedate_to_datetime(value)
+    except (ValueError, TypeError):
+        return value
+    if dt is None:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def takeoutGoogleMail(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.mbox'):
+            continue
+        source_path = file_found
+        rel = context.get_relative_path(file_found)
+
+        for message in mailbox.mbox(file_found):
+            attachments = []
             if message.is_multipart():
                 for part in message.walk():
-                    if part.get_content_maintype() == 'multipart': continue
-                    if part.get('Content-Disposition') is None: continue
-                    if part.get_content_disposition() == 'attachment':
-                        filename = part.get_filename()
-                    if filename is None:
-                        attachmentnumber = attachmentnumber + 1
-                        filename = str(attachmentnumber)
-                            
-                    foldernumber = str(i)
-                    
-                        #join(report_folder, basename(file_found))
-                    pathfile = f'{report_folder}{mailboxid}_attachments_data{splitter}{foldernumber}{splitter}{filename}'
-                    os.makedirs(os.path.dirname(pathfile), exist_ok=True)
-                    
-                    with open(pathfile, "wb") as f:
-                        f.write(part.get_payload(decode=True))
-                        
-                    extension = guess_extension(pathfile)
-                        
-                    renamed = f'{pathfile}.{extension}' if extension else pathfile
-                    try:
-                        os.rename(pathfile, renamed)
-                    except:
-                        pass
-                    tolink = []
-                    tolink.append(renamed)
-                    thumb = media_to_html(renamed, tolink, f'{report_folder}{mailboxid}_attachments_report{splitter}')
-                    attachments = attachments + '<table><tr><td>' + thumb + '</td></tr></table><p>'
-        
-            data_list.append((msentdate_formatted, mfrom, mto, msubject, thebody, attachments))
-        
-        if data_list:
-            description = f'Google Takeout - MBOX'
-            report = ArtifactHtmlReport(f'Google Takeout - MBOX - {a}')
-            report.start_artifact_report(report_folder, f'Google Takeout - MBOX - {a}', description)
-            report.add_script()
-            data_headers = ('Date','From','To','Subject','Body','Attachments')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Attachments'])
-            report.end_artifact_report()
-            
-            tsvname = f'Google Takeout - MBOX - {a}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-    
-        else:
-            logfunc(f'No Google Takeout - MBOX - {a} data available')
-                
-__artifacts__ = {
-        "takeoutGoogleMail": (
-            "Google Takeout Archive",
-            ('*/Mail/All mail Including Spam and Trash.mbox','*/Deleted.mbox'),
-            get_takeoutGoogleMail)
-}
+                    if part.get_content_maintype() == 'multipart':
+                        continue
+                    if part.get('Content-Disposition') is None:
+                        continue
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        name = part.get_filename() or part.get_content_type()
+                        ref = check_in_embedded_media(file_found, payload, name)
+                        if ref:
+                            attachments.append(ref)
+            data_list.append((_parse_date(message.get('date', '')), message.get('from', ''),
+                              message.get('to', ''), str(message.get('Subject', '')),
+                              _get_body(message), attachments, rel))
+
+    data_headers = (('Date', 'datetime'), 'From Address', 'To Address', 'Subject', 'Body',
+                    ('Attachments', 'media'), 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
**Final Google Takeout Archive batch** — Google Takeout Mail (MBOX). With this, all 22 Google Takeout artifacts are on LAVA.

Parses the MBOX mailboxes (All Mail, Deleted) into a single LAVA table.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; date kept.
- Context form; one row per message across all matched mailboxes, with a **`Source File`** column (`context.get_relative_path`) identifying the mbox.

## Key changes
- **🔑 Reserved words:** the original `From`/`To` columns sanitize to SQLite keywords and would break LAVA's unquoted `CREATE TABLE`. Renamed to **`From Address`/`To Address`** (verified: `from_address`/`to_address` create cleanly).
- **Dates:** RFC-2822 parsed with `email.utils.parsedate_to_datetime` and normalized to aware UTC — replacing the original's manual weekday/month/offset string surgery. (Verified `-0500` → UTC.)
- **Attachments → `check_in_embedded_media`:** the legacy `media_to_html` + extract-to-disk is replaced with embedded-media check-in (hashes the raw part bytes; **no files written to the report folder**). Multiple attachments per message → a media list.

## 🔒 Forensic note
This artifact is now **fully read-only** — the legacy version wrote extracted attachment files into the report folder; that disk I/O is gone.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean; **PluginLoader** loads (total 209); **functional test** (synthetic mbox) asserting UTC dates with offset normalization, From/To rename, body extraction, and attachment detection/naming/check-in (the framework media boundary is stubbed in the test, as it needs full LAVA output state — its signature/behavior were verified separately).