### PR TITLE
Convert Pinger category to LAVA (completes Pinger)

### DIFF
--- a/scripts/artifacts/accPinger.py
+++ b/scripts/artifacts/accPinger.py
@@ -1,44 +1,40 @@
+__artifacts_v2__ = {
+    "accPinger": {
+        "name": "Pinger - Account",
+        "description": "User account data from a Pinger law enforcement return (docx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-07-17",
+        "last_update_date": "2026-06-28",
+        "requirements": "mammoth",
+        "category": "Pinger",
+        "notes": "",
+        "paths": ('*/*.docx',),
+        "output_types": "standard",
+        "html_columns": ["User Data"],
+        "artifact_icon": "user",
+    }
+}
+
 import os
+
 import mammoth
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_accPinger(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def accPinger(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
             continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        with open(file_found, "rb") as docx_file:
+        source_path = file_found
+        with open(file_found, 'rb') as docx_file:
             result = mammoth.convert_to_html(docx_file)
-            html = result.value 
-            data_list.append((html,))
-            
-        
-        if data_list:
-            description = f'User account data'
-            report = ArtifactHtmlReport('Pinger - Account')
-            report.start_artifact_report(report_folder, 'Pinger - Account', description)
-            report.add_script()
-            data_headers = ('User Data',)
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['User Data'])
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No Pinger Account data available')
-            
-__artifacts__ = {
-        "Pinger Account": (
-            "Pinger",
-            ('*/*.docx'),
-            get_accPinger)
-}
+        data_list.append((result.value,))
+
+    data_headers = ('User Data',)
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/cdrPinger.py
+++ b/scripts/artifacts/cdrPinger.py
@@ -1,62 +1,79 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_cdrPinger(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        #dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 1:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 2:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 2:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            #description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            description = f'Sheet name: {sheetnames[0]}'
-            report = ArtifactHtmlReport('Pinger - CDR')
-            report.start_artifact_report(report_folder, 'Pinger - CDR', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No Pinger CDR data available')
-            
-__artifacts__ = {
-        "Pinger CDR": (
-            "Pinger",
-            ('*/*CDR.xlsx'),
-            get_cdrPinger)
+__artifacts_v2__ = {
+    "cdrPinger": {
+        "name": "Pinger - CDR",
+        "description": "Call detail records from a Pinger law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-28",
+        "requirements": "openpyxl",
+        "category": "Pinger",
+        "notes": "",
+        "paths": ('*/*CDR.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def cdrPinger(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        try:
+            sheet_headers, rows = _parse_xlsx(file_found, 1)
+        except (InvalidFileException, KeyError):
+            continue
+        source_path = file_found
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/dmlPinger.py
+++ b/scripts/artifacts/dmlPinger.py
@@ -1,62 +1,79 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_dmlPinger(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        #dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 1:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 2:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 2:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            #description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            description = f'Sheet name: {sheetnames[0]}'
-            report = ArtifactHtmlReport('Pinger - DML')
-            report.start_artifact_report(report_folder, 'Pinger - DML', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No Pinger DML data available')
-            
-__artifacts__ = {
-        "Pinger DML": (
-            "Pinger",
-            ('*/*DML.xlsx'),
-            get_dmlPinger)
+__artifacts_v2__ = {
+    "dmlPinger": {
+        "name": "Pinger - DML",
+        "description": "DML records from a Pinger law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-28",
+        "requirements": "openpyxl",
+        "category": "Pinger",
+        "notes": "",
+        "paths": ('*/*DML.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def dmlPinger(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        try:
+            sheet_headers, rows = _parse_xlsx(file_found, 1)
+        except (InvalidFileException, KeyError):
+            continue
+        source_path = file_found
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/ipPinger.py
+++ b/scripts/artifacts/ipPinger.py
@@ -1,62 +1,79 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_ipPinger(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        #dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 1:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 2:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 2:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            #description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            description = f'Sheet name: {sheetnames[0]}'
-            report = ArtifactHtmlReport('Pinger - IP')
-            report.start_artifact_report(report_folder, 'Pinger - IP', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No Pinger IP data available')
-            
-__artifacts__ = {
-        "Pinger IP": (
-            "Pinger",
-            ('*/*IP Logs.xlsx'),
-            get_ipPinger)
+__artifacts_v2__ = {
+    "ipPinger": {
+        "name": "Pinger - IP",
+        "description": "IP logs from a Pinger law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-28",
+        "requirements": "openpyxl",
+        "category": "Pinger",
+        "notes": "",
+        "paths": ('*/*IP Logs.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def ipPinger(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        try:
+            sheet_headers, rows = _parse_xlsx(file_found, 1)
+        except (InvalidFileException, KeyError):
+            continue
+        source_path = file_found
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/mcPinger.py
+++ b/scripts/artifacts/mcPinger.py
@@ -1,62 +1,79 @@
-import os
-import xlrd
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
-
-def get_mcPinger(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('.'):
-            continue
-        
-        loc = file_found
-        
-        
-        dth = []
-        list = []
-        data_headers = []
-        data_list =[]
-        
-        #First worksheet
-        
-        wb = xlrd.open_workbook(loc)
-        sheetnames = wb.sheet_names() 
-        sheet = wb.sheet_by_index(0)
-        #dsid = sheet.cell_value(2, 0)
-        
-        for i in range(sheet.nrows):
-            for j in range(sheet.ncols):
-                if i == 1:
-                    dth.append(sheet.cell_value(i, j))
-                if i >= 2:
-                    list.append(sheet.cell_value(i, j))
-            if i >= 2:
-                data_list.append(list) 
-            list =[]
-        
-        
-        if data_list:
-            #description = f'Sheet name: {sheetnames[0]} - {dsid}'
-            description = f'Sheet name: {sheetnames[0]}'
-            report = ArtifactHtmlReport('Pinger - MC')
-            report.start_artifact_report(report_folder, 'Pinger - MC', description)
-            report.add_script()
-            data_headers = (dth)
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-        else:
-            logfunc('No Pinger MC data available')
-            
-__artifacts__ = {
-        "Pinger MC": (
-            "Pinger",
-            ('*/*MC.xlsx'),
-            get_mcPinger)
+__artifacts_v2__ = {
+    "mcPinger": {
+        "name": "Pinger - MC",
+        "description": "MC records from a Pinger law enforcement return (xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-08-18",
+        "last_update_date": "2026-06-28",
+        "requirements": "openpyxl",
+        "category": "Pinger",
+        "notes": "",
+        "paths": ('*/*MC.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "list",
+    }
 }
+
+import os
+from datetime import date, time
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _parse_xlsx(file_found, header_row):
+    workbook = load_workbook(file_found, read_only=True, data_only=True)
+    sheet = workbook.worksheets[0]
+    headers, rows = [], []
+    for i, row in enumerate(sheet.iter_rows(values_only=True)):
+        if i < header_row:
+            continue
+        cells = [str(c) if isinstance(c, (date, time)) else ('' if c is None else c) for c in row]
+        if i == header_row:
+            headers = _safe_headers(cells)
+        else:
+            rows.append(cells)
+    workbook.close()
+    return headers, rows
+
+
+@artifact_processor
+def mcPinger(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = os.path.basename(file_found)
+        if basename.startswith('~') or basename.startswith('.'):
+            continue
+        try:
+            sheet_headers, rows = _parse_xlsx(file_found, 1)
+        except (InvalidFileException, KeyError):
+            continue
+        source_path = file_found
+        if sheet_headers:
+            headers = sheet_headers
+            data_list.extend(rows)
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
All 5 **Pinger** law-enforcement-return parsers — completes the category.

| Artifact | Source | Parser |
|---|---|---|
| cdrPinger | *CDR.xlsx | xlsx |
| dmlPinger | *DML.xlsx | xlsx |
| ipPinger | *IP Logs.xlsx | xlsx |
| mcPinger | *MC.xlsx | xlsx |
| accPinger | *.docx | mammoth → html |

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; attributed @AlexisBrignoni; dates kept. **Also fixes the originals' space-containing registration keys** (`Pinger CDR` etc.).
- Context form, `context.get_relative_path(source)`.

## xlrd → openpyxl (same fix as iCloud #319)
The four spreadsheet artifacts shared the generic xlsx dump (sheet 0, header row 1, dynamic headers) **and** the same xlrd-on-Python-3.9+ breakage → migrated to openpyxl; dynamic headers made LAVA-safe via `_safe_headers` (blanks/dups/reserved-words); date cells → readable strings.

`accPinger` reads the account `.docx` via **mammoth** → a single `User Data` html_column.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader** (5 new keys, old space-keys gone, total 217); **functional test** (synthetic xlsx for cdrPinger; mammoth stubbed for accPinger).

*(Note: the CDR phone columns can't be `phonenumber`-typed — the headers are read dynamically from the sheet, so they're unknown at code time.)*