### PR TITLE
Convert iCloud Returns Messages-in-Cloud + Account Details to LAVA (openpyxl)

### DIFF
--- a/scripts/artifacts/icloudMsgsInCloud.py
+++ b/scripts/artifacts/icloudMsgsInCloud.py
@@ -1,74 +1,82 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudMsgsInCloud(files_found, report_folder, seeker, wrap_text):
-    
-    #for file_found in files_found:
-    for iteration, file_found in enumerate(files_found):
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        counter = 0
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 6:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 7:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 7:
-                data_list.append(list)
-            
-                if len(data_list) == 10000:
-                    description = f'Sheet name: {sheetnames[0]} - {dsid}'
-                    report = ArtifactHtmlReport('iCloud - Messages in Cloud')
-                    report.start_artifact_report(report_folder, f'iCloud - Messages in Cloud[{iteration}][{str(counter).zfill(2)}]', description)
-                    report.add_script()
-                    data_headers = (dth)
-                    report.write_artifact_data_table(data_headers, data_list, file_found)
-                    report.end_artifact_report()
-                
-                    counter = counter + 1
-                    data_list = []
-                    
-                    
-            list =[]
-        
-        if len(data_list) > 0:
-            description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            report = ArtifactHtmlReport('iCloud - Messages in Cloud')
-            report.start_artifact_report(report_folder, f'iCloud - Messages in Cloud[{iteration}][{str(counter).zfill(2)}]', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-                    #else:
-            #logfunc('No iCloud - Messages in Cloud data available')
-            
-__artifacts__ = {
-        "icloudMsgsInCloud": (
-            "iCloud Returns",
-            ('*/Messagesinicloud/*MessagesInICloud*', '*/Messages/MessagesInICloud*'),
-            get_icloudMsgsInCloud)
+__artifacts_v2__ = {
+    "icloudMsgsInCloud": {
+        "name": "iCloud - Messages in Cloud",
+        "description": "Messages in iCloud from an iCloud law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/Messagesinicloud/*MessagesInICloud*', '*/Messages/MessagesInICloud*'),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row, sheet_index=0):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    if sheet_index >= len(workbook.worksheets):
+        workbook.close()
+        return [], []
+    sheet = workbook.worksheets[sheet_index]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def icloudMsgsInCloud(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        try:
+            sheet_headers, rows = _parse_icloud_xlsx(file_found, 6, 0)
+        except (InvalidFileException, KeyError):
+            continue
+        source_path = file_found
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/icloudReturnsAcc.py
+++ b/scripts/artifacts/icloudReturnsAcc.py
@@ -1,96 +1,103 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_icloudReturnsAcc(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 6:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 7:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 7:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            report = ArtifactHtmlReport('iCloud - Account Details')
-            report.start_artifact_report(report_folder, 'iCloud - Account Details', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - Account Details data available')
-            
-        #Second worksheet
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        
-        sheet = wb.sheet_by_index(1)
-        dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 5:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 6:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 6:
-                data_list.append(list) 
-            list =[]
-            
-            
-        if data_list:
-            description = f'Sheet name: {sheetnames[1]} - {dsid}'
-            report = ArtifactHtmlReport('iCloud - Account Features')
-            report.start_artifact_report(report_folder, 'iCloud - Account Features', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No iCloud - Account Features data available')
-            
-__artifacts__ = {
-        "icloudReturnsAcc": (
-            "iCloud Returns",
-            ('*/Account/*_AccountDetails.xlsx'),
-            get_icloudReturnsAcc)
+__artifacts_v2__ = {
+    "icloudReturnsAccDetails": {
+        "name": "iCloud - Account Details",
+        "description": "Account details (sheet 1) from an iCloud law enforcement return (AccountDetails.xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/Account/*_AccountDetails.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    },
+    "icloudReturnsAccFeatures": {
+        "name": "iCloud - Account Features",
+        "description": "Account features (sheet 2) from an iCloud law enforcement return (AccountDetails.xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-27",
+        "requirements": "openpyxl",
+        "category": "iCloud Returns",
+        "notes": "",
+        "paths": ('*/Account/*_AccountDetails.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "sliders",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_icloud_xlsx(file_found, header_row, sheet_index=0):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    if sheet_index >= len(workbook.worksheets):
+        workbook.close()
+        return [], []
+    sheet = workbook.worksheets[sheet_index]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+def _icloud_account_sheet(context, sheet_index, header_row):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        try:
+            sheet_headers, rows = _parse_icloud_xlsx(file_found, header_row, sheet_index)
+        except (InvalidFileException, KeyError):
+            continue
+        source_path = file_found
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+    return tuple(headers), data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def icloudReturnsAccDetails(context):
+    return _icloud_account_sheet(context, sheet_index=0, header_row=6)
+
+
+@artifact_processor
+def icloudReturnsAccFeatures(context):
+    return _icloud_account_sheet(context, sheet_index=1, header_row=5)


### PR DESCRIPTION
Second **iCloud Returns** batch — the multi-sheet / chunked spreadsheet artifacts.

## Same xlrd → openpyxl fix as #319
The originals crash on Python 3.9+ (xlrd can't read `.xlsx`). Migrated to openpyxl; dynamic headers made LAVA-safe; date/time cells → readable strings.

## icloudMsgsInCloud (sheet 0, header row 6)
Dropped the legacy **10,000-row HTML report chunking** → one LAVA table.

## icloudReturnsAcc → **two artifacts** (AccountDetails.xlsx has two sheets)
- `icloudReturnsAccDetails` (sheet 1, header row 6) — Account Details
- `icloudReturnsAccFeatures` (sheet 2, header row 5) — Account Features
- `_parse_icloud_xlsx` gained a bounds-guarded `sheet_index` param.

Non-xlsx / corrupt matches are skipped (`InvalidFileException` guard) instead of crashing. Loader **216 → 217**.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader** (3 keys incl. 2 new, old `icloudReturnsAcc` gone, total 217); **functional test** on generated single- and two-sheet workbooks (offset header rows per sheet; chunking dropped).

*(Remaining iCloud: ReturnsphotoLibrary — JSON + media — the finale.)*