### PR TITLE
Convert Snapchat Returns Story + Reported Conversations to LAVA (multiline CSV + media)

### DIFF
--- a/scripts/artifacts/snapRepconN.py
+++ b/scripts/artifacts/snapRepconN.py
@@ -1,135 +1,83 @@
-import os
-import datetime
+__artifacts_v2__ = {
+    "snapRepconN": {
+        "name": "Snapchat - Reported Conversations",
+        "description": "Reported conversations parsed from a Snapchat law enforcement return (reported_conversations.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2024-06-13",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/reported_conversations.csv', '*/*.*'),
+        "output_types": "standard",
+        "artifact_icon": "flag",
+    }
+}
+
 import csv
-import traceback
+import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
-def monthletter(month):
-    monthdict = {'Jan': '01', 'Feb': '02', 'Mar': '03', 'Apr': '04', 'May': '05', 'Jun': '06', 'Jul': '07', 'Aug': '08', 'Sep': '09', 'Oct': '10', 'Nov': '11', 'Dec': '12'}
-    return monthdict[month]
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
-def read_multiline_csv(file_path):
+
+def _snap_ts(value):
+    parts = (value or '').split(' ')
+    try:
+        return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _read_multiline_csv(file_path):
     rows = []
-    start_adding = False
-    with open(file_path, 'r', newline='', encoding='utf-8') as csvfile:
-        reader = csv.reader(csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL)
-        for row in reader:
-            if start_adding:
+    start = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if start:
                 rows.append(row)
             elif '===========================' in row:
-                start_adding = True
+                start = True
     return rows
 
 
-def get_snapRepconN(files_found, report_folder, seeker, wrap_text):
+@artifact_processor
+def snapRepconN(context):
+    ts_idx, msg_ts_idx, media_idx = 15, 8, 13
+    data_headers = (('Timestamp', 'datetime'), 'Reporter_user_id', 'Reason', 'Context',
+                    'Reported_user_id', 'Reported_profile_type', 'Conversation_id',
+                    'Reported_message_id', ('Message_timestamp', 'datetime'), 'Message_id',
+                    'Sender_user_id', 'Sender_username', 'Text', 'Media_id', 'Reply_to_message_id',
+                    'Message_type', ('Media', 'media'))
+    non_media = len(data_headers) - 1
 
-    for file_found in files_found:
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        data_list_f = []
-        
-        if filename.startswith('reported_conversations.csv'):
-            csv_rows = read_multiline_csv(file_found)
+        if not os.path.basename(file_found).startswith('reported_conversations.csv'):
+            continue
+        source_path = file_found
+        rows = _read_multiline_csv(file_found)
+        for raw in rows[1:]:
+            if len(raw) <= ts_idx:
+                continue
+            entry = list(raw)
+            entry.insert(0, _snap_ts(entry[ts_idx]))
+            del entry[ts_idx + 1]
+            if len(entry) > msg_ts_idx:
+                entry[msg_ts_idx] = _snap_ts(entry[msg_ts_idx])
+            media_raw = entry[media_idx] if len(entry) > media_idx else ''
+            media_parts = media_raw.split(':')
+            media_val = media_parts[1] if len(media_parts) > 1 else media_raw
+            refs = [r for r in (check_in_media(m.strip(), m.strip())
+                                for m in media_val.split(';') if m.strip()) if r]
+            entry = (entry + [''] * non_media)[:non_media]
+            entry.append(refs)
+            data_list.append(entry)
 
-            data_list_f = []
-            try:
-                header = csv_rows[0]
-            
-                timestamp = header[15]
-                header.insert(0,timestamp)
-                del header[15]
-    
-                data_list = csv_rows[1:]
-                for entry in data_list:
-                    
-                    #Change timestamp format
-                    timestamp = entry[15]
-                    timestamp = timestamp.split(' ')
-                    year = timestamp[5]
-                    day = timestamp[2]
-                    time = timestamp[3]
-                    month = monthletter(timestamp[1])
-                    timestampfinal = (f'{year}-{month}-{day} {time}')
-                    
-                    #Move timestamp to the front of the list and delete the original positon
-                    entry.insert(0, timestampfinal)
-                    del entry[16]
-                    
-                    timestamp = entry[8]
-                    timestamp = timestamp.split(' ')
-                    year = timestamp[5]
-                    day = timestamp[2]
-                    time = timestamp[3]
-                    month = monthletter(timestamp[1])
-                    timestampfinal = (f'{year}-{month}-{day} {time}')
-                    
-                    entry[8] = timestampfinal
-                    #Look for media and substitute it in the list
-                    
-                    media = entry[13]
-                    
-                    media = media.split(':')[1]
-                    if media == '':
-                        agregator = ''
-                    else:
-                        if ';' in media:
-                            media = media.split(';')
-                            agregator = '<table>'
-                            counter = 0
-                            for x in media:
-                                if counter == 0:
-                                    agregator = agregator + ('<tr>')
-                                thumb = media_to_html(x, files_found, report_folder)        
-                                
-                                counter = counter + 1
-                                agregator = agregator + f'<td>{thumb}</td>'
-                                #hacer uno que no tenga html
-                                if counter == 2:
-                                    counter = 0
-                                    agregator = agregator + ('</tr>')
-                            if counter == 1:
-                                agregator = agregator + ('</tr>')
-                            agregator = agregator + ('</table><br>')
-                        else:
-                            agregator = media_to_html(media, files_found, report_folder)
-                    entry[13] = agregator
-                    #Add to the final list for reporting
-                    
-                    data_list_f.append(entry)
-            except:
-                pass
-                    
-                    
-            if data_list_f:
-                report = ArtifactHtmlReport(f'Snapchat - Reported Conversations')
-                report.start_artifact_report(report_folder, f'Snapchat - Reported Conversations - {username}')
-                report.add_script()
-                data_headers = ('Timestamp', 'Reporter_user_id', 'Reason', 'Context', 'Reported_user_id', 'Reported_profile_type', 'Conversation_id', 'Reported_message_id', 'Message_timestamp', 'Message_id', 'Sender_user_id', 'Sender_username', 'Text', 'Media_id', 'Reply_to_message_id', 'Message_type')
-                report.write_artifact_data_table(data_headers, data_list_f, file_found, html_no_escape=['Media_id'])#
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Reported Conversations - {username}'
-                tsv(report_folder, data_headers, data_list_f, tsvname)
-                
-                tlactivity = f'Snapchat - Reported Conversations - {username}'
-                timeline(report_folder, tlactivity, data_list_f, data_headers)
-
-                
-            else:
-                logfunc(f'No Snapchat - Reported Conversations - {username}')
-            
-            data_list_f = []
-        
-        
-__artifacts__ = {
-        "snapRepconN": (
-            "Snapchat Returns",
-            ('*/reported_conversations.csv','*/*.*'),
-            get_snapRepconN)
-}
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapStoryN.py
+++ b/scripts/artifacts/snapStoryN.py
@@ -1,123 +1,76 @@
-import os
-import datetime
+__artifacts_v2__ = {
+    "snapStoryN": {
+        "name": "Snapchat - Story",
+        "description": "Story entries parsed from a Snapchat law enforcement return (story.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2024-06-13",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/story.csv', '*/*.*'),
+        "output_types": "standard",
+        "artifact_icon": "book-open",
+    }
+}
+
 import csv
