### PR TITLE
Convert FB-Instagram Returns Direct Shares + Direct Stories to LAVA (index.html aggregator + media)

### DIFF
--- a/scripts/artifacts/fbigDirecShares.py
+++ b/scripts/artifacts/fbigDirecShares.py
@@ -1,91 +1,86 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigDirecShares(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-direct_shares"})
-            
-            control = 0
-            agg = ''
-            media = ''
-            thumb = ''
-            time = ''
-            
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    
-                    
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td"))
-                    
-                    if thvalue == 'Direct Shares':
-                        pass
-                    if thvalue == 'Videos Definition':
-                        pass
-                    if thvalue == 'Time':
-                        timestamp = tdvalue.get_text()
-                    elif thvalue == 'Linked Media File:':
-                        media = tdvalue.get_text().split('/')[1]
-                        thumb = media_to_html(media,files_found, report_folder)
-                    elif thvalue == 'Id':
-                        if control == 0:
-                            agg = agg + f"<table>{table.find('th')} {tdvalue}</table>"
-                            control = 1
-                        else:
-                            data_list.append((timestamp,thumb,agg,media))
-                            agg  = ''
-                            thumb = ''
-                            media = ''
-                            agg = agg + f"<table>{table.find('th')} {tdvalue}</table>"
-                            
-                            
-                            
-                    else:
-                        if 'Direct Shares' in thvalue:
-                            pass
-                        else:
-                            agg = agg + f"<table>{table.find('th')} {tdvalue}</table>"
-                data_list.append((timestamp,thumb,agg,media))
-                
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Direct Shares - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Direct Shares - {rfilename}')
-            report.add_script()
-            data_headers = ('Timestamp','Thumb','Data','Filename' )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Thumb','Data'])
-            report.end_artifact_report()
-            
-            #tsvname = f'Facebook Instagram - Direct Shares - {rfilename}'
-            #tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Direct Shares - {rfilename}')
-                
-__artifacts__ = {
-        "fbigDirecShares": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html', '*/linked_media/direct_shares_*'),
-            get_fbigDirecShares)
+__artifacts_v2__ = {
+    "fbigDirecShares": {
+        "name": "Facebook Instagram Returns - Direct Shares",
+        "description": "Direct shares (with linked media) parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-01",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html', '*/linked_media/direct_shares_*'),
+        "output_types": "standard",
+        "html_columns": ["Data"],
+        "artifact_icon": "share-2",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _fbig_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+    except ValueError:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def fbigDirecShares(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        for section in soup.find_all('div', {'id': 'property-direct_shares'}):
+            timestamp = thumb = media_name = ''
+            agg_parts = []
+            started = False
+            for table in section.find_all('table'):
+                th = table.find('th')
+                if not th:
+                    continue
+                label = th.get_text()
+                td = th.find_next_sibling('td')
+                value = td.get_text() if td else ''
+                if label in ('Direct Shares', 'Videos Definition'):
+                    continue
+                if label == 'Time':
+                    timestamp = value
+                elif label == 'Linked Media File:':
+                    media_name = value.split('/')[1] if '/' in value else value
+                    thumb = check_in_media(media_name, media_name)
+                elif label == 'Id':
+                    if started:
+                        data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+                        timestamp = thumb = media_name = ''
+                        agg_parts = []
+                    started = True
+                    agg_parts.append(f'{label}: {value}')
+                else:
+                    agg_parts.append(f'{label}: {value}')
+            if started:
+                data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+
+    data_headers = (('Timestamp', 'datetime'), ('Thumb', 'media'), 'Data', 'Filename')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigDirectStories.py
+++ b/scripts/artifacts/fbigDirectStories.py
@@ -1,91 +1,86 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigDirectStories(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-direct_stories"})
-            
-            control = 0
-            agg = ''
-            media = ''
-            thumb = ''
-            time = ''
-            
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    
-                    
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td"))
-                    
-                    if thvalue == 'Direct Stories':
-                        pass
-                    if thvalue == 'Videos Definition':
-                        pass
-                    if thvalue == 'Time':
-                        timestamp = tdvalue.get_text()
-                    elif thvalue == 'Linked Media File:':
-                        media = tdvalue.get_text().split('/')[1]
-                        thumb = media_to_html(media,files_found, report_folder)
-                    elif thvalue == 'Media Id':
-                        if control == 0:
-                            agg = agg + f"<table>{table.find('th')} {tdvalue}</table>"
-                            control = 1
-                        else:
-                            data_list.append((timestamp,thumb,agg,media))
-                            agg  = ''
-                            thumb = ''
-                            media = ''
-                            agg = agg + f"<table>{table.find('th')} {tdvalue}</table>"
-                            
-                            
-                            
-                    else:
-                        if 'Direct Stories' in thvalue:
-                            pass
-                        else:
-                            agg = agg + f"<table>{table.find('th')} {tdvalue}</table>"
-                data_list.append((timestamp,thumb,agg,media))
-                
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Direct Stories - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Direct Stories - {rfilename}')
-            report.add_script()
-            data_headers = ('Timestamp','Thumb','Data','Filename' )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Thumb','Data'])
-            report.end_artifact_report()
-            
-            #tsvname = f'Facebook Instagram - Direct Shares - {rfilename}'
-            #tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Stories - {rfilename}')
-                
-__artifacts__ = {
-        "fbigDirectStories": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html', '*/linked_media/direct_stories_*'),
-            get_fbigDirectStories)
+__artifacts_v2__ = {
+    "fbigDirectStories": {
+        "name": "Facebook Instagram Returns - Direct Stories",
+        "description": "Direct stories (with linked media) parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-01",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html', '*/linked_media/direct_stories_*'),
+        "output_types": "standard",
+        "html_columns": ["Data"],
+        "artifact_icon": "share-2",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _fbig_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+    except ValueError:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def fbigDirectStories(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        for section in soup.find_all('div', {'id': 'property-direct_stories'}):
+            timestamp = thumb = media_name = ''
+            agg_parts = []
+            started = False
+            for table in section.find_all('table'):
+                th = table.find('th')
+                if not th:
+                    continue
+                label = th.get_text()
+                td = th.find_next_sibling('td')
+                value = td.get_text() if td else ''
+                if label in ('Direct Stories', 'Videos Definition'):
+                    continue
+                if label == 'Time':
+                    timestamp = value
+                elif label == 'Linked Media File:':
+                    media_name = value.split('/')[1] if '/' in value else value
+                    thumb = check_in_media(media_name, media_name)
+                elif label == 'Media Id':
+                    if started:
+                        data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+                        timestamp = thumb = media_name = ''
+                        agg_parts = []
+                    started = True
+                    agg_parts.append(f'{label}: {value}')
+                else:
+                    agg_parts.append(f'{label}: {value}')
+            if started:
+                data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+
+    data_headers = (('Timestamp', 'datetime'), ('Thumb', 'media'), 'Data', 'Filename')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Fourth **Facebook – Instagram Returns** batch — the two near-identical `index.html` aggregator parsers (`property-direct_shares` / `property-direct_stories`), grouped per `Id` / `Media Id`.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`.
- **`media_to_html` → `check_in_media`** (typed `('Thumb','media')`); raw filename kept in `Filename`.
- `Time` → aware UTC via best-effort `_fbig_ts`.
- `Data` is now a clean `Label: value<br>` aggregate (`html_columns`) instead of the original raw `<table>{th_element} {td_element}</table>` HTML soup.

## 🐞 Bug fixes
- **timestamp (and thumb/media) leaked across groups:** only `agg` was reset on a new group, so an entry missing a `Time`/media displayed the **previous** entry's value. Every field now resets per group. *(Verified: a 2nd group with no Time comes back empty, not the 1st group's timestamp.)*
- The trailing unconditional append could reference an **undefined `timestamp`** (`NameError`) when the first group had no Time; a tracked final flush now only emits started groups.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean; **PluginLoader** loads both (total 209); **synthetic-HTML functional test** (two groups) asserting UTC, media check-in, clean Data, and **no field leak** (media boundary stubbed).