### PR TITLE
Convert 5 iCloud Returns xlsx artifacts to LAVA (+ fix broken xlrd parsing)

### DIFF
--- a/scripts/artifacts/icloudBookmarks.py
+++ b/scripts/artifacts/icloudBookmarks.py
@@ -1,82 +1,75 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudBookmarks(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 5:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 6:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 6:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            report = ArtifactHtmlReport('iCloud - Bookmarks')
-            report.start_artifact_report(report_folder, 'iCloud - Bookmarks', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - Bookmarks data available')
-            
-        #Second worsheet
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        
-        sheet = wb.sheet_by_index(0)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 5:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 6:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 6:
-                data_list.append(list) 
-        
-__artifacts__ = {
-        "icloudBookmarks": (
-            "iCloud Returns",
-            ('*/Bookmarks/*_iCloud_Bookmarks.xlsx'),
-            get_icloudBookmarks)
+__artifacts_v2__ = {
+    "icloudBookmarks": {
+        "name": "iCloud - Bookmarks",
+        "description": "Safari bookmarks from an iCloud law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/Bookmarks/*_iCloud_Bookmarks.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "bookmark",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def icloudBookmarks(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        source_path = file_found
+        sheet_headers, rows = _parse_icloud_xlsx(file_found, 5)
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/icloudFMFFollowers.py
+++ b/scripts/artifacts/icloudFMFFollowers.py
@@ -1,62 +1,77 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudFMFFollowers(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        #dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 1:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 2:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 2:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            #description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            description = f'Sheet name: {sheetnames[0]}'
-            report = ArtifactHtmlReport('iCloud - FMF Followers')
-            report.start_artifact_report(report_folder, 'iCloud - FMF Followers', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - FMF Followers data available')
-            
-__artifacts__ = {
-        "icloudFMFFollowers": (
-            "iCloud Returns",
-            ('*/fmf/*_Followers.xlsx'),
-            get_icloudFMFFollowers)
+__artifacts_v2__ = {
+    "icloudFMFFollowers": {
+        "name": "iCloud - FMF Followers",
+        "description": "Find My Friends followers from an iCloud law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/fmf/*_Followers.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    # Dynamic headers from the spreadsheet: ensure non-empty, unique, and not SQL reserved words
+    # (LAVA builds CREATE TABLE with unquoted identifiers).
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def icloudFMFFollowers(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        source_path = file_found
+        sheet_headers, rows = _parse_icloud_xlsx(file_found, 1)
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/icloudFMFFollowing.py
+++ b/scripts/artifacts/icloudFMFFollowing.py
@@ -1,62 +1,75 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudFMFFollowing(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        #dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 1:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 2:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 2:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            #description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            description = f'Sheet name: {sheetnames[0]}'
-            report = ArtifactHtmlReport('iCloud - FMF Following')
-            report.start_artifact_report(report_folder, 'iCloud - FMF Following', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - FMF Following data available')
-            
-__artifacts__ = {
-        "icloudFMFFollowing": (
-            "iCloud Returns",
-            ('*/fmf/*_Following.xlsx'),
-            get_icloudFMFFollowing)
+__artifacts_v2__ = {
+    "icloudFMFFollowing": {
+        "name": "iCloud - FMF Following",
+        "description": "Find My Friends following from an iCloud law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/fmf/*_Following.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def icloudFMFFollowing(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        source_path = file_found
+        sheet_headers, rows = _parse_icloud_xlsx(file_found, 1)
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/icloudQueryLogs.py
+++ b/scripts/artifacts/icloudQueryLogs.py
@@ -1,85 +1,75 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudQueryLogs(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            
-            if i == 8:
-                #Row is headers
-                idsh = sheet.cell_value(8,0)
-                timestamph = sheet.cell_value(8,1)
-                ciph = sheet.cell_value(8,2)
-                sourceHandleh = sheet.cell_value(8,3)
-                lookupHandleh = sheet.cell_value(8,4)
-                lookupDevicesh = sheet.cell_value(8,5)
-                usrh = sheet.cell_value(8,6)
-                hwvh = sheet.cell_value(8,7)
-                osvh = sheet.cell_value(8,8)
-                
-                data_headers = (timestamph,idsh,ciph,sourceHandleh,lookupHandleh,lookupDevicesh,usrh,hwvh,osvh)
-                                
-            elif i >= 9:
-                #Row data
-                ids = sheet.cell_value(i,0)
-                timestamp = sheet.cell_value(i,1)
-                split_timestamp = timestamp.split(' ')
-                clean_timestamp = f'{split_timestamp[0]}-{split_timestamp[1]}'
-                cip = sheet.cell_value(i,2)
-                sourceHandle = sheet.cell_value(i,3)
-                lookupHandle = sheet.cell_value(i,4)
-                lookupDevices = sheet.cell_value(i,5)
-                usr = sheet.cell_value(i,6)
-                hwv = sheet.cell_value(i,7)
-                osv = sheet.cell_value(i,8)
-                
-                data_list.append((clean_timestamp, ids, cip, sourceHandle, lookupHandle, lookupDevices, usr, hwv, osv))
-                
-            else:
-                continue
-            
-
-        if data_list:
-            description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            report = ArtifactHtmlReport('iCloud - Query Logs')
-            report.start_artifact_report(report_folder, 'iCloud - Query Logs', description)
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - No Query Log data available')
-            
-__artifacts__ = {
-        "icloudQueryLogs": (
-            "iCloud Returns",
-            ('*/LOG/*_IDS_QueryLogs.xlsx'),
-            get_icloudQueryLogs)
+__artifacts_v2__ = {
+    "icloudQueryLogs": {
+        "name": "iCloud - Query Logs",
+        "description": "IDS query logs from an iCloud law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/LOG/*_IDS_QueryLogs.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def icloudQueryLogs(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        source_path = file_found
+        sheet_headers, rows = _parse_icloud_xlsx(file_found, 8)
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/icloudReturnsLogs.py
+++ b/scripts/artifacts/icloudReturnsLogs.py
@@ -1,61 +1,75 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudReturnsLogs(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 6:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 7:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 7:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            report = ArtifactHtmlReport('iCloud - Logs')
-            report.start_artifact_report(report_folder, 'iCloud - Logs', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - No Log data available')
-            
-__artifacts__ = {
-        "icloudReturnsLogs": (
-            "iCloud Returns",
-            ('*/LOG/*_iCloudLogs.xlsx'),
-            get_icloudReturnsLogs)
+__artifacts_v2__ = {
+    "icloudReturnsLogs": {
+        "name": "iCloud - Logs",
+        "description": "iCloud access logs from an iCloud law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/LOG/*_iCloudLogs.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "list",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def icloudReturnsLogs(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        source_path = file_found
+        sheet_headers, rows = _parse_icloud_xlsx(file_found, 6)
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
First **iCloud Returns** batch — the 5 single-sheet spreadsheet artifacts (FMF Followers, FMF Following, Bookmarks, Logs, Query Logs). Dynamic headers; the header-row index differs per return type (1 / 1 / 5 / 6 / 8).

## 🐞 Bug fix — the originals were non-functional on modern Python
They parsed `.xlsx` with **xlrd**, but xlrd ≥ 2.0 dropped xlsx support and **xlrd 1.2 crashes on Python 3.9+** (`AttributeError: 'ElementTree' object has no attribute 'getiterator'`). Switched to **openpyxl** (`requirements: openpyxl`), which reads `.xlsx` natively and returns real datetime objects. Verified end-to-end against a generated workbook.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept.
- Context form, `context.get_relative_path(source)`.
- **Dynamic headers made LAVA-safe** via `_safe_headers`: blanks → `Column N`, duplicates de-duplicated, and any header that sanitizes to a SQL **reserved word** gets a ` Value` suffix (LAVA's `CREATE TABLE` is unquoted).
- Excel date/time cells → readable strings; empty cells → `''`.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader** loads all (total 216); **functional test** on a generated `.xlsx` covering the offset header rows, the dup/reserved-word header handling, and date-cell conversion.

*(Remaining iCloud: MsgsInCloud + ReturnsAcc — 2 sheets each; ReturnsphotoLibrary — JSON + media.)*