### PR TITLE
Convert Snapchat Archive account_history.json to LAVA: 9 sections -> 9 artifacts (completes Snapchat)

### DIFF
--- a/scripts/artifacts/snapchatAccounthist.py
+++ b/scripts/artifacts/snapchatAccounthist.py
@@ -1,218 +1,123 @@
-import os
-import json
+def _m(name, icon):
+    return {"name": f"Snapchat Archive - {name}",
+            "description": f"{name} from a Snapchat data archive (account_history.json).",
+            "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
+            "last_update_date": "2026-06-28", "requirements": "none",
+            "category": "Snapchat Archive", "notes": "",
+            "paths": ('*/account_history.json',), "output_types": "standard", "artifact_icon": icon}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
 
-def get_snapchatAccounthist(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        one = (os.path.split(file_found))
-        username = (os.path.basename(one[0]))
-        
-        if filename.startswith('account_history.json'):
-            data_list =[]
-            with open(file_found, 'r') as fp:
-                deserialized = json.load(fp)
-            
-            for key, value in deserialized.items():
-                
-                if key == 'Display Name Change':
-                    data_list_dn = []
-                    for items in value:
-                        data_list_dn.append((items['Date'],items['Display Name']))
-                        
-                if key == 'Email Change':
-                    data_list_ec = []
-                    if len(value) > 0:
-                        data_list_ec.append((value,))
-                    
-                if key == 'Mobile Number Change':
-                    data_list_mn = []
-                    for items in value:
-                        data_list_mn.append((items['Date'],items['Mobile Number']))
-                        
-                if key == 'Password Change':
-                    data_list_pc = []
-                    for items in value:
-                        data_list_pc.append((items['Date'],))
-                        
-                if key == 'Snapchat Linked to Bitmoji':
-                    data_list_lb = []
-                    for items in value:
-                        data_list_lb.append((items['Date'],))
-                        
-                if key == 'Spectacles':
-                    data_list_spec = []
-                    if len(value) > 0:
-                        data_list_spec.append((value,))
-                    
-                if key == 'Two-Factor Authentication':
-                    data_list_2f = []
-                    if len(value) > 0:
-                        data_list_2f.append((value,))
-                    
-                if key == 'Account deactivated / reactivated':
-                    data_list_adr = []
-                    if len(value) > 0:
-                        data_list_adr.append((value,))
-                    
-                if key == 'Download My Data Reports':
-                    data_list_dd = []
-                    for items in value:
-                        data_list_dd.append((items['Date'],items['Status'],items['Email Address']))
-            
-            if data_list_dd:
-                report = ArtifactHtmlReport(f'Snapchat - Download My Data Reports')
-                report.start_artifact_report(report_folder, f'Snapchat - Download My Data Reports')
-                report.add_script()
-                data_headers = ('Timestamp','Status','Email Address')
-                report.write_artifact_data_table(data_headers, data_list_dd, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Download My Data Reports'
-                tsv(report_folder, data_headers, data_list_dd, tsvname)
-                
-                tlactivity = f'Snapchat - Download My Data Reports'
-                timeline(report_folder, tlactivity, data_list_dd, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Display Name Change')
-            
-            if data_list_adr:
-                report = ArtifactHtmlReport(f'Snapchat - Account Deactivated - Reactivated')
-                report.start_artifact_report(report_folder, f'Snapchat - Account Deactivated - Reactivated')
-                report.add_script()
-                data_headers = ('Data',)
-                report.write_artifact_data_table(data_headers, data_list_adr, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Account Deactivated - Reactivated'
-                tsv(report_folder, data_headers, data_list_adr, tsvname)
-                
-            else:
-                logfunc(f'No Snapchat - Account Deactivated - Reactivated')
-            
-            if data_list_2f:
-                report = ArtifactHtmlReport(f'Snapchat - Two-Factor Authentication')
-                report.start_artifact_report(report_folder, f'Snapchat - Two-Factor Authentication')
-                report.add_script()
-                data_headers = ('Data',)
-                report.write_artifact_data_table(data_headers, data_list_2f, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Two-Factor Authentication'
-                tsv(report_folder, data_headers, data_list_2f, tsvname)
-                
-            else:
-                logfunc(f'No Snapchat - Two-Factor Authentication')
-            
-            if data_list_spec:
-                report = ArtifactHtmlReport(f'Snapchat - Spectacles')
-                report.start_artifact_report(report_folder, f'Snapchat - Spectacles')
-                report.add_script()
-                data_headers = ('Data',)
-                report.write_artifact_data_table(data_headers, data_list_spec, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Linked to Spectacles'
-                tsv(report_folder, data_headers, data_list_spec, tsvname)
-                
-            else:
-                logfunc(f'No Snapchat - Linked to Spectacles')
-            
-            if data_list_lb:
-                report = ArtifactHtmlReport(f'Snapchat - Linked to Bitmoji')
-                report.start_artifact_report(report_folder, f'Snapchat - Linked to Bitmoji')
-                report.add_script()
-                data_headers = ('Timestamp',)
-                report.write_artifact_data_table(data_headers, data_list_lb, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Linked to Bitmoji'
-                tsv(report_folder, data_headers, data_list_lb, tsvname)
-                
-                tlactivity = f'Snapchat - Linked to Bitmoji'
-                timeline(report_folder, tlactivity, data_list_lb, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Linked to Bitmoji')
-            
-            if data_list_pc:
-                report = ArtifactHtmlReport(f'Snapchat - Password Change')
-                report.start_artifact_report(report_folder, f'Snapchat - Password Change')
-                report.add_script()
-                data_headers = ('Timestamp',)
-                report.write_artifact_data_table(data_headers, data_list_pc, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Password Change'
-                tsv(report_folder, data_headers, data_list_pc, tsvname)
-                
-                tlactivity = f'Snapchat - Password Change'
-                timeline(report_folder, tlactivity, data_list_pc, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Password Change')
-            
-            if data_list_mn:
-                report = ArtifactHtmlReport(f'Snapchat - Mobile Number Change')
-                report.start_artifact_report(report_folder, f'Snapchat - Mobile Number Change')
-                report.add_script()
-                data_headers = ('Timestamp','Mobile Number')
-                report.write_artifact_data_table(data_headers, data_list_mn, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Mobile Number Change'
-                tsv(report_folder, data_headers, data_list_mn, tsvname)
-                
-                tlactivity = f'Snapchat - Mobile Number Change'
-                timeline(report_folder, tlactivity, data_list_mn, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Mobile Number Change')
-                
-            
-            if data_list_ec:
-                report = ArtifactHtmlReport(f'Snapchat - Email Change')
-                report.start_artifact_report(report_folder, f'Snapchat - Email Change')
-                report.add_script()
-                data_headers = ('Data',)
-                report.write_artifact_data_table(data_headers, data_list_ec, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Email Change'
-                tsv(report_folder, data_headers, data_list_ec, tsvname)
-                
-            else:
-                logfunc(f'No Snapchat - Email Change')
-            
-            if data_list_dn:
-                report = ArtifactHtmlReport(f'Snapchat - Display Name Change')
-                report.start_artifact_report(report_folder, f'Snapchat - Display Name Change')
-                report.add_script()
-                data_headers = ('Timestamp','Display Name')
-                report.write_artifact_data_table(data_headers, data_list_dn, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Snapchat - Display Name Change'
-                tsv(report_folder, data_headers, data_list_dn, tsvname)
-                
-                tlactivity = f'Snapchat - Display Name Change'
-                timeline(report_folder, tlactivity, data_list_dn, data_headers)
-                
-            else:
-                logfunc(f'No Snapchat - Display Name Change')
-            
-        
-            
-    
-__artifacts__ = {
-        "snapchatAccounthist": (
-            "Snapchat Archive",
-            ('*/account_history.json'),
-            get_snapchatAccounthist)
+__artifacts_v2__ = {
+    "snapHistDisplayNameChange": _m("Display Name Change", "edit-3"),
+    "snapHistEmailChange": _m("Email Change", "mail"),
+    "snapHistMobileNumberChange": _m("Mobile Number Change", "phone"),
+    "snapHistPasswordChange": _m("Password Change", "key"),
+    "snapHistLinkedToBitmoji": _m("Linked to Bitmoji", "smile"),
+    "snapHistSpectacles": _m("Spectacles", "eye"),
+    "snapHistTwoFactorAuth": _m("Two-Factor Authentication", "shield"),
+    "snapHistAccountDeactivated": _m("Account Deactivated - Reactivated", "power"),
+    "snapHistDownloadReports": _m("Download My Data Reports", "download"),
 }
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+_MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+           'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
+
+
+def _snap_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    cleaned = value.replace(' UTC', '').strip()
+    if cleaned.isdigit():
+        return convert_unix_ts_to_utc(int(cleaned))
+    try:
+        dt = datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        pass
+    try:
+        parts = value.split(' ')
+        return datetime(int(parts[-1]), _MONTHS[parts[1]], int(parts[2]),
+                        *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
+    except (IndexError, KeyError, ValueError):
+        return value
+
+
+def _account_history(context):
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('account_history.json'):
+            with open(file_found, encoding='utf-8') as fp:
+                return file_found, json.load(fp)
+    return '', {}
+
+
+@artifact_processor
+def snapHistDisplayNameChange(context):
+    src, data = _account_history(context)
+    rows = [(_snap_ts(it.get('Date', '')), it.get('Display Name', ''))
+            for it in data.get('Display Name Change', [])]
+    return (('Timestamp', 'datetime'), 'Display Name'), rows, context.get_relative_path(src)
+
+
+@artifact_processor
+def snapHistMobileNumberChange(context):
+    src, data = _account_history(context)
+    rows = [(_snap_ts(it.get('Date', '')), it.get('Mobile Number', ''))
+            for it in data.get('Mobile Number Change', [])]
+    return (('Timestamp', 'datetime'), ('Mobile Number', 'phonenumber')), rows, context.get_relative_path(src)
+
+
+@artifact_processor
+def snapHistPasswordChange(context):
+    src, data = _account_history(context)
+    rows = [(_snap_ts(it.get('Date', '')),) for it in data.get('Password Change', [])]
+    return (('Timestamp', 'datetime'),), rows, context.get_relative_path(src)
+
+
+@artifact_processor
+def snapHistLinkedToBitmoji(context):
+    src, data = _account_history(context)
+    rows = [(_snap_ts(it.get('Date', '')),) for it in data.get('Snapchat Linked to Bitmoji', [])]
+    return (('Timestamp', 'datetime'),), rows, context.get_relative_path(src)
+
+
+@artifact_processor
+def snapHistDownloadReports(context):
+    src, data = _account_history(context)
+    rows = [(_snap_ts(it.get('Date', '')), it.get('Status', ''), it.get('Email Address', ''))
+            for it in data.get('Download My Data Reports', [])]
+    return (('Timestamp', 'datetime'), 'Status', 'Email Address'), rows, context.get_relative_path(src)
+
+
+def _single_value(context, key):
+    src, data = _account_history(context)
+    value = data.get(key)
+    rows = [(value,)] if value else []
+    return ('Data',), rows, context.get_relative_path(src)
+
+
+@artifact_processor
+def snapHistEmailChange(context):
+    return _single_value(context, 'Email Change')
+
+
+@artifact_processor
+def snapHistSpectacles(context):
+    return _single_value(context, 'Spectacles')
+
+
+@artifact_processor
+def snapHistTwoFactorAuth(context):
+    return _single_value(context, 'Two-Factor Authentication')
+
+
+@artifact_processor
+def snapHistAccountDeactivated(context):
+    return _single_value(context, 'Account deactivated / reactivated')


### PR DESCRIPTION
Final **Snapchat Archive** batch — account_history.json. The legacy artifact emitted **9 reports** → 9 `@artifact_processor` artifacts sharing `_account_history()` + `_single_value()` helpers: Display Name Change, Email Change, Mobile Number Change, Password Change, Linked to Bitmoji, Spectacles, Two-Factor Authentication, Account Deactivated/Reactivated, Download My Data Reports.

With this, **Snapchat Archive is complete (4 files → 22 artifacts)** and the Snapchat provider overall is done.

## Conventions applied
- `__artifacts__` funckey → `__artifacts_v2__`; @AlexisBrignoni; date kept.
- Context form; `Date` timestamps → aware UTC via `_snap_ts` (UTC + LAVA epoch storage verified in #324's round-trip).
- **`phonenumber` type** on the real `Mobile Number` column.
- Names use the `Snapchat Archive - ` prefix (loader requires globally-unique artifact names).
- Each artifact reads its key independently with `.get()` — the originals' `data_list_*` were defined only inside their `if key ==` blocks → `NameError` on a missing key.

Loader **227 → 235**.

## Validation
`py_compile` OK; **pylint clean (no W/E/F)**; **PluginLoader** (9 new keys, old key gone, unique-name check passes, total 235); **synthetic-JSON functional test** (UTC timestamps, the phonenumber column, single-value Data sections, absent section → empty).