### PR TITLE
Convert 2 Facebook-Instagram Returns media artifacts to LAVA (Archived Stories, Profile Picture)

### DIFF
--- a/scripts/artifacts/fbigArchiveStories.py
+++ b/scripts/artifacts/fbigArchiveStories.py
@@ -1,68 +1,75 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigArchiveStories(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-archived_stories"})
-            
-            control = 0
-            agg = ''
-            
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td").get_text())
-                    
-                    if thvalue == 'Archived Stories':
-                        pass
-                    elif thvalue == 'Story Id':
-                        storyid = tdvalue
-                    elif thvalue == 'Timestamp':
-                        time = tdvalue
-                    elif thvalue == 'Linked Media File:':
-                        media = tdvalue.split('/')[1]
-                        thumb = media_to_html(media,files_found, report_folder)
-                        data_list.append((time,storyid,tdvalue,thumb))
-                
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Archived Stories - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Archived Stories - {rfilename}')
-            report.add_script()
-            data_headers = ('Timestamp','Story ID','Filename','Thumb' )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Thumb'])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - Archived Stories - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Archived Stories - {rfilename}')
-                
-__artifacts__ = {
-        "fbigArchiveStories": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html', '*/linked_media/archived_stories_*'),
-            get_fbigArchiveStories)
+__artifacts_v2__ = {
+    "fbigArchiveStories": {
+        "name": "Facebook Instagram Returns - Archived Stories",
+        "description": "Archived stories with linked media parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-06-30",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html', '*/linked_media/archived_stories_*'),
+        "output_types": "standard",
+        "artifact_icon": "book-open",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _fbig_ts(value):
+    # Return timestamps vary by export; convert epoch / ISO (incl. ' UTC') to aware UTC, else keep raw.
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+    except ValueError:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def fbigArchiveStories(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        story_id = ''
+        timestamp = ''
+        for section in soup.find_all('div', {'id': 'property-archived_stories'}):
+            for table in section.find_all('table'):
+                th = table.find('th')
+                if not th:
+                    continue
+                label = th.get_text()
+                td = th.find_next_sibling('td')
+                value = td.get_text() if td else ''
+                if label == 'Story Id':
+                    story_id = value
+                elif label == 'Timestamp':
+                    timestamp = value
+                elif label == 'Linked Media File:':
+                    media_name = value.split('/')[1] if '/' in value else value
+                    data_list.append((_fbig_ts(timestamp), story_id, value,
+                                      check_in_media(media_name, media_name)))
+
+    data_headers = (('Timestamp', 'datetime'), 'Story ID', 'Filename', ('Thumb', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigPofilePic.py
+++ b/scripts/artifacts/fbigPofilePic.py
@@ -1,62 +1,48 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigPofilePic(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-profile_picture"})
-            #print(uni)
-            control = 0
-            
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td").get_text())
-                    
-                    #print(thvalue)
-                    if thvalue == 'Profile Picture':
-                        picturename = tdvalue.split('/')[1]
-                        thumb = media_to_html(picturename,files_found, report_folder)
-                        data_list.append((thumb,picturename))
-        
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Profile picture - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Profile picture - {rfilename}')
-            report.add_script()
-            data_headers = ('Linked Media File','Filename' )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Current Participants', 'Linked Media File'])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - Profile picture - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Devices - {rfilename}')
-                
-__artifacts__ = {
-        "fbigPofilePic": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html', '*/linked_media/profile_picture_*'),
-            get_fbigPofilePic)
+__artifacts_v2__ = {
+    "fbigPofilePic": {
+        "name": "Facebook Instagram Returns - Profile Picture",
+        "description": "Profile picture (linked media) parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-06-30",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html', '*/linked_media/profile_picture_*'),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
 }
+
+import os
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, check_in_media
+
+
+@artifact_processor
+def fbigPofilePic(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        for section in soup.find_all('div', {'id': 'property-profile_picture'}):
+            for table in section.find_all('table'):
+                th = table.find('th')
+                if not th or th.get_text() != 'Profile Picture':
+                    continue
+                td = th.find_next_sibling('td')
+                value = td.get_text() if td else ''
+                picture_name = value.split('/')[1] if '/' in value else value
+                data_list.append((check_in_media(picture_name, picture_name), picture_name))
+
+    data_headers = (('Linked Media File', 'media'), 'Filename')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Second **Facebook – Instagram Returns** batch — the two `index.html` table-walker artifacts that carry **linked media**.

| Artifact | Section | Media |
|---|---|---|
| Archived Stories | property-archived_stories | Thumb |
| Profile Picture | property-profile_picture | Linked Media File |

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`, dropped boilerplate + unused imports.
- **`media_to_html` → `check_in_media`** (typed `('Col','media')`); the linked-media filename is extracted from the return's `linked_media/<name>` path and resolved by name.
- Archived Stories `Timestamp` → aware UTC via the best-effort `_fbig_ts` parser (epoch / ISO / ` UTC`, naive treated as UTC).
- More robust `th/td` walking (guards missing `th`/`td`) than the originals.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean; **PluginLoader** loads both (total 209); **synthetic-HTML functional test** asserting linked-media filename extraction, media-column detection, and (Archived Stories) UTC timestamp parsing. (Media framework boundary stubbed in the test, as it needs full LAVA output state.)