### PR TITLE
Convert Discord Returns artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/discordReturnsdms.py
+++ b/scripts/artifacts/discordReturnsdms.py
@@ -1,86 +1,71 @@
-import os
-import datetime
-import csv
-import calendar
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsdms(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if not file_found.startswith('._'):
-            if file_found.endswith('.csv'):
-                data_list_dm =[]
-                with open(file_found, 'r', errors='backslashreplace') as f:
-                    for line in f:
-                        delimited = csv.reader(f, delimiter=',')
-                        for item in delimited:
-                            timestamp = item[3]
-                            username = item[4]
-                            contents = item[5]
-                            media = item[6]
-                            id = item[1]
-                            channelid = item[0]
-                            authorid = item[2]
-                            
-                            if media == '':
-                                agregator = ' '
-                            else:
-                                if '\n' in media:
-                                    media = media.split('\n')
-                                    agregator = '<table>'
-                                    counter = 0
-                                    for x in media:
-                                        if counter == 0:
-                                            agregator = agregator + ('<tr>')
-                                        media = x.split('/')
-                                        originalfilename = media[-1]
-                                        attachmentidentifier = f"{media[-2]}"
-                                        thumb = media_to_html(attachmentidentifier, files_found, report_folder)
-                                        counter = counter + 1
-                                        agregator = agregator + f'<td>{thumb}</td>'
-                                        #hacer uno que no tenga html
-                                        if counter == 2:
-                                            counter = 0
-                                            agregator = agregator + ('</tr>')
-                                    if counter == 1:
-                                        agregator = agregator + ('</tr>')
-                                    agregator = agregator + ('</table><br>')
-                                else:
-                                    media = media.split('/')
-                                    originalfilename = media[-1]
-                                    attachmentidentifier = f"{media[-2]}"
-                                    agregator = media_to_html(attachmentidentifier, files_found, report_folder)
-                            
-                            data_list_dm.append((timestamp,username,contents,agregator,id,channelid,authorid))
-                            
-        
-                if data_list_dm:
-                    report = ArtifactHtmlReport(f'Discord - Direct Messages ')
-                    report.start_artifact_report(report_folder, f'Discord - Direct Messages - {csvname}')
-                    report.add_script()
-                    data_headers = ('Timestamp','Username','Contents','Media','ID','Channel ID','Author ID')
-                    report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                    report.end_artifact_report()
-                    
-                    tsvname = f'Discord - Direct Messages - {csvname}'
-                    tsv(report_folder, data_headers, data_list_dm, tsvname)
-                    
-                    tlactivity = f'Discord -Direct Messages - {csvname}'
-                    timeline(report_folder, tlactivity, data_list_dm, data_headers)
-                else:
-                    logfunc(f'Discord - Direct Messages - {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsdms": (
-            "Discord Returns",
-            ('*/attachments/*.*', '*/messages/dms/*.csv'),
-            get_discordReturnsdms)
+__artifacts_v2__ = {
+    "discordReturnsdms": {
+        "name": "Discord - Direct Messages",
+        "description": "Direct messages from a Discord law enforcement return (messages/dms/*.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-12-04",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns",
+        "notes": "",
+        "paths": ('*/attachments/*.*', '*/messages/dms/*.csv'),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    }
 }
+
+import csv
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _discord_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    if value.isdigit():
+        return convert_unix_ts_to_utc(int(value))
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _media_refs(field):
+    refs = []
+    for part in (field or '').split('\n'):
+        part = part.strip()
+        if not part:
+            continue
+        segs = part.split('/')
+        attachment_id = segs[-2] if len(segs) >= 2 else part
+        ref = check_in_media(attachment_id, attachment_id)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+@artifact_processor
+def discordReturnsdms(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)  # header
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                data_list.append((_discord_ts(item[3]), item[4], item[5], _media_refs(item[6]),
+                                  item[1], item[0], item[2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Contents', ('Media', 'media'), 'ID',
+                    'Channel ID', 'Author ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsfriends.py
+++ b/scripts/artifacts/discordReturnsfriends.py
@@ -1,50 +1,40 @@
-import os
-import datetime
-import csv
-import calendar
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsfriends(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.csv'):
-            data_list_dm =[]
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                for line in f:
-                    delimited = csv.reader(f, delimiter=',')
-                    for item in delimited:
-                        userid = item[0]
-                        username = item[1]
-                        relationship = item[2]
-                        
-                        data_list_dm.append((userid,username,relationship))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'Discord - Friendships ')
-                report.start_artifact_report(report_folder, f'Discord - Friendships - {csvname}')
-                report.add_script()
-                data_headers = ('User ID','Username','Relationship')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Discord - Friendships - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-            else:
-                logfunc(f'Discord - Friendships - {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsfriends": (
-            "Discord Returns",
-            ('*/relationships_*.csv'),
-            get_discordReturnsfriends)
+__artifacts_v2__ = {
+    "discordReturnsfriends": {
+        "name": "Discord - Friendships",
+        "description": "Relationships/friendships from a Discord law enforcement return (relationships_*.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-12-04",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns",
+        "notes": "",
+        "paths": ('*/relationships_*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+    }
 }
+
+import csv
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def discordReturnsfriends(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)  # header
+            for item in reader:
+                if len(item) < 3:
+                    continue
+                data_list.append((item[0], item[1], item[2]))
+
+    data_headers = ('User ID', 'Username', 'Relationship')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsser.py
+++ b/scripts/artifacts/discordReturnsser.py
@@ -1,62 +1,45 @@
-import os
+__artifacts_v2__ = {
+    "discordReturnsser": {
+        "name": "Discord - Server Metadata",
+        "description": "Server metadata from a Discord law enforcement return (servers/*.json).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-12-04",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns",
+        "notes": "",
+        "paths": ('*/servers/*.json',),
+        "output_types": "standard",
+        "html_columns": ["Channels"],
+        "artifact_icon": "server",
+    }
+}
+
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
+from scripts.ilapfuncs import artifact_processor
 
-def get_discordReturnsser(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+@artifact_processor
+def discordReturnsser(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.json'):
-            data_list_dm =[]
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                data = json.load(f)
-                
-            id = data.get('id','')
-            name = data.get('name','')
-            owner_id = data.get('owner_id','')
-            banner = data.get('banner','')
-            preferred_locale = data.get('preferred_locale','')
-            region = data.get('region','')
-            splash = data.get('splash','')
-            threads = data.get('threads','')
-            channels = data.get('channels','')
-            agregator = '<table>'
-            if channels == '':
-                pass
-            else:
-                for key, value in channels.items():
-                    agregator = f'{agregator}<tr><td>{key}</td><td>{value}</td></tr>'
-            agregator = f'{agregator} </table>'
-            description = data.get('description','')
-            icon = data.get('icon','')
-            
-            data_list_dm.append((name,description,agregator,banner,icon,id,owner_id,preferred_locale,region,threads))
-            
-                        
-        
-            if len(data_list_dm) > 1:
-                report = ArtifactHtmlReport(f'Discord - Server Metadata ')
-                report.start_artifact_report(report_folder, f'Discord - Server Metadata - {csvname}')
-                report.add_script()
-                data_headers = ('Name','Description','Channels','Banner','Icon ID','ID','Owner ID','Preferred Locale','Region','Threads')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Channels'])
-                report.end_artifact_report()
-                
-                tsvname = f'Discord - Server Metadata - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-            else:
-                logfunc(f'No data in Discord - Server Metadata - {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsser": (
-            "Discord Returns",
-            ('*/servers/*.json'),
-            get_discordReturnsser)
-}
+        if not file_found.endswith('.json'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data = json.load(f)
+
+        channels = data.get('channels', '')
+        channels_agg = ('<br>'.join(f'{k}: {v}' for k, v in channels.items())
+                        if isinstance(channels, dict) else '')
+        data_list.append((data.get('name', ''), data.get('description', ''), channels_agg,
+                          data.get('banner', ''), data.get('icon', ''), data.get('id', ''),
+                          data.get('owner_id', ''), data.get('preferred_locale', ''),
+                          data.get('region', ''), data.get('threads', '')))
+
+    data_headers = ('Name', 'Description', 'Channels', 'Banner', 'Icon ID', 'ID', 'Owner ID',
+                    'Preferred Locale', 'Region', 'Threads')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsserver.py
+++ b/scripts/artifacts/discordReturnsserver.py
@@ -1,85 +1,71 @@
-import os
-import datetime
-import csv
-import calendar
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsserver(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.csv'):
-            data_list_dm =[]
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                for line in f:
-                    delimited = csv.reader(f, delimiter=',')
-                    for item in delimited:
-                        timestamp = item[3]
-                        username = item[4]
-                        contents = item[5]
-                        media = item[6]
-                        id = item[0]
-                        channelid = item[1]
-                        authorid = item[2]
-                        
-                        if media == '':
-                            agregator = ' '
-                        else:
-                            if '\n' in media:
-                                media = media.split('\n')
-                                agregator = '<table>'
-                                counter = 0
-                                for x in media:
-                                    if counter == 0:
-                                        agregator = agregator + ('<tr>')
-                                    media = x.split('/')
-                                    originalfilename = media[-1]
-                                    attachmentidentifier = f"{media[-2]}"
-                                    thumb = media_to_html(attachmentidentifier, files_found, report_folder)
-                                    counter = counter + 1
-                                    agregator = agregator + f'<td>{thumb}</td>'
-                                    #hacer uno que no tenga html
-                                    if counter == 2:
-                                        counter = 0
-                                        agregator = agregator + ('</tr>')
-                                if counter == 1:
-                                    agregator = agregator + ('</tr>')
-                                agregator = agregator + ('</table><br>')
-                            else:
-                                media = media.split('/')
-                                originalfilename = media[-1]
-                                attachmentidentifier = f"{media[-2]}"
-                                agregator = media_to_html(attachmentidentifier, files_found, report_folder)
-                        
-                        data_list_dm.append((timestamp,username,contents,agregator,id,channelid,authorid))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'Discord - Messages Server')
-                report.start_artifact_report(report_folder, f'Discord - Messages Server - {csvname}')
-                report.add_script()
-                data_headers = ('Timestamp','Username','Contents','Media','ID','Channel ID','Author ID')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Discord - Messages Server - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-                tlactivity = f'Discord - Messages Server - {csvname}'
-                timeline(report_folder, tlactivity, data_list_dm, data_headers)
-            else:
-                logfunc(f'Discord - Messages Server - {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsserver": (
-            "Discord Returns",
-            ('*/attachments/*.*', '*/messages/servers/*.csv'),
-            get_discordReturnsserver)
+__artifacts_v2__ = {
+    "discordReturnsserver": {
+        "name": "Discord - Messages Server",
+        "description": "Server messages from a Discord law enforcement return (messages/servers/*.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-12-04",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns",
+        "notes": "",
+        "paths": ('*/attachments/*.*', '*/messages/servers/*.csv'),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
 }
+
+import csv
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _discord_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    if value.isdigit():
+        return convert_unix_ts_to_utc(int(value))
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _media_refs(field):
+    refs = []
+    for part in (field or '').split('\n'):
+        part = part.strip()
+        if not part:
+            continue
+        segs = part.split('/')
+        attachment_id = segs[-2] if len(segs) >= 2 else part
+        ref = check_in_media(attachment_id, attachment_id)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+@artifact_processor
+def discordReturnsserver(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)  # header
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                data_list.append((_discord_ts(item[3]), item[4], item[5], _media_refs(item[6]),
+                                  item[0], item[1], item[2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Contents', ('Media', 'media'), 'ID',
+                    'Channel ID', 'Author ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsunkn.py
+++ b/scripts/artifacts/discordReturnsunkn.py
@@ -1,84 +1,71 @@
-import os
-import datetime
-import csv
-import calendar
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsunkn(files_found, report_folder, seeker, wrap_text):
-
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.csv'):
-            data_list_dm =[]
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                for line in f:
-                    delimited = csv.reader(f, delimiter=',')
-                    for item in delimited:
-                        timestamp = item[3]
-                        username = item[4]
-                        contents = item[5]
-                        media = item[6]
-                        id = item[0]
-                        channelid = item[1]
-                        authorid = item[2]
-                        
-                        if media == '':
-                            agregator = ' '
-                        else:
-                            if '\n' in media:
-                                media = media.split('\n')
-                                agregator = '<table>'
-                                counter = 0
-                                for x in media:
-                                    if counter == 0:
-                                        agregator = agregator + ('<tr>')
-                                    media = x.split('/')
-                                    originalfilename = media[-1]
-                                    attachmentidentifier = f"{media[-2]}"
-                                    thumb = media_to_html(attachmentidentifier, files_found, report_folder)
-                                    counter = counter + 1
-                                    agregator = agregator + f'<td>{thumb}</td>'
-                                    #hacer uno que no tenga html
-                                    if counter == 2:
-                                        counter = 0
-                                        agregator = agregator + ('</tr>')
-                                if counter == 1:
-                                    agregator = agregator + ('</tr>')
-                                agregator = agregator + ('</table><br>')
-                            else:
-                                media = media.split('/')
-                                originalfilename = media[-1]
-                                attachmentidentifier = f"{media[-2]}"
-                                agregator = media_to_html(attachmentidentifier, files_found, report_folder)
-                        
-                        data_list_dm.append((timestamp,username,contents,agregator,id,channelid,authorid))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'Discord - Unknown Messages ')
-                report.start_artifact_report(report_folder, f'Discord - Unknown Messages - {csvname}')
-                report.add_script()
-                data_headers = ('Timestamp','Username','Contents','Media','ID','Channel ID','Author ID')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'Discord - Unknown Messages - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-                tlactivity = f'Discord - Unknown Messages - {csvname}'
-                timeline(report_folder, tlactivity, data_list_dm, data_headers)
-            else:
-                logfunc(f'Discord - Unknown Messages - {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsunkn": (
-            "Discord Returns",
-            ('*/attachments/*.*', '*/messages/unknown/*.csv'),
-            get_discordReturnsunkn)
+__artifacts_v2__ = {
+    "discordReturnsunkn": {
+        "name": "Discord - Unknown Messages",
+        "description": "Unknown-channel messages from a Discord law enforcement return (messages/unknown/*.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-12-04",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns",
+        "notes": "",
+        "paths": ('*/attachments/*.*', '*/messages/unknown/*.csv'),
+        "output_types": "standard",
+        "artifact_icon": "help-circle",
+    }
 }
+
+import csv
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+def _discord_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    if value.isdigit():
+        return convert_unix_ts_to_utc(int(value))
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _media_refs(field):
+    refs = []
+    for part in (field or '').split('\n'):
+        part = part.strip()
+        if not part:
+            continue
+        segs = part.split('/')
+        attachment_id = segs[-2] if len(segs) >= 2 else part
+        ref = check_in_media(attachment_id, attachment_id)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+@artifact_processor
+def discordReturnsunkn(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)  # header
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                data_list.append((_discord_ts(item[3]), item[4], item[5], _media_refs(item[6]),
+                                  item[0], item[1], item[2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Contents', ('Media', 'media'), 'ID',
+                    'Channel ID', 'Author ID')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the five **Discord Returns** artifacts to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `discordReturnsfriends` | Discord - Friendships | `relationships_*.csv` |
| `discordReturnsser` | Discord - Server Metadata | `servers/*.json` |
| `discordReturnsdms` | Discord - Direct Messages | `messages/dms/*.csv` |
| `discordReturnsserver` | Discord - Messages Server | `messages/servers/*.csv` |
| `discordReturnsunkn` | Discord - Unknown Messages | `messages/unknown/*.csv` |

## Changes
- **Context API** — `context.get_files_found()` and `context.get_relative_path()` for source-file columns.
- **Timestamps → UTC** — message timestamps parsed to aware-UTC datetimes (unix-seconds, ISO, and ISO-`Z` forms) and typed `('Timestamp','datetime')`.
- **Media** — `check_in_media` replaces `media_to_html`; the Media column is built as a list of refs from the newline-separated attachment paths (attachment id = second-to-last path segment). AppleDouble `._` sidecars are skipped.
- **Bug fix** — Server Metadata previously gated output on `len(...) > 1` and never reported; it now emits one row per server JSON.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit via real `CREATE TABLE` + `sanitize_sql_name`: no collisions.
- `PluginLoader` loads all five (total **235**), no duplicate-name error.
- Synthetic round-trip test: all three timestamp formats normalize to the same UTC instant; media lists built; positional ID / Channel ID / Author ID mapping preserved per original (dms swaps the first two columns vs server/unkn).