### PR TITLE
Convert FB-Instagram Returns Photos + Videos to LAVA (records.html state-machine + media)

### DIFF
--- a/scripts/artifacts/fbigPhotos.py
+++ b/scripts/artifacts/fbigPhotos.py
@@ -1,96 +1,109 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigPhotos(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        if filename.startswith('records.html') or filename.startswith('preservation'):
-            rfilename = filename
-        
-        
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'lxml')
-                data_list = []
-            
-                uni = soup.find_all("div", {"id": "property-photos"})
-                
-                divs = uni[0].find_all('div', class_='div_table outer')
-                
-                current_group = 0
-                for index, div in enumerate(divs):
-                    if index > 1:
-                        inner_div = div.find('div', class_='div_table inner')
-                        if inner_div and 'Image' in inner_div.text:
-                            if current_group == 1:
-                                data_list.append((taken,thumb,lmf,url,source,filter,pub,sba,carid,caption,comments,location))
-                                current_group = 0
-                        elif inner_div and 'Linked Media File' in inner_div.text:
-                            lmf = div.find('div', class_='most_inner')
-                            lmf = (lmf.get_text())
-                            #fnt = os.path.basename(lmf)
-                            thumb = media_to_html(lmf, files_found, report_folder)
-                        elif inner_div and 'Url' in inner_div.text:
-                            url = div.find('div', class_='most_inner')
-                            url = (url.get_text())
-                        elif inner_div and 'Source' in inner_div.text:
-                            source = div.find('div', class_='most_inner')
-                            source = (source.get_text())
-                        elif inner_div and 'Filter' in inner_div.text:
-                            filter = div.find('div', class_='most_inner')
-                            filter = (filter.get_text())
-                        elif inner_div and 'Is Published' in inner_div.text:
-                            pub = div.find('div', class_='most_inner')
-                            pub = (pub.get_text())
-                        elif inner_div and 'Shared By Author' in inner_div.text:
-                            sba = div.find('div', class_='most_inner')
-                            sba = (sba.get_text())
-                        elif inner_div and 'Carousel Id' in inner_div.text:
-                            carid = div.find('div', class_='most_inner')
-                            carid = (carid.get_text())
-                        elif inner_div and 'Caption' in inner_div.text:
-                            caption = (str(div))  # Keep the entire div with tags
-                        elif inner_div and 'Comments' in inner_div.text:
-                            comments = (str(div))  # Keep the entire div with tags
-                        elif inner_div and 'Taken' in inner_div.text:
-                            taken = div.find('div', class_='most_inner')
-                            taken = (taken.get_text())
-                        elif inner_div and 'Location' in inner_div.text:
-                            location = (str(div))  # Keep the entire div with tags
-                            current_group = 1
-                        else:
-                            pass
-                    
-                data_list.append((taken,thumb,lmf,url,source,filter,pub,sba,carid,caption,comments,location))
-            
-            
-                
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Photos - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Photos - {rfilename}')
-            report.add_script()
-            data_headers = ('Timestamp','Thumb','Linked Media File','URL','Source','Filter','Is Published','Shared by Author','Carousel Id','Caption','Comments','Location')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Thumb','Caption','Comments','Location'])
-            report.end_artifact_report()
-            
-            #tsvname = f'Facebook Instagram - Videos - {rfilename}'
-            #tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Photos - {rfilename}')
-                
-__artifacts__ = {
-        "fbigPhotos": (
-            "Facebook - Instagram Returns",
-            ('*/records.html', '*/preservation*.html', '*/linked_media/*.*'),
-            get_fbigPhotos)
+__artifacts_v2__ = {
+    "fbigPhotos": {
+        "name": "Facebook Instagram Returns - Photos",
+        "description": "Photos (with linked media) parsed from a Facebook/Instagram law enforcement return (records.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-01",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/records.html', '*/preservation*.html', '*/linked_media/*.*'),
+        "output_types": "standard",
+        "html_columns": ["Caption", "Comments", "Location"],
+        "artifact_icon": "image",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _fbig_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+    except ValueError:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _row(fields):
+    return (_fbig_ts(fields.get('taken', '')), fields.get('thumb'), fields.get('lmf', ''),
+            fields.get('url', ''), fields.get('source', ''), fields.get('filter', ''),
+            fields.get('pub', ''), fields.get('sba', ''), fields.get('carid', ''),
+            fields.get('caption', ''), fields.get('comments', ''), fields.get('location', ''))
+
+
+@artifact_processor
+def fbigPhotos(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('records.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'lxml')
+
+        for section in soup.find_all('div', {'id': 'property-photos'}):
+            fields = {}
+            started = False
+            for index, div in enumerate(section.find_all('div', class_='div_table outer')):
+                if index <= 1:
+                    continue
+                inner_div = div.find('div', class_='div_table inner')
+                label = inner_div.text if inner_div else ''
+                if 'Image' in label:
+                    if started:
+                        data_list.append(_row(fields))
+                    fields = {}
+                    started = True
+                    continue
+                if not started:
+                    continue
+                most_inner = div.find('div', class_='most_inner')
+                value = most_inner.get_text() if most_inner else div.get_text(' ', strip=True)
+                if 'Linked Media File' in label:
+                    fields['lmf'] = value
+                    fields['thumb'] = check_in_media(value, value)
+                elif 'Url' in label:
+                    fields['url'] = value
+                elif 'Source' in label:
+                    fields['source'] = value
+                elif 'Filter' in label:
+                    fields['filter'] = value
+                elif 'Is Published' in label:
+                    fields['pub'] = value
+                elif 'Shared By Author' in label:
+                    fields['sba'] = value
+                elif 'Carousel Id' in label:
+                    fields['carid'] = value
+                elif 'Caption' in label:
+                    fields['caption'] = value
+                elif 'Comments' in label:
+                    fields['comments'] = value
+                elif 'Taken' in label:
+                    fields['taken'] = value
+                elif 'Location' in label:
+                    fields['location'] = value
+            if started:
+                data_list.append(_row(fields))
+
+    data_headers = (('Timestamp', 'datetime'), ('Thumb', 'media'), 'Linked Media File', 'URL',
+                    'Source', 'Filter', 'Is Published', 'Shared by Author', 'Carousel Id',
+                    'Caption', 'Comments', 'Location')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigVideos.py
+++ b/scripts/artifacts/fbigVideos.py
@@ -1,96 +1,109 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigVideos(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        if filename.startswith('records.html') or filename.startswith('preservation'):
-            rfilename = filename
-        
-        
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'lxml')
-                data_list = []
-            
-                uni = soup.find_all("div", {"id": "property-videos"})
-                
-                divs = uni[0].find_all('div', class_='div_table outer')
-                
-                current_group = 0
-                for index, div in enumerate(divs):
-                    if index > 1:
-                        inner_div = div.find('div', class_='div_table inner')
-                        if inner_div and 'Video' in inner_div.text:
-                            if current_group == 1:
-                                data_list.append((taken,thumb,lmf,url,source,filter,pub,sba,carid,caption,comments,location))
-                                current_group = 0
-                        elif inner_div and 'Linked Media File' in inner_div.text:
-                            lmf = div.find('div', class_='most_inner')
-                            lmf = (lmf.get_text())
-                            #fnt = os.path.basename(lmf)
-                            thumb = media_to_html(lmf, files_found, report_folder)
-                        elif inner_div and 'Url' in inner_div.text:
-                            url = div.find('div', class_='most_inner')
-                            url = (url.get_text())
-                        elif inner_div and 'Source' in inner_div.text:
-                            source = div.find('div', class_='most_inner')
-                            source = (source.get_text())
-                        elif inner_div and 'Filter' in inner_div.text:
-                            filter = div.find('div', class_='most_inner')
-                            filter = (filter.get_text())
-                        elif inner_div and 'Is Published' in inner_div.text:
-                            pub = div.find('div', class_='most_inner')
-                            pub = (pub.get_text())
-                        elif inner_div and 'Shared By Author' in inner_div.text:
-                            sba = div.find('div', class_='most_inner')
-                            sba = (sba.get_text())
-                        elif inner_div and 'Carousel Id' in inner_div.text:
-                            carid = div.find('div', class_='most_inner')
-                            carid = (carid.get_text())
-                        elif inner_div and 'Caption' in inner_div.text:
-                            caption = (str(div))  # Keep the entire div with tags
-                        elif inner_div and 'Comments' in inner_div.text:
-                            comments = (str(div))  # Keep the entire div with tags
-                        elif inner_div and 'Taken' in inner_div.text:
-                            taken = div.find('div', class_='most_inner')
-                            taken = (taken.get_text())
-                        elif inner_div and 'Location' in inner_div.text:
-                            location = (str(div))  # Keep the entire div with tags
-                            current_group = 1
-                        else:
-                            pass
-                    
-                data_list.append((taken,thumb,lmf,url,source,filter,pub,sba,carid,caption,comments,location))
-            
-            
-                
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Videos - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Videos - {rfilename}')
-            report.add_script()
-            data_headers = ('Timestamp','Thumb','Linked Media File','URL','Source','Filter','Is Published','Shared by Author','Carousel Id','Caption','Comments','Location')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Thumb','Caption','Comments','Location'])
-            report.end_artifact_report()
-            
-            #tsvname = f'Facebook Instagram - Videos - {rfilename}'
-            #tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Videos - {rfilename}')
-                
-__artifacts__ = {
-        "fbigVideos": (
-            "Facebook - Instagram Returns",
-            ('*/records.html', '*/preservation*.html', '*/linked_media/*.*'),
-            get_fbigVideos)
+__artifacts_v2__ = {
+    "fbigVideos": {
+        "name": "Facebook Instagram Returns - Videos",
+        "description": "Videos (with linked media) parsed from a Facebook/Instagram law enforcement return (records.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-01",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/records.html', '*/preservation*.html', '*/linked_media/*.*'),
+        "output_types": "standard",
+        "html_columns": ["Caption", "Comments", "Location"],
+        "artifact_icon": "video",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _fbig_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+    except ValueError:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _row(fields):
+    return (_fbig_ts(fields.get('taken', '')), fields.get('thumb'), fields.get('lmf', ''),
+            fields.get('url', ''), fields.get('source', ''), fields.get('filter', ''),
+            fields.get('pub', ''), fields.get('sba', ''), fields.get('carid', ''),
+            fields.get('caption', ''), fields.get('comments', ''), fields.get('location', ''))
+
+
+@artifact_processor
+def fbigVideos(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('records.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'lxml')
+
+        for section in soup.find_all('div', {'id': 'property-videos'}):
+            fields = {}
+            started = False
+            for index, div in enumerate(section.find_all('div', class_='div_table outer')):
+                if index <= 1:
+                    continue
+                inner_div = div.find('div', class_='div_table inner')
+                label = inner_div.text if inner_div else ''
+                if 'Video' in label:
+                    if started:
+                        data_list.append(_row(fields))
+                    fields = {}
+                    started = True
+                    continue
+                if not started:
+                    continue
+                most_inner = div.find('div', class_='most_inner')
+                value = most_inner.get_text() if most_inner else div.get_text(' ', strip=True)
+                if 'Linked Media File' in label:
+                    fields['lmf'] = value
+                    fields['thumb'] = check_in_media(value, value)
+                elif 'Url' in label:
+                    fields['url'] = value
+                elif 'Source' in label:
+                    fields['source'] = value
+                elif 'Filter' in label:
+                    fields['filter'] = value
+                elif 'Is Published' in label:
+                    fields['pub'] = value
+                elif 'Shared By Author' in label:
+                    fields['sba'] = value
+                elif 'Carousel Id' in label:
+                    fields['carid'] = value
+                elif 'Caption' in label:
+                    fields['caption'] = value
+                elif 'Comments' in label:
+                    fields['comments'] = value
+                elif 'Taken' in label:
+                    fields['taken'] = value
+                elif 'Location' in label:
+                    fields['location'] = value
+            if started:
+                data_list.append(_row(fields))
+
+    data_headers = (('Timestamp', 'datetime'), ('Thumb', 'media'), 'Linked Media File', 'URL',
+                    'Source', 'Filter', 'Is Published', 'Shared by Author', 'Carousel Id',
+                    'Caption', 'Comments', 'Location')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Third **Facebook – Instagram Returns** batch — the two near-identical `records.html` label-walking media parsers (`property-photos` / `property-videos`), 12 columns each.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`.
- **`media_to_html` → `check_in_media`** (typed `('Thumb','media')`).
- `Taken` → aware UTC via best-effort `_fbig_ts`.
- Caption/Comments/Location kept as text via `html_columns` (was raw `str(div)` HTML).

## 🐞 Bug fixes (the originals mishandled grouping)
- **Per-group field reset:** fields are cleared at each Image/Video header, so a value missing from one entry no longer **leaks** the previous entry's value. *(Verified: group 2 with no Url/Caption comes back empty, not group 1's values.)*
- **Every entry emitted:** the original only flushed a group when it had a `Location` field, plus a trailing unconditional append that `NameError`s on zero groups (and can duplicate the last). Now each header flushes the prior group and a tracked final flush emits the last — no dropped/duplicated rows, no `NameError`.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean (12 cols); **PluginLoader** loads both (total 209); **synthetic-HTML functional test** with two groups asserting UTC timestamps, media check-in, and **no field leak** between groups (media boundary stubbed).