### PR TITLE
Convert Snapchat Archive Chat History + Account Info to LAVA

### DIFF
--- a/scripts/artifacts/snapAccountinfo.py
+++ b/scripts/artifacts/snapAccountinfo.py
@@ -1,113 +1,122 @@
-import os
-import json
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_snapAccountinfo(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        if filename.startswith('account.json'):
-            data_list =[]
-            with open(file_found, 'r') as fp:
-                deserialized = json.load(fp)
-            
-            for key, value in deserialized.items():
-                if key == 'Basic Information':
-                    data_list_bi = []
-                    data_list_bi.append((value['Creation Date'],value['Username'],value['Name'],value.get('Registration IP',''),value.get('Country',''),value.get('PhoneNumber',''),value.get('Carrier','')))
-                    
-                if key == 'Device Information':
-                    data_list_di = []
-                    data_list_di.append((value['Make'],value['Model ID'],value['Model Name'],value.get('User Agent',''),value['Language'],value['OS Type'],value['OS Version'],value['Connection Type']))
-                    
-                if key == 'Device History':
-                    data_list_dh = []
-                    for items in value:
-                        data_list_dh.append((items['Start Time'],items['Make'],items['Model'],items['Device Type']))
-                        
-                if key == 'Login History':
-                    data_list_lh = []
-                    for items in value:
-                        data_list_lh.append((items['Created'],items['IP'],items['Country'],items['Status'],items['Device']))
-            
-            if data_list_lh:
-                report = ArtifactHtmlReport(f'Snapchat - Login History')
-                report.start_artifact_report(report_folder, f'Snapchat - Login History')
-                report.add_script()
-                data_headers = ('Timestamp','IP','Country','Status','Device')
-                report.write_artifact_data_table(data_headers, data_list_lh, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Login History'
-                tsv(report_folder, data_headers, data_list_lh, tsvname)
-                
-                tlactivity = f'Snapchat - Login History'
-                timeline(report_folder, tlactivity, data_list_lh, data_headers)
-                    
-            else:
-                logfunc(f'No Snapchat - Login History')
-            
-            if data_list_di:
-                report = ArtifactHtmlReport(f'Snapchat - Device History')
-                report.start_artifact_report(report_folder, f'Snapchat - Device History')
-                report.add_script()
-                data_headers = ('Start Time','Make','Model','Device type')
-                report.write_artifact_data_table(data_headers, data_list_di, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Device History'
-                tsv(report_folder, data_headers, data_list_di, tsvname)
-                
-                tlactivity = f'Snapchat - Device History'
-                timeline(report_folder, tlactivity, data_list_di, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Device History')
-            
-            if data_list_di:
-                report = ArtifactHtmlReport(f'Snapchat - Device Information')
-                report.start_artifact_report(report_folder, f'Snapchat - Device Information')
-                report.add_script()
-                data_headers = ('Make','Model ID','Model Name','User Agent','Language','OS Type','OS Version','Connection Type')
-                report.write_artifact_data_table(data_headers, data_list_di, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Device Information'
-                tsv(report_folder, data_headers, data_list_di, tsvname)
-                
-            else:
-                logfunc(f'No Snapchat - Device Information')
-            
-            if data_list_bi:
-                report = ArtifactHtmlReport(f'Snapchat - Account Basic Info')
-                report.start_artifact_report(report_folder, f'Snapchat - Account Basic Info')
-                report.add_script()
-                data_headers = ('Timestamp','Username','Name','Registration IP','Country','Phone Number','Carrier')
-                report.write_artifact_data_table(data_headers, data_list_bi, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Account Basic Info'
-                tsv(report_folder, data_headers, data_list_bi, tsvname)
-                
-                tlactivity = f'Snapchat - Account Basic Info'
-                timeline(report_folder, tlactivity, data_list_bi, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Account Basic Info')
-            
-        
-            
-    
-__artifacts__ = {
-        "snapAccountinfo": (
-            "Snapchat Archive",
-            ('*/account.json'),
-            get_snapAccountinfo)
+__artifacts_v2__ = {
+    "snapArchiveBasicInfo": {
+        "name": "Snapchat - Account Basic Info",
+        "description": "Account basic information from a Snapchat data archive (account.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
+        "last_update_date": "2026-06-28", "requirements": "none",
+        "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "user",
+    },
+    "snapArchiveDeviceInfo": {
+        "name": "Snapchat - Device Information",
+        "description": "Device information from a Snapchat data archive (account.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
+        "last_update_date": "2026-06-28", "requirements": "none",
+        "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "smartphone",
+    },
+    "snapArchiveDeviceHistory": {
+        "name": "Snapchat - Device History",
+        "description": "Device history from a Snapchat data archive (account.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
+        "last_update_date": "2026-06-28", "requirements": "none",
+        "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "clock",
+    },
+    "snapArchiveLoginHistory": {
+        "name": "Snapchat - Login History",
+        "description": "Login history from a Snapchat data archive (account.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
+        "last_update_date": "2026-06-28", "requirements": "none",
+        "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "log-in",
+    }
 }
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
+
+
+def _snap_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        pass
+    try:
+        parts = value.split(' ')
+        return datetime(int(parts[-1]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _account_json(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('account.json'):
+            with open(file_found, encoding='utf-8') as fp:
+                return file_found, json.load(fp)
+    return '', {}
+
+
+@artifact_processor
+def snapArchiveBasicInfo(context):
+    source_path, data = _account_json(context)
+    data_list = []
+    bi = data.get('Basic Information')
+    if bi:
+        data_list.append((_snap_ts(bi.get('Creation Date', '')), bi.get('Username', ''),
+                          bi.get('Name', ''), bi.get('Registration IP', ''), bi.get('Country', ''),
+                          bi.get('PhoneNumber', ''), bi.get('Carrier', '')))
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Name', 'Registration IP', 'Country',
+                    ('Phone Number', 'phonenumber'), 'Carrier')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def snapArchiveDeviceInfo(context):
+    source_path, data = _account_json(context)
+    data_list = []
+    di = data.get('Device Information')
+    if di:
+        data_list.append((di.get('Make', ''), di.get('Model ID', ''), di.get('Model Name', ''),
+                          di.get('User Agent', ''), di.get('Language', ''), di.get('OS Type', ''),
+                          di.get('OS Version', ''), di.get('Connection Type', '')))
+    data_headers = ('Make', 'Model ID', 'Model Name', 'User Agent', 'Language', 'OS Type',
+                    'OS Version', 'Connection Type')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def snapArchiveDeviceHistory(context):
+    source_path, data = _account_json(context)
+    data_list = []
+    for item in data.get('Device History', []):
+        data_list.append((_snap_ts(item.get('Start Time', '')), item.get('Make', ''),
+                          item.get('Model', ''), item.get('Device Type', '')))
+    data_headers = (('Start Time', 'datetime'), 'Make', 'Model', 'Device Type')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def snapArchiveLoginHistory(context):
+    source_path, data = _account_json(context)
+    data_list = []
+    for item in data.get('Login History', []):
+        data_list.append((_snap_ts(item.get('Created', '')), item.get('IP', ''),
+                          item.get('Country', ''), item.get('Status', ''), item.get('Device', '')))
+    data_headers = (('Timestamp', 'datetime'), 'IP', 'Country', 'Status', 'Device')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapChathistory.py
+++ b/scripts/artifacts/snapChathistory.py
@@ -1,60 +1,74 @@
-import os
-import json
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_snapChathistory(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        if filename.startswith('chat_history.json'):
-            data_list =[]
-            with open(file_found, 'r') as fp:
-                deserialized = json.load(fp)
-            
-            for x, y in deserialized.items():
-                for mess in y:
-                    typeline = x
-                    #print(itemsdict)
-                    if mess.get('From'):
-                        directionality = mess['From']
-                        directionality = 'From: ' + directionality
-                    elif mess.get('To'):
-                        directionality = mess['To']
-                        directionality = 'To: ' + directionality
-                        
-                    mediatype = mess['Media Type']
-                    created = mess['Created']
-                    textm = mess['Text']
-                    
-                    data_list.append((created, directionality, textm, mediatype, typeline ))
-                    
-            if data_list:
-                report = ArtifactHtmlReport(f'Snapchat - Chat History')
-                report.start_artifact_report(report_folder, f'Snapchat - Chat History')
-                report.add_script()
-                data_headers = ('Timestamp','Directionality','Text','Media Type','Message Type')
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Chat History'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Snapchat - Chat History'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc(f'Snapchat - Chat History')
-    
-__artifacts__ = {
-        "snapChathistory": (
-            "Snapchat Archive",
-            ('*/chat_history.json'),
-            get_snapChathistory)
+__artifacts_v2__ = {
+    "snapChathistory": {
+        "name": "Snapchat - Chat History",
+        "description": "Chat history from a Snapchat data archive (chat_history.json).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-04-05",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Snapchat Archive",
+        "notes": "",
+        "paths": ('*/chat_history.json',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
 }
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
+
+
+def _snap_ts(value):
+    # Snapchat archive timestamps vary: ISO ('2021-08-19 12:00:00 UTC'), epoch, or
+    # the return-style 'Wed Aug 19 12:00:00 UTC 2021'. Best-effort to aware UTC, else raw.
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        pass
+    try:
+        parts = value.split(' ')
+        return datetime(int(parts[-1]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+@artifact_processor
+def snapChathistory(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('chat_history.json'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as fp:
+            data = json.load(fp)
+
+        for conv_type, messages in data.items():
+            for mess in messages:
+                if mess.get('From'):
+                    directionality = 'From: ' + mess['From']
+                elif mess.get('To'):
+                    directionality = 'To: ' + mess['To']
+                else:
+                    directionality = ''
+                data_list.append((_snap_ts(mess.get('Created', '')), directionality,
+                                  mess.get('Text', ''), mess.get('Media Type', ''), conv_type))
+
+    data_headers = (('Timestamp', 'datetime'), 'Directionality', 'Text', 'Media Type',
+                    'Message Type')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
First **Snapchat Archive** batch (JSON user-data export). 2 files → 5 artifacts.

## snapChathistory (chat_history.json) → 1 artifact
- `Created` → aware UTC via `_snap_ts` (handles ISO / ` UTC` / epoch / return-style).
- Guarded the From/To **directionality** so a message with neither no longer leaks the previous one's value (original could `NameError`).

## snapAccountinfo (account.json) → 4 artifacts
`snapArchiveBasicInfo`, `snapArchiveDeviceInfo`, `snapArchiveDeviceHistory`, `snapArchiveLoginHistory`.

### 🐞 Bug fixes
- The original's **Device History** report actually rendered the Device *Information* data (`data_list_di`) under Device-History headers, while the real Device History (`data_list_dh`) was computed but **never reported**. Each table now uses its own data.
- The `data_list_*` vars were defined only inside their `if key ==` blocks → a missing JSON key caused a `NameError` at the report checks. Each artifact now reads its key independently with `.get()` defaults.

### Other
- **`phonenumber` type** on the real `Phone Number` (Basic Info) column.
- Timestamps → aware UTC.

Loader **217 → 220**.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word + phonenumber audit clean; **PluginLoader** (5 keys, old `snapAccountinfo` gone, total 220); **synthetic-JSON functional test** (UTC timestamps, the Device History fix, the phonenumber column, From/To directionality).