-import traceback
+import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
-def monthletter(month):
-    monthdict = {'Jan': '01', 'Feb': '02', 'Mar': '03', 'Apr': '04', 'May': '05', 'Jun': '06', 'Jul': '07', 'Aug': '08', 'Sep': '09', 'Oct': '10', 'Nov': '11', 'Dec': '12'}
-    return monthdict[month]
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
-def read_multiline_csv(file_path):
+
+def _snap_ts(value):
+    parts = (value or '').split(' ')
+    try:
+        return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _read_multiline_csv(file_path):
     rows = []
-    start_adding = False
-    with open(file_path, 'r', newline='', encoding='utf-8') as csvfile:
-        reader = csv.reader(csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL)
-        for row in reader:
-            if start_adding:
+    start = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if start:
                 rows.append(row)
             elif '===========================' in row:
-                start_adding = True
+                start = True
     return rows
 
 
-def get_snapStoryN(files_found, report_folder, seeker, wrap_text):
+@artifact_processor
+def snapStoryN(context):
+    ts_idx, media_idx = 6, 2
+    data_headers = (('Timestamp', 'datetime'), 'ID', 'Media_id', 'Username', 'Media_type', 'Time',
+                    'Filter_id', 'Upload_ip', 'Source_port_number', ('Media', 'media'))
+    non_media = len(data_headers) - 1
 
