### PR TITLE
Convert Snapchat Archive friends.json to LAVA: 8 sections -> 8 artifacts

### DIFF
--- a/scripts/artifacts/snapFriendsjson.py
+++ b/scripts/artifacts/snapFriendsjson.py
@@ -1,203 +1,135 @@
-import os
-import json
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_snapFriendsjson(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        if filename.startswith('friends.json'):
-            data_list =[]
-            with open(file_found, 'r') as fp:
-                deserialized = json.load(fp)
-            
-            for key, value in deserialized.items():
-                if key == 'Friends':
-                    data_list_f = []
-                    for items in value:
-                        data_list_f.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Friend Requests Sent':
-                    data_list_fr = []
-                    for items in value:
-                        data_list_fr.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Blocked Users':
-                    data_list_bu = []
-                    for items in value:
-                        data_list_bu.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Deleted Friends':
-                    data_list_df = []
-                    for items in value:
-                        data_list_df.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Hidden Friend Suggestions':
-                    data_list_hf = []
-                    for items in value:
-                        data_list_hf.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Ignored Snapchatters':
-                    data_list_ig = []
-                    for items in value:
-                        data_list_ig.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Pending Requests':
-                    data_list_pr = []
-                    for items in value:
-                        data_list_pr.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                        
-                if key == 'Shortcuts':
-                    data_list_sc = []
-                    for items in value:
-                        data_list_sc.append((items['Creation Timestamp'],items['Last Modified Timestamp'],items['Username'],items['Display Name'],items['Source']))
-                    
-            if data_list_f:
-                report = ArtifactHtmlReport(f'Snapchat - Friends')
-                report.start_artifact_report(report_folder, f'Snapchat - Friends')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_f, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Friends'
-                tsv(report_folder, data_headers, data_list_f, tsvname)
-                
-                tlactivity = f'Snapchat - Friends'
-                timeline(report_folder, tlactivity, data_list_f, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Friends')
-            
-            if data_list_fr:
-                report = ArtifactHtmlReport(f'Snapchat - Friends Request Sent')
-                report.start_artifact_report(report_folder, f'Snapchat - Friends Request Sent')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_fr, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Friends Request Sent'
-                tsv(report_folder, data_headers, data_list_fr, tsvname)
-                
-                tlactivity = f'Snapchat - Friends Request Sent'
-                timeline(report_folder, tlactivity, data_list_fr, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Friends Request Sent')
-            
-            if data_list_bu:
-                report = ArtifactHtmlReport(f'Snapchat - Blocked Users')
-                report.start_artifact_report(report_folder, f'Snapchat - Blocked Users')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_bu, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Blocked Users'
-                tsv(report_folder, data_headers, data_list_bu, tsvname)
-                
-                tlactivity = f'Snapchat - Blocked Users'
-                timeline(report_folder, tlactivity, data_list_bu, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Blocked Users')
-            
-            if data_list_df:
-                report = ArtifactHtmlReport(f'Snapchat - Deleted Friends')
-                report.start_artifact_report(report_folder, f'Snapchat - Deleted Friends')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_df, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Deleted Friends'
-                tsv(report_folder, data_headers, data_list_df, tsvname)
-                
-                tlactivity = f'Snapchat - Deleted Friends'
-                timeline(report_folder, tlactivity, data_list_df, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Deleted Friends')
-                
-            if data_list_hf:
-                report = ArtifactHtmlReport(f'Snapchat - Hidden Friends Suggestions')
-                report.start_artifact_report(report_folder, f'Snapchat - Hidden Friends Suggestions')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_hf, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Hidden Friends Suggestions'
-                tsv(report_folder, data_headers, data_list_hf, tsvname)
-                
-                tlactivity = f'Snapchat - Hidden Friends Suggestions'
-                timeline(report_folder, tlactivity, data_list_hf, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Hidden Friends Suggestions')
-                
-            if data_list_ig:
-                report = ArtifactHtmlReport(f'Snapchat - Ignored Snapchatters')
-                report.start_artifact_report(report_folder, f'Snapchat - Ignored Snapchatters')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_ig, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Ignored Snapchatters'
-                tsv(report_folder, data_headers, data_list_ig, tsvname)
-                
-                tlactivity = f'Snapchat - Ignored Snapchatters'
-                timeline(report_folder, tlactivity, data_list_ig, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Ignored Snapchatters')
-                
-            if data_list_pr:
-                report = ArtifactHtmlReport(f'Snapchat - Pending Requests')
-                report.start_artifact_report(report_folder, f'Snapchat - Pending Requests')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_pr, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Pending Requests'
-                tsv(report_folder, data_headers, data_list_pr, tsvname)
-                
-                tlactivity = f'Snapchat - Pending Requests'
-                timeline(report_folder, tlactivity, data_list_pr, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Pending Requests')
-                
-            if data_list_sc:
-                report = ArtifactHtmlReport(f'Snapchat - Shortcuts')
-                report.start_artifact_report(report_folder, f'Snapchat - Shortcuts')
-                report.add_script()
-                data_headers = ('Timestamp','Last Modified Timestamp','Username','Display Name','Source')
-                report.write_artifact_data_table(data_headers, data_list_sc, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Shortcuts'
-                tsv(report_folder, data_headers, data_list_sc, tsvname)
-                
-                tlactivity = f'Snapchat - Shortcuts'
-                timeline(report_folder, tlactivity, data_list_sc, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Shorcuts')
-    
-__artifacts__ = {
-        "snapFriendsjson": (
-            "Snapchat Archive",
-            ('*/friends.json'),
-            get_snapFriendsjson)
+__artifacts_v2__ = {
+    "snapArchiveFriends": {
+        "name": "Snapchat Archive - Friends", "description": "Friends from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "users",
+    },
+    "snapArchiveFriendRequestsSent": {
+        "name": "Snapchat Archive - Friend Requests Sent", "description": "Friend requests sent from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "user-plus",
+    },
+    "snapArchiveBlockedUsers": {
+        "name": "Snapchat Archive - Blocked Users", "description": "Blocked users from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "user-x",
+    },
+    "snapArchiveDeletedFriends": {
+        "name": "Snapchat Archive - Deleted Friends", "description": "Deleted friends from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "user-minus",
+    },
+    "snapArchiveHiddenFriendSuggestions": {
+        "name": "Snapchat Archive - Hidden Friend Suggestions", "description": "Hidden friend suggestions from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "eye-off",
+    },
+    "snapArchiveIgnoredSnapchatters": {
+        "name": "Snapchat Archive - Ignored Snapchatters", "description": "Ignored Snapchatters from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "user-x",
+    },
+    "snapArchivePendingRequests": {
+        "name": "Snapchat Archive - Pending Requests", "description": "Pending requests from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "clock",
+    },
+    "snapArchiveShortcuts": {
+        "name": "Snapchat Archive - Shortcuts", "description": "Shortcuts from a Snapchat data archive (friends.json).",
+        "author": "@AlexisBrignoni", "creation_date": "2023-12-11", "last_update_date": "2026-06-28",
+        "requirements": "none", "category": "Snapchat Archive", "notes": "",
+        "paths": ('*/friends.json',), "output_types": "standard", "artifact_icon": "bookmark",
+    }
 }
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
+_HEADERS = (('Timestamp', 'datetime'), ('Last Modified Timestamp', 'datetime'), 'Username',
+            'Display Name', 'Source')
+
+
+def _snap_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        pass
+    try:
+        parts = value.split(' ')
+        return datetime(int(parts[-1]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _friend_section(context, key):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('friends.json'):
+            continue
+        with open(file_found, encoding='utf-8') as fp:
+            data = json.load(fp)
+        rows = [(_snap_ts(it.get('Creation Timestamp', '')),
+                 _snap_ts(it.get('Last Modified Timestamp', '')), it.get('Username', ''),
+                 it.get('Display Name', ''), it.get('Source', '')) for it in data.get(key, [])]
+        return _HEADERS, rows, context.get_relative_path(file_found)
+    return _HEADERS, [], ''
+
+
+@artifact_processor
+def snapArchiveFriends(context):
+    return _friend_section(context, 'Friends')
+
+
+@artifact_processor
+def snapArchiveFriendRequestsSent(context):
+    return _friend_section(context, 'Friend Requests Sent')
+
+
+@artifact_processor
+def snapArchiveBlockedUsers(context):
+    return _friend_section(context, 'Blocked Users')
+
+
+@artifact_processor
+def snapArchiveDeletedFriends(context):
+    return _friend_section(context, 'Deleted Friends')
+
+
+@artifact_processor
+def snapArchiveHiddenFriendSuggestions(context):
+    return _friend_section(context, 'Hidden Friend Suggestions')
+
+
+@artifact_processor
+def snapArchiveIgnoredSnapchatters(context):
+    return _friend_section(context, 'Ignored Snapchatters')
+
+
+@artifact_processor
+def snapArchivePendingRequests(context):
+    return _friend_section(context, 'Pending Requests')
+
+
+@artifact_processor
+def snapArchiveShortcuts(context):
+    return _friend_section(context, 'Shortcuts')


### PR DESCRIPTION
Second **Snapchat Archive** batch — friends.json. The legacy artifact emitted **8 reports** (all identical columns) → 8 `@artifact_processor` artifacts sharing a `_friend_section()` helper: Friends, Friend Requests Sent, Blocked Users, Deleted Friends, Hidden Friend Suggestions, Ignored Snapchatters, Pending Requests, Shortcuts.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; @AlexisBrignoni; date kept.
- Context form; both `Creation` + `Last Modified` timestamps → aware UTC via `_snap_ts`.

## 🐞 Bug fix
The original's `data_list_*` were defined only inside their `if key ==` blocks → a missing JSON key raised `NameError` at the report checks. Each artifact now reads its key independently with `.get()` defaults (absent section → empty).

## Naming
The artifact **names** use a `Snapchat Archive - ` prefix: the loader enforces **globally unique artifact names**, and `Snapchat - Friends` was already taken by the Snapchat *Returns* artifact (`snapFriendsN`).

Loader **220 → 227**.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; reserved-word audit clean; **PluginLoader** (8 new keys, old key gone, unique-name check passes, total 227); **synthetic-JSON functional test** (UTC timestamps; an absent section returning empty without crashing).