### PR TITLE
Convert FB-Instagram Returns NCMEC Reports to LAVA (index.html aggregator + media)

### DIFF
--- a/scripts/artifacts/fbigNcmec.py
+++ b/scripts/artifacts/fbigNcmec.py
@@ -1,88 +1,98 @@
-import os
-import datetime
-import json
-import shutil
-from bs4 import BeautifulSoup
-from pathlib import Path	
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, kmlgen, is_platform_windows, utf8_in_extended_ascii, media_to_html
-
-def get_fbigNcmec(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-    
-        if filename.startswith('index.html') or filename.startswith('preservation'):
-            rfilename = filename
-            file_to_report_data = file_found
-            data_list = []
-            with open(file_found, encoding='utf-8') as fp:
-                soup = BeautifulSoup(fp, 'html.parser')
-            #<div id="property-unified_messages" class="content-pane">
-                
-            uni = soup.find_all("div", {"id": "property-ncmec_reports"})
-            
-            control = 0
-            agg = ''
-            
-            for x in uni:
-                tables = x.find_all("table")
-                
-                for table in tables:
-                    
-                    
-                    thvalue = (table.find('th').get_text())
-                    tdvalue = (table.find('th').find_next_sibling("td").get_text())
-                    thvalue = str(thvalue)
-                    tdvalue = str(tdvalue)
-                    
-                    
-                    if thvalue == 'Ncmec Reports Definition':
-                        pass
-                    elif thvalue == 'NCMEC Cybertips':
-                        pass
-                    elif thvalue == 'Media uploaded in this cybertip':
-                        pass
-                    elif thvalue == 'CyberTip ID':
-                        if control == 0:
-                            cybertipid = tdvalue
-                            control = 1
-                        else:
-                            data_list.append((time,cybertipid,resid,agg))
-                            agg  = ''
-                            cybertipid = tdvalue
-                    elif thvalue == 'Time':
-                        time = tdvalue
-                    elif thvalue == 'Responsible Id':
-                        resid = tdvalue
-                    else:
-                        if thvalue == 'Linked Media File:':
-                            media = tdvalue.split('/')[1]
-                            tdvalue = media_to_html(media,files_found, report_folder)
-                        agg = agg + f'{thvalue} {tdvalue} <br>'
-                        
-                data_list.append((time,cybertipid,resid,agg))
-                
-        if data_list:
-            report = ArtifactHtmlReport(f'Facebook & Instagram - NECMEC Reports - {rfilename}')
-            report.start_artifact_report(report_folder, f'Facebook Instagram - NECMEC Reports - {rfilename}')
-            report.add_script()
-            data_headers = ('Time','CyberTip ID','Responsible ID','Data' )
-            report.write_artifact_data_table(data_headers, data_list, file_to_report_data, html_no_escape=['Data'])
-            report.end_artifact_report()
-            
-            tsvname = f'Facebook Instagram - NECMEC Reports - {rfilename}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-        
-        else:
-            logfunc(f'No Facebook Instagram - NECMEC Reports - {rfilename}')
-                
-__artifacts__ = {
-        "fbigNcmec": (
-            "Facebook - Instagram Returns",
-            ('*/index.html', '*/preservation*.html', '*/linked_media/ncmec_reports_*'),
-            get_fbigNcmec)
+__artifacts_v2__ = {
+    "fbigNcmec": {
+        "name": "Facebook Instagram Returns - NCMEC Reports",
+        "description": "NCMEC CyberTip reports parsed from a Facebook/Instagram law enforcement return (index.html / preservation).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-01",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Facebook - Instagram Returns",
+        "notes": "",
+        "paths": ('*/index.html', '*/preservation*.html', '*/linked_media/ncmec_reports_*'),
+        "output_types": "standard",
+        "html_columns": ["Data"],
+        "artifact_icon": "alert-triangle",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+_SKIP_LABELS = ('Ncmec Reports Definition', 'NCMEC Cybertips', 'Media uploaded in this cybertip')
+
+
+def _fbig_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+    except ValueError:
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def fbigNcmec(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if not (basename.startswith('index.html') or basename.startswith('preservation')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            soup = BeautifulSoup(fp, 'html.parser')
+
+        for section in soup.find_all('div', {'id': 'property-ncmec_reports'}):
+            cybertip_id = time_val = resid = ''
+            agg_parts = []
+            media_refs = []
+            started = False
+            for table in section.find_all('table'):
+                th = table.find('th')
+                if not th:
+                    continue
+                label = th.get_text()
+                if label in _SKIP_LABELS:
+                    continue
+                td = th.find_next_sibling('td')
+                value = td.get_text() if td else ''
+                if label == 'CyberTip ID':
+                    if started:
+                        data_list.append((_fbig_ts(time_val), cybertip_id, resid,
+                                          '<br>'.join(agg_parts), media_refs))
+                        cybertip_id = time_val = resid = ''
+                        agg_parts = []
+                        media_refs = []
+                    started = True
+                    cybertip_id = value
+                elif label == 'Time':
+                    time_val = value
+                elif label == 'Responsible Id':
+                    resid = value
+                elif label == 'Linked Media File:':
+                    media_name = value.split('/')[1] if '/' in value else value
+                    ref = check_in_media(media_name, media_name)
+                    if ref:
+                        media_refs.append(ref)
+                    agg_parts.append(f'Linked Media File: {value}')
+                else:
+                    agg_parts.append(f'{label} {value}')
+            if started:
+                data_list.append((_fbig_ts(time_val), cybertip_id, resid,
+                                  '<br>'.join(agg_parts), media_refs))
+
+    data_headers = (('Time', 'datetime'), 'CyberTip ID', 'Responsible ID', 'Data',
+                    ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Eighth **Facebook – Instagram Returns** batch — NCMEC CyberTip reports (index.html aggregator with linked media).

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; date kept.
- Context form, `context.get_relative_path(source)`.
- **`media_to_html` → `check_in_media`:** media is pulled **out** of the aggregated `Data` HTML blob into a dedicated `('Media','media')` column (a list of refs per CyberTip); the linked-media filename is still listed in `Data` for reference.
- `Data` is now a clean `label value<br>` aggregate (`html_columns`).
- `Time` → aware UTC via best-effort `_fbig_ts`.

## 🐞 Bug fix
`Time` / `CyberTip ID` / `Responsible ID` (and the aggregate/media) **leaked** across CyberTips — only `agg` was reset on a new `CyberTip ID`, so an entry missing a field displayed the previous CyberTip's value; the trailing unconditional append could also reference undefined vars. Now every field resets per CyberTip and a tracked final flush only emits started records. *(Verified: a 2nd CyberTip with no Time/media comes back empty, not the 1st's values.)*

Read-only: resolves `linked_media` files by name (no disk writes).

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean; **PluginLoader** loads (total 209); **synthetic-HTML functional test** (two CyberTips) asserting Time→UTC, media in its own column, clean Data, and no field leak (media boundary stubbed).