-    for file_found in files_found:
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        data_list_f = []
-        
-        if filename.startswith('story.csv'):
-            csv_rows = read_multiline_csv(file_found)
+        if not os.path.basename(file_found).startswith('story.csv'):
+            continue
+        source_path = file_found
+        rows = _read_multiline_csv(file_found)
+        for raw in rows[1:]:
+            if len(raw) <= ts_idx:
+                continue
+            entry = list(raw)
+            entry.insert(0, _snap_ts(entry[ts_idx]))
+            del entry[ts_idx + 1]
+            media_raw = entry[media_idx] if len(entry) > media_idx else ''
+            refs = [r for r in (check_in_media(m.strip(), m.strip())
+                                for m in media_raw.split(';') if m.strip()) if r]
+            entry = (entry + [''] * non_media)[:non_media]
+            entry.append(refs)
+            data_list.append(entry)
 
-            data_list_f = []
-            try:
-                header = csv_rows[0]
-            
-                timestamp = header[6]
-                header.insert(0,timestamp)
-                del header[7]
-    
-                data_list = csv_rows[1:]
-                for entry in data_list:
-                    
-                    #Change timestamp format
-                    timestamp = entry[6]
-                    timestamp = timestamp.split(' ')
-                    year = timestamp[5]
-                    day = timestamp[2]
-                    time = timestamp[3]
-                    month = monthletter(timestamp[1])
-                    timestampfinal = (f'{year}-{month}-{day} {time}')
-                    
-                    #Move timestamp to the front of the list and delete the original positon
-                    entry.insert(0, timestampfinal)
-                    del entry[7]
-                    
-                    
-                    #Look for media and substitute it in the list
-                    
-                    media = entry[2]
-                    if media == '':
-                        agregator = ''
-                    else:
-                        if ';' in media:
-                            media = media.split(';')
-                            agregator = '<table>'
-                            counter = 0
-                            for x in media:
-                                if counter == 0:
-                                    agregator = agregator + ('<tr>')
-                                thumb = media_to_html(x, files_found, report_folder)        
-                                
-                                counter = counter + 1
-                                agregator = agregator + f'<td>{thumb}</td>'
-                                #hacer uno que no tenga html
-                                if counter == 2:
-                                    counter = 0
-                                    agregator = agregator + ('</tr>')
-                            if counter == 1:
-                                agregator = agregator + ('</tr>')
-                            agregator = agregator + ('</table><br>')
-                        else:
-                            agregator = media_to_html(media, files_found, report_folder)
-                    entry[2] = agregator
-                    #Add to the final list for reporting
-                    
-                    data_list_f.append(entry)
-            except:
-                pass
-                    
-                    
-            if data_list_f:
-                report = ArtifactHtmlReport(f'Snapchat - Story')
-                report.start_artifact_report(report_folder, f'Snapchat - Story - {username}')
-                report.add_script()
-                data_headers = ('Timestamp', 'ID', 'Media_id', 'Username', 'Media_type', 'Time', 'Filter_id', 'Upload_ip', 'Source_port_number')
-                report.write_artifact_data_table(data_headers, data_list_f, file_found, html_no_escape=['Media_id'])#
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Story - {username}'
-                tsv(report_folder, data_headers, data_list_f, tsvname)
-                
-                tlactivity = f'Snapchat - Story - {username}'
-                timeline(report_folder, tlactivity, data_list_f, data_headers)
-
-            else:
-                logfunc(f'No Snapchat - Story - {username}')
-            
-            data_list_f = []
-        
-__artifacts__ = {
-        "snapStoryN": (
-            "Snapchat Returns",
-            ('*/story.csv','*/*.*'),
-            get_snapStoryN)
-}
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Second **Snapchat Returns** batch — same `=====`-multiline-CSV + media pattern as #314.

| Artifact | Source |
|---|---|
| Story | story.csv |
| Reported Conversations | reported_conversations.csv |

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`.
- Snapchat timestamps → aware UTC via `_snap_ts`; moved to the first column.
- **`media_to_html` → `check_in_media`** into a dedicated `('Media','media')` column; raw `Media_id` kept.
- Replaced the bare `except: pass` with length guards + header-width padding.

## Reported Conversations specifics
- **Two timestamps:** primary `Timestamp` **and** `Message_timestamp` (both → aware UTC).
- `Media_id` is `prefix:value` form; the value after the first `:` is split on `;` for `check_in_media` (guarded against the original's `IndexError` on empty media).

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + dup audit clean (Context/Reason/Time/Text all OK); **PluginLoader** loads both (total 210); **synthetic multiline-CSV functional test** asserting UTC timestamps (two for Repcon), the media split, and Media_id kept raw (media boundary stubbed).