### PR TITLE
Convert FB-Instagram Returns Following, Incoming Follow Requests, Devices to LAVA

### DIFF
--- a/scripts/artifacts/fbigDevices.py
+++ b/scripts/artifacts/fbigDevices.py
@@ -1,77 +1,61 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigDevices(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-devices"})
-            
-            control = 0
-            itemsdict = {}
-            lmf = []
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td").get_text())
-                    
-                    if thvalue == 'Devices':
-                        for subtable in table.find_all('table'):
-                            thvalue = (subtable.find('th').get_text())
-                            tdvalue = (subtable.find('th').find_next_sibling("td").get_text())
-                            
-                            if control < 4:
-                                control = control+1
-                                if thvalue == 'Type':
-                                    typeof = tdvalue
-                                if thvalue == 'Id':
-                                    idof = tdvalue
-                                if thvalue == 'Active':
-                                    active = tdvalue
-                                    data_list.append((typeof,idof,active,''))
-                            else:
-                                control = 0
-                            if thvalue == 'User':
-                                user = tdvalue
-                                data_list.append(('','','',user))
-        
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Devices - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Devices - {rfilename}')
-            report.add_script()
-            data_headers = ('Type','ID','Active', 'User' )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Current Participants', 'Linked Media File'])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - Devices - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Devices - {rfilename}')
-                
-__artifacts__ = {
-        "fbigDevices": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html'),
-            get_fbigDevices)
+__artifacts_v2__ = {
+    "fbigDevices": {
+        "name": "Facebook Instagram Returns - Devices",
+        "description": "Devices parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-06-30",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html'),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    }
 }
+
+import os
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def fbigDevices(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        for section in soup.find_all('div', {'id': 'property-devices'}):
+            for table in section.find_all('table'):
+                th = table.find('th')
+                if not th or th.get_text() != 'Devices':
+                    continue
+                type_ = device_id = ''
+                for subtable in table.find_all('table'):
+                    sth = subtable.find('th')
+                    if not sth:
+                        continue
+                    label = sth.get_text()
+                    std = sth.find_next_sibling('td')
+                    value = std.get_text() if std else ''
+                    if label == 'Type':
+                        type_ = value
+                    elif label == 'Id':
+                        device_id = value
+                    elif label == 'Active':
+                        data_list.append((type_, device_id, value, ''))
+                        type_ = device_id = ''
+                    elif label == 'User':
+                        data_list.append(('', '', '', value))
+
+    data_headers = ('Type', 'ID', 'Active', 'User')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigFollowing.py
+++ b/scripts/artifacts/fbigFollowing.py
@@ -1,60 +1,52 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigFollowing(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('records.html') or filename.startswith('preservation'):
-            rfilename = filename
-            
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'lxml')
-            
-            data_list = []
-            uni = soup.find_all("div", {"id": "property-following"})
-            divs = uni[0].find_all('div', class_='div_table inner')
-            
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divinn = str(divinn)
-                    #divtext = (divinn.get_text())
-                    divinn = divinn.replace('<div class="most_inner">','')
-                    divinn = divinn.replace('<div>','')
-                    divinn = divinn.replace('</div>','')
-                    divinn = divinn.split('<br/>')
-
-                    for x in divinn:
-                        data_list.append((x,))
-        
-        if divinn:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Following - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Following - {rfilename}')
-            report.add_script()
-            data_headers = ('User', )
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=[''])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - Following - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Following - {rfilename}')
-                
-__artifacts__ = {
-        "fbigFollowing": (
-            "Facebook - Instagram Returns",
-            ('*/records.html', '*/preservation*.html'),
-            get_fbigFollowing)
+__artifacts_v2__ = {
+    "fbigFollowing": {
+        "name": "Facebook Instagram Returns - Following",
+        "description": "Accounts followed, parsed from a Facebook/Instagram law enforcement return (records.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-06-30",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/records.html', '*/preservation*.html'),
+        "output_types": "standard",
+        "artifact_icon": "user-check",
+    }
 }
+
+import os
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def fbigFollowing(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('records.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'lxml')
+
+        for section in soup.find_all('div', {'id': 'property-following'}):
+            for index, div in enumerate(section.find_all('div', class_='div_table inner')):
+                if index == 0:
+                    continue
+                inner = div.find('div', class_='most_inner')
+                if not inner:
+                    continue
+                for br in inner.find_all('br'):
+                    br.replace_with('\n')
+                for user in inner.get_text().split('\n'):
+                    user = user.strip()
+                    if user:
+                        data_list.append((user,))
+
+    data_headers = ('User',)
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigIncoFollow.py
+++ b/scripts/artifacts/fbigIncoFollow.py
@@ -1,63 +1,51 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigIncoFollow(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-incoming_follow_requests"})
-            
-            control = 0
-            itemsdict = {}
-            lmf = []
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td"))
-                    tdvalue = ((str(tdvalue).split('<br/>')))
-                    
-            for x in tdvalue:
-                x = x.strip('<td>')
-                x = x.strip('</td>')
-                data_list.append((x,))
-        
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Incoming Follow Request - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Incoming Follow Request - {rfilename}')
-            report.add_script()
-            data_headers = ('User', )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Current Participants', 'Linked Media File'])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - Incoming Follow Request - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Incoming Follow Request - {rfilename}')
-                
-__artifacts__ = {
-        "fbigIncoFollow": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html'),
-            get_fbigIncoFollow)
+__artifacts_v2__ = {
+    "fbigIncoFollow": {
+        "name": "Facebook Instagram Returns - Incoming Follow Requests",
+        "description": "Incoming follow requests parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-06-30",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html'),
+        "output_types": "standard",
+        "artifact_icon": "user-plus",
+    }
 }
+
+import os
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def fbigIncoFollow(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        for section in soup.find_all('div', {'id': 'property-incoming_follow_requests'}):
+            for table in section.find_all('table'):
+                th = table.find('th')
+                td = th.find_next_sibling('td') if th else None
+                if not td:
+                    continue
+                for br in td.find_all('br'):
+                    br.replace_with('\n')
+                for user in td.get_text().split('\n'):
+                    user = user.strip()
+                    if user:
+                        data_list.append((user,))
+
+    data_headers = ('User',)
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Fifth **Facebook – Instagram Returns** batch — three **non-media** bs4 parsers.

| Artifact | Source | Columns |
|---|---|---|
| Following | property-following (records.html) | User |
| Incoming Follow Requests | property-incoming_follow_requests (index.html) | User |
| Devices | property-devices (index.html) | Type, ID, Active, User |

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`, dropped boilerplate + unused imports.
- `<br/>`-separated user lists now extracted via bs4 (replace `<br>` with newline, then split) instead of brittle `str(div)` tag stripping.

## 🐞 Bug fixes
- **fbigIncoFollow:** the original only processed the **LAST** table's `<td>` (the user loop sat *outside* the table loop) and used `x.strip('<td>')` — which strips **characters**, not the tag substring. Now every table's `<td>` is processed with proper text extraction. *(Verified: both users returned.)*
- **fbigDevices:** dropped the fragile `control < 4` counter (a hacky per-device delimiter); a device row is appended on its `Active` field with `Type`/`Id` reset, so values no longer carry between devices. *(Verified.)*

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean (Type/ID/Active/User); **PluginLoader** loads all (total 209); **synthetic-HTML functional test** for each.