### PR TITLE
Convert Snapchat Returns IP Data, Inc Comms, Location Privacy Settings to LAVA

### DIFF
--- a/scripts/artifacts/snapIPd.py
+++ b/scripts/artifacts/snapIPd.py
@@ -1,129 +1,73 @@
+__artifacts_v2__ = {
+    "snapIPd": {
+        "name": "Snapchat - IP Data",
+        "description": "IP data parsed from a Snapchat law enforcement return (ip_data.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2024-06-13",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/ip_data.csv',),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+    }
+}
+
 import os
-import datetime
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
+from scripts.ilapfuncs import artifact_processor
 
-def monthletter(month):
-    monthdict = {'Jan': '01', 'Feb': '02', 'Mar': '03', 'Apr': '04', 'May': '05', 'Jun': '06', 'Jul': '07', 'Aug': '08', 'Sep': '09', 'Oct': '10', 'Nov': '11', 'Dec': '12'}
-    return monthdict[month]
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
-def clean_and_group_data(input_data):
-    # Split the input data into lines
-    lines = input_data.split('\n')
-    
-    # Initialize variables to track whether we are in a section to exclude
-    exclude = False
-    grouped_data = []
-    current_section = []
-    
-    for line in lines:
-        # Check if the line contains dashes or equal signs
+
+def _snap_ts(value):
+    parts = (value or '').split(' ')
+    try:
+        return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _clean_and_group(input_data):
+    sections, current, exclude = [], [], False
+    for line in input_data.split('\n'):
         if line.startswith('---') or line.startswith('==='):
             exclude = not exclude
-            if not exclude:
-                # End of an excluded section, start a new section
-                if current_section:
-                    grouped_data.append(current_section)
-                    current_section = []
+            if not exclude and current:
+                sections.append(current)
+                current = []
             continue
-        
-        # Add the line to current_section if we are not in an excluded section
         if not exclude and line.strip():
-            current_section.append(line.strip())
-            
-    # Add the last section to the grouped data if it exists
-    if current_section:
-        grouped_data.append(current_section)
-        
-    return grouped_data
+            current.append(line.strip())
+    if current:
+        sections.append(current)
+    return sections
 
-def get_snapIPd(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def snapIPd(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        data_list2 = []
-        
-        if filename.startswith('ip_data.csv'):
-            with open(file_found) as f:
-                input_data = f.read() 
-                
-            # Run the cleaning and grouping function
-            grouped_data = clean_and_group_data(input_data)
-            
-            for x in grouped_data:
-                data_list = []
-                header = x[0]
-            
-                for y in x[1:]:
-                    item = y.strip().split(',')
-                    data_list.append(item)
-            
-                    
-                if header.startswith('"Target username "'):
-                    header1 = list((header,''))
-                    data_list1 = data_list
-                elif header.startswith('ip,first seen time,last seen time'):
-                    header = header.strip().split(',')
-                    header2 = header
-                    header2[0]='IP'
-                    header2[1]='First Seen Time'
-                    header2[2]='Last Seen Time'
-                    
-                    data_list2 = data_list
-                    for x in data_list2:
-                        if x[1] == '':
-                            pass
-                        else:
-                            timestamp = x[1].split(' ')
-                            year = timestamp[5]
-                            day = timestamp[2]
-                            time = timestamp[3]
-                            month = monthletter(timestamp[1])
-                            timestampfinal = (f'{year}-{month}-{day} {time}')
-                            x[1] = timestampfinal
-                            
-                        if x[2] == '':
-                            pass
-                        else:
-                            timestamp = x[2].split(' ')
-                            year = timestamp[5]
-                            day = timestamp[2]
-                            time = timestamp[3]
-                            month = monthletter(timestamp[1])
-                            timestampfinal = (f'{year}-{month}-{day} {time}')
-                            x[2] = timestampfinal
-                            
-                        
-                    
-        if len(data_list2):
-            report = ArtifactHtmlReport(f'Snapchat - IP Data')
-            report.start_artifact_report(report_folder, f'Snapchat - IP Data - {username}')
-            report.add_script()
-            #data_headers = ('Timestamp','Username','Name','Registration IP','Country','Phone Number','Carrier')
-            report.write_artifact_data_table(header2, data_list2, file_found, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-            tsvname = f'Snapchat - IP Data - {username}'
-            tsv(report_folder, header2, data_list2, tsvname)
-            
-            tlactivity = f'Snapchat - IP Data - {username}'
-            timeline(report_folder, tlactivity, data_list2, header2)
-            
-            
-        else:
-            logfunc(f'No Snapchat - IP Data - {username}')
-        
-        data_list2 = []
-    
-__artifacts__ = {
-        "snapIPd": (
-            "Snapchat Returns",
-            ('*/ip_data.csv'),
-            get_snapIPd)
-}
+        if not os.path.basename(file_found).startswith('ip_data.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            for section in _clean_and_group(f.read()):
+                if not section[0].startswith('ip,first seen time,last seen time'):
+                    continue
+                for line in section[1:]:
+                    item = line.strip().split(',')
+                    if len(item) < 3:
+                        continue
+                    first_seen = _snap_ts(item[1]) if item[1] else ''
+                    last_seen = _snap_ts(item[2]) if item[2] else ''
+                    data_list.append((item[0], first_seen, last_seen))
+
+    data_headers = ('IP', ('First Seen Time', 'datetime'), ('Last Seen Time', 'datetime'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapIncCom.py
+++ b/scripts/artifacts/snapIncCom.py
@@ -1,132 +1,75 @@
-import os
-import datetime
+__artifacts_v2__ = {
+    "snapIncCom": {
+        "name": "Snapchat - Inc Comms",
+        "description": "Incoming communications parsed from a Snapchat law enforcement return (snap_inc_communications.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2024-06-13",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/snap_inc_communications.csv',),
+        "output_types": "standard",
+        "artifact_icon": "mail",
+    }
+}
+
 import csv
+import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
+from scripts.ilapfuncs import artifact_processor
 
-def monthletter(month):
-    monthdict = {'Jan': '01', 'Feb': '02', 'Mar': '03', 'Apr': '04', 'May': '05', 'Jun': '06', 'Jul': '07', 'Aug': '08', 'Sep': '09', 'Oct': '10', 'Nov': '11', 'Dec': '12'}
-    return monthdict[month]
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
-def clean_and_group_data(input_data):
-    # Split the input data into lines
-    lines = input_data.split('\n')
-    
-    # Initialize variables to track whether we are in a section to exclude
-    exclude = False
-    grouped_data = []
-    current_section = []
-    
-    for line in lines:
-        # Check if the line contains dashes or equal signs
+
+def _snap_ts(value):
+    parts = (value or '').split(' ')
+    try:
+        return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _clean_and_group(input_data):
+    sections, current, exclude = [], [], False
+    for line in input_data.split('\n'):
         if line.startswith('---') or line.startswith('==='):
             exclude = not exclude
-            if not exclude:
-                # End of an excluded section, start a new section
-                if current_section:
-                    grouped_data.append(current_section)
-                    current_section = []
+            if not exclude and current:
+                sections.append(current)
+                current = []
             continue
-        
-        # Add the line to current_section if we are not in an excluded section
         if not exclude and line.strip():
-            current_section.append(line.strip())
-            
-    # Add the last section to the grouped data if it exists
-    if current_section:
-        grouped_data.append(current_section)
-        
-    return grouped_data
+            current.append(line.strip())
+    if current:
+        sections.append(current)
+    return sections
 
-def get_snapIncCom(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def snapIncCom(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        data_list2 = []
-        
-        if filename.startswith('snap_inc_communications.csv'):
-            with open(file_found) as f:
-                input_data = f.read() 
-                
-            # Run the cleaning and grouping function
-            grouped_data = clean_and_group_data(input_data)
-            
-            for x in grouped_data:
-                data_list = []
-                header = x[0]
-            
-                for y in x[1:]:
-                    for item in csv.reader([y], skipinitialspace=True):
-                        data_list.append(item)
-            
-                    
-                if header.startswith('"Target username "'):
-                    header1 = list((header,''))
-                    data_list1 = data_list
-                elif header.startswith('user_id,email_address,user_agent,campaign_name,type,event_timestamp'):
-                    header = header.strip().split(',')
-                    header2 = header
-                    header2[0]='Timestamp'
-                    header2[1]='User ID'
-                    header2[2]='Email Address'
-                    header2[3]='User Agent'
-                    header2[4]='Campaign Name'
-                    header2[5]='Type'
-                    
-                    data_list2 = data_list
-                    for x in data_list2:
-                        timestamp = x[5].split(' ')
-                        year = timestamp[5]
-                        day = timestamp[2]
-                        time = timestamp[3]
-                        month = monthletter(timestamp[1])
-                        timestampfinal = (f'{year}-{month}-{day} {time}')
-                        
-                        userid = x[0]
-                        emailad = x[1]
-                        usera = x[2]
-                        cn = x[3]
-                        typ = x[4]
-                        
-                        x[0] = timestampfinal
-                        x[1] = userid
-                        x[2] = emailad
-                        x[3] = usera
-                        x[4] = cn
-                        x[5] = typ
-                            
-                            
-                        
-                    
-        if len(data_list2):
-            report = ArtifactHtmlReport(f'Snapchat - Inc Comms')
-            report.start_artifact_report(report_folder, f'Snapchat - Inc Comms - {username}')
-            report.add_script()
-            #data_headers = ('Timestamp','Username','Name','Registration IP','Country','Phone Number','Carrier')
-            report.write_artifact_data_table(header2, data_list2, file_found, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-            tsvname = f'Snapchat - Inc Comms - {username}'
-            tsv(report_folder, header2, data_list2, tsvname)
-            
-            tlactivity = f'Snapchat - Inc Comms - {username}'
-            timeline(report_folder, tlactivity, data_list2, header2)
-            
-            
-        else:
-            logfunc(f'No Snapchat - Inc Comms - {username}')
-        
-        data_list2 = []
-        
-__artifacts__ = {
-        "snapIncCom": (
-            "Snapchat Returns",
-            ('*/snap_inc_communications.csv'),
-            get_snapIncCom)
-}
+        if not os.path.basename(file_found).startswith('snap_inc_communications.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            for section in _clean_and_group(f.read()):
+                if not section[0].startswith('user_id,email_address,user_agent,campaign_name,type,event_timestamp'):
+                    continue
+                for line in section[1:]:
+                    rows = list(csv.reader([line], skipinitialspace=True))
+                    if not rows or len(rows[0]) < 6:
+                        continue
+                    x = rows[0]
+                    # source order: user_id, email, user_agent, campaign, type, event_timestamp
+                    data_list.append((_snap_ts(x[5]), x[0], x[1], x[2], x[3], x[4]))
+
+    data_headers = (('Timestamp', 'datetime'), 'User ID', 'Email Address', 'User Agent',
+                    'Campaign Name', 'Type')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapLocprivsets.py
+++ b/scripts/artifacts/snapLocprivsets.py
@@ -1,114 +1,73 @@
+__artifacts_v2__ = {
+    "snapLocprivsets": {
+        "name": "Snapchat - Location Privacy Settings",
+        "description": "Location privacy settings parsed from a Snapchat law enforcement return (loc_priv_sets.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2024-06-13",
+        "last_update_date": "2026-06-27",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/loc_priv_sets.csv',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin",
+    }
+}
+
 import os
-import datetime
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def monthletter(month):
-    monthdict = {'Jan': '01', 'Feb': '02', 'Mar': '03', 'Apr': '04', 'May': '05', 'Jun': '06', 'Jul': '07', 'Aug': '08', 'Sep': '09', 'Oct': '10', 'Nov': '11', 'Dec': '12'}
-    return monthdict[month]
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
-def clean_and_group_data(input_data):
-    # Split the input data into lines
-    lines = input_data.split('\n')
-    
-    # Initialize variables to track whether we are in a section to exclude
-    exclude = False
-    grouped_data = []
-    current_section = []
-    
-    for line in lines:
-        # Check if the line contains dashes or equal signs
+
+def _snap_ts(value):
+    parts = (value or '').split(' ')
+    try:
+        return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _clean_and_group(input_data):
+    sections, current, exclude = [], [], False
+    for line in input_data.split('\n'):
         if line.startswith('---') or line.startswith('==='):
             exclude = not exclude
-            if not exclude:
-                # End of an excluded section, start a new section
-                if current_section:
-                    grouped_data.append(current_section)
-                    current_section = []
+            if not exclude and current:
+                sections.append(current)
+                current = []
             continue
-        
-        # Add the line to current_section if we are not in an excluded section
         if not exclude and line.strip():
-            current_section.append(line.strip())
-            
-    # Add the last section to the grouped data if it exists
-    if current_section:
-        grouped_data.append(current_section)
-        
-    return grouped_data
+            current.append(line.strip())
+    if current:
+        sections.append(current)
+    return sections
 
-def get_snapLocprivsets(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def snapLocprivsets(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        data_list2 = []
-        
-        if filename.startswith('loc_priv_sets.csv'):
-            with open(file_found) as f:
-                input_data = f.read() 
-                
-            # Run the cleaning and grouping function
-            grouped_data = clean_and_group_data(input_data)            
-            
-            for x in grouped_data:
-                data_list = []
-                header = x[0]
-                
-                for y in x[1:]:
-                    item = y.strip().split(',')
-                    data_list.append(item)
-                    
-                    
-                if header.startswith('timestamp,audience,allowlist,blocklist,ghost_mode,ghost_mode_expiration,live_session_ids,live_session_expirations'):
-                    header = header.strip().split(',')
-                    header2 = header
-                    header2[0]='Timestamp'
-                    header2[1]='Audience'
-                    header2[2]='Allow List'
-                    header2[3]='Block List'
-                    header2[4]='Ghost Mode'
-                    header2[5]='Ghost Mode Expiration'
-                    header2[6]='Live Session IDS'
-                    header2[7]='Live Session Expirations'
-                    data_list2 = data_list
-                    for x in data_list2:
-                        timestamp = x[0].split(' ')
-                        year = timestamp[5]
-                        day = timestamp[2]
-                        time = timestamp[3]
-                        month = monthletter(timestamp[1])
-                        timestampfinal = (f'{year}-{month}-{day} {time}')
-                        x[0] = timestampfinal
-                        
-                    
-        if len(data_list2):
-            report = ArtifactHtmlReport(f'Snapchat - Location Privacy Settings')
-            report.start_artifact_report(report_folder, f'Snapchat - Location Privacy Settings - {username}')
-            report.add_script()
-            #data_headers = ('Timestamp','Username','Name','Registration IP','Country','Phone Number','Carrier')
-            report.write_artifact_data_table(header2, data_list2, file_found, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-            tsvname = f'Snapchat - Location Privacy Settings - {username}'
-            tsv(report_folder, header2, data_list2, tsvname)
-            
-            tlactivity = f'Snapchat - Location Privacy Settings - {username}'
-            timeline(report_folder, tlactivity, data_list2, header2)
-            
-        else:
-            logfunc(f'No Snapchat - Location Privacy Settings - {username}')
-            
-        data_list2 = []
-    
-__artifacts__ = {
-        "snapLocprivsets": (
-            "Snapchat Returns",
-            ('*/loc_priv_sets.csv'),
-            get_snapLocprivsets)
-}
+        if not os.path.basename(file_found).startswith('loc_priv_sets.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            for section in _clean_and_group(f.read()):
+                if not section[0].startswith('timestamp,audience,allowlist,blocklist,ghost_mode'):
+                    continue
+                for line in section[1:]:
+                    item = line.strip().split(',')
+                    if len(item) < 8:
+                        continue
+                    data_list.append((_snap_ts(item[0]), item[1], item[2], item[3], item[4],
+                                      item[5], item[6], item[7]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Audience', 'Allow List', 'Block List', 'Ghost Mode',
+                    'Ghost Mode Expiration', 'Live Session IDS', 'Live Session Expirations')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Third **Snapchat Returns** batch — three **sectioned-CSV** parsers (the `---`/`===` delimited format, `clean_and_group_data`).

| Artifact | Source | Timestamps |
|---|---|---|
| IP Data | ip_data.csv | First Seen + Last Seen |
| Inc Comms | snap_inc_communications.csv | event_timestamp |
| Location Privacy Settings | loc_priv_sets.csv | timestamp |

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`.
- Snapchat timestamps → aware UTC via `_snap_ts` (IP Data both timestamps, empty-guarded; Inc Comms keeps the original's field reorder; Loc Priv the single timestamp).
- Added row length guards.

## Note
**No media or phone columns** — the `Phone Number` references in the originals were a **commented-out template line**, not real output. (The `phonenumber` type will apply to Subinfo/Geo if those carry real phone columns.)

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean; **PluginLoader** loads all (total 210); **synthetic sectioned-CSV functional test** asserting UTC timestamps and the Inc Comms field reorder.