### PR TITLE
Convert FB-Instagram Returns Account Info to LAVA + tag googleFi phone columns

### DIFF
--- a/scripts/artifacts/fbigAccountInfo.py
+++ b/scripts/artifacts/fbigAccountInfo.py
@@ -1,206 +1,86 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigAccountInfo(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    logfunc('Processing the request. This may take a few moments.')
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('records.html') or filename.startswith('preservation'):
-            rfilename = filename
-            
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'lxml')
-                
-            data_list =[]
-            uni = soup.find_all("div", {"id": "property-request_parameters"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                divinn = (div.find('div', class_='most_inner'))
-                divtext = (divinn.get_text())
-                if index == 0:
-                    data_list.append(('Service',divtext))
-                elif index == 1:
-                    data_list.append(('Target',divtext))
-                elif index == 2:
-                    data_list.append(('Account Identifier',divtext))
-                elif index == 3:
-                    data_list.append(('Account Type',divtext))
-                elif index == 4:
-                    data_list.append(('Meta Business Records Report Generated',divtext))
-                elif index == 5:
-                    data_list.append(('Meta Business Records Report Date Range',divtext))
-                else:
-                    data_list.append(('',divtext))
-                    
-                    
-                    
-                    
-            uni = soup.find_all("div", {"id": "property-name"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 1:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Name Provided by Account Holder',divtext))
-                    
-                    
-                    
-                    
-            uni = soup.find_all("div", {"id": "property-emails"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Registered Email Address',divtext))
-                    
-                    
-                    
-            uni = soup.find_all("div", {"id": "property-vanity"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Vanity Name',divtext))
-                    
-                    
-                    
-                    
-            uni = soup.find_all("div", {"id": "property-registration_date"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Account Registration/Creation Date',divtext))
-                    
-                    
-            uni = soup.find_all("div", {"id": "property-registration_ip"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Registration IP',divtext))
-                    
-                    
-                    
-            uni = soup.find_all("div", {"id": "property-account_end_date"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    if index == 2:
-                        data_list.append(('Account Still Active',divtext))
-                    else:
-                        data_list.append(('Account Data',divtext))
-                        
-                        
-            uni = soup.find_all("div", {"id": "property-phone_numbers"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Phone Number', divtext))
-            
-            
-            uni = soup.find_all("div", {"id": "property-privacy_settings"})
-            pairs_list = []
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 1:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    pairs_list.append(divtext)
-                    if len(pairs_list) == 2:
-                        data_list.append((pairs_list[0],pairs_list[1]))
-                        pairs_list = []
-            
-            uni = soup.find_all("div", {"id": "property-popular_block"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 1:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Blocked from showing media in Instagram explorer page', divtext))
-                    
-            uni = soup.find_all("div", {"id": "property-gender"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Gender', divtext))
-            
-            uni = soup.find_all("div", {"id": "property-date_of_birth"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Date of Birth', divtext))
-                    
-            uni = soup.find_all("div", {"id": "property-website"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 0:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    data_list.append(('Website', divtext))
-            
-            uni = soup.find_all("div", {"id": "property-profile_picture"})
-            
-            divs = uni[0].find_all('div', class_='div_table inner')
-            for index, div in enumerate(divs):
-                if index > 1:
-                    divinn = (div.find('div', class_='most_inner'))
-                    divtext = (divinn.get_text())
-                    thumb = media_to_html(divtext, files_found, report_folder)
-                    data_list.append(('Profile Picture',thumb))
-
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - Account and Report Information - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - Account and Report Information - {rfilename}')
-            report.add_script()
-            data_headers = ('Key','Value')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Value'])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - Account and Report  Information - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - Account and Report  Information - {rfilename}')
-                
-__artifacts__ = {
-        "fbigAccountInfo": (
-            "Facebook - Instagram Returns",
-            ('*/records.html', '*/preservation*.html', '*/linked_media/profile_picture_*.jpg'),
-            get_fbigAccountInfo)
+__artifacts_v2__ = {
+    "fbigAccountInfo": {
+        "name": "Facebook Instagram Returns - Account and Report Information",
+        "description": "Account and report information parsed from a Facebook/Instagram law enforcement return (records.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-01",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "Flat Key/Value table; date/phone values stay as raw text (the Value column is heterogeneous and can't be column-typed).",
+        "paths": ('*/records.html', '*/preservation*.html', '*/linked_media/profile_picture_*.jpg'),
+        "output_types": "standard",
+        "artifact_icon": "info",
+    }
 }
+
+import os
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, check_in_media
+
+
+def _texts(soup, prop_id, skip):
+    """(enumerate index, most_inner text) for each 'div_table inner' at/after `skip`."""
+    out = []
+    for section in soup.find_all('div', {'id': prop_id}):
+        for index, div in enumerate(section.find_all('div', class_='div_table inner')):
+            if index < skip:
+                continue
+            inner = div.find('div', class_='most_inner')
+            out.append((index, inner.get_text() if inner else ''))
+    return out
+
+
+@artifact_processor
+def fbigAccountInfo(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('records.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'lxml')
+
+        param_keys = ['Service', 'Target', 'Account Identifier', 'Account Type',
+                      'Meta Business Records Report Generated',
+                      'Meta Business Records Report Date Range']
+        for index, text in _texts(soup, 'property-request_parameters', 0):
+            data_list.append((param_keys[index] if index < len(param_keys) else '', text, None))
+
+        for _, text in _texts(soup, 'property-name', 2):
+            data_list.append(('Name Provided by Account Holder', text, None))
+        for _, text in _texts(soup, 'property-emails', 1):
+            data_list.append(('Registered Email Address', text, None))
+        for _, text in _texts(soup, 'property-vanity', 1):
+            data_list.append(('Vanity Name', text, None))
+        for _, text in _texts(soup, 'property-registration_date', 1):
+            data_list.append(('Account Registration/Creation Date', text, None))
+        for _, text in _texts(soup, 'property-registration_ip', 1):
+            data_list.append(('Registration IP', text, None))
+        for index, text in _texts(soup, 'property-account_end_date', 1):
+            data_list.append(('Account Still Active' if index == 2 else 'Account Data', text, None))
+        for _, text in _texts(soup, 'property-phone_numbers', 1):
+            data_list.append(('Phone Number', text, None))
+
+        pairs = [text for _, text in _texts(soup, 'property-privacy_settings', 2)]
+        for i in range(0, len(pairs) - 1, 2):
+            data_list.append((pairs[i], pairs[i + 1], None))
+
+        for _, text in _texts(soup, 'property-popular_block', 2):
+            data_list.append(('Blocked from showing media in Instagram explorer page', text, None))
+        for _, text in _texts(soup, 'property-gender', 1):
+            data_list.append(('Gender', text, None))
+        for _, text in _texts(soup, 'property-date_of_birth', 1):
+            data_list.append(('Date of Birth', text, None))
+        for _, text in _texts(soup, 'property-website', 1):
+            data_list.append(('Website', text, None))
+        for _, text in _texts(soup, 'property-profile_picture', 2):
+            data_list.append(('Profile Picture', text, check_in_media(text, text)))
+
+    data_headers = ('Key', 'Value', ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleFi_UserInfoRecords.py
+++ b/scripts/artifacts/googleFi_UserInfoRecords.py
@@ -55,8 +55,9 @@ def googleFi_UserInfoRecords(context):
                 entry[13].title(), entry[14].title(), entry[15].title(), entry[16].strip().title()))
 
     data_headers = (('Start Timestamp', 'datetime'), ('End Timestamp', 'datetime'),
-                    'User Phone Number', 'Usage Type', 'Direction', 'Duration (Minutes)',
-                    'Remote Phone Number', 'Equipment ID', 'Carrier', 'Network Carrier',
+                    ('User Phone Number', 'phonenumber'), 'Usage Type', 'Direction',
+                    'Duration (Minutes)', ('Remote Phone Number', 'phonenumber'),
+                    'Equipment ID', 'Carrier', 'Network Carrier',
                     ('Network Carrier Start Timestamp', 'datetime'), 'Is Wifi?', 'Is Hosted Voice?',
                     'Is Hangouts?', 'Is Voicemail?')
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Seventh **Facebook – Instagram Returns** batch — Account Info — **and** the folded-in googleFi `phonenumber` fix.

## fbigAccountInfo (Facebook – Instagram Returns)
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; date kept.
- Context form, `context.get_relative_path(source)`. Flat **Key/Value** table built from ~14 `property-*` sections via a small `_texts()` helper (robust to missing sections; the original indexed `uni[0]` and would `IndexError`).
- **Profile-picture media moved out of the heterogeneous `Value` cell into a dedicated `('Media','media')` column** via `check_in_media` (`None` for all non-picture rows).
- Note: date/phone values stay raw text — a Key/Value column can't be type-cast.

## googleFi (Google Takeout) — deferred fix, folded in here
Tagged **`User Phone Number`** and **`Remote Phone Number`** as `('Col','phonenumber')`. This completes the fix deferred from #296: RLEAPP **does** support the `phonenumber` type — it's a pass-through label (identical to iLEAPP/ALEAPP; the column stays `TEXT`, the LAVA viewer renders it). Verified both columns still `CREATE` cleanly.

*(AccountInfo's own phone data appears as Key/Value rows, not a dedicated column, so the type can't apply there — googleFi is the artifact with real phone columns, hence the bundling in this phone-themed batch.)*

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean (Key/Value/Media; googleFi phonenumber cols create cleanly); **PluginLoader** loads both (total 209); **functional test** of fbigAccountInfo (Key/Value rows incl. a phone row + profile-picture media in the dedicated Media column; media boundary stubbed).