### PR TITLE
Convert Discord Returns Online artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/discordReturnsOnlineArchived.py
+++ b/scripts/artifacts/discordReturnsOnlineArchived.py
@@ -1,95 +1,98 @@
-import os
-import datetime
-import csv
-import calendar
-from pathlib import Path
-import requests
-import urllib.parse
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsOnlineArchived(files_found, report_folder, seeker, wrap_text):
-
-    counter = 0
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.csv'):
-            data_list_dm =[]
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                for line in f:
-                    delimited = csv.reader(f, delimiter=',')
-                    for item in delimited:
-                        timestamp = item[3]
-                        username = item[4]
-                        contents = item[5]
-                        media = item[6]
-                        id = item[0]
-                        channelid = item[1]
-                        authorid = item[2]
-                        thumb = ''
-                        if media.startswith('https'):
-                            url = urllib.parse.unquote(media)
-                            dlpath = Path(report_folder, f'media{counter}')
-                            response = requests.get(url, stream=True)
-                            if not response.ok:
-                                logfunc(f'{response} on {csvname}')
-                            else:
-                                with open(dlpath, 'wb') as handle:
-                                    for block in response.iter_content(1024):
-                                        if not block:
-                                            break
-                                        
-                                        handle.write(block)
-                                datalist_temp =[]
-                                datalist_temp.append(str(dlpath))
-                                thumb = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                counter = counter + 1
-                        
-                        if ('cdn.discordapp.com' or 'media.discordapp.net') in contents and (contents.startswith('http')):
-                            url = urllib.parse.unquote(contents)
-                            dlpath = Path(report_folder, f'media{counter}')
-                            response = requests.get(url, stream=True)
-                            if not response.ok:
-                                logfunc(f'{response} on {csvname}')
-                            else:
-                                with open(dlpath, 'wb') as handle:
-                                    for block in response.iter_content(1024):
-                                        if not block:
-                                            break
-                                        
-                                        handle.write(block)
-                                datalist_temp =[]
-                                datalist_temp.append(str(dlpath))
-                                contents = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                counter = counter + 1
-                                
-                        data_list_dm.append((timestamp,username,contents,thumb,id,channelid,authorid))
-                            
-        
-        if len(data_list_dm) > 0:
-            report = ArtifactHtmlReport(f'Discord - Archived ')
-            report.start_artifact_report(report_folder, f'Discord - Archived - {csvname}')
-            report.add_script()
-            data_headers = ('Timestamp','Username','Contents','Attachment','ID','Channel ID','Author ID')
-            report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Attachment','Contents'])
-            report.end_artifact_report()
-            
-            tsvname = f'Discord - Archived - {csvname}'
-            tsv(report_folder, data_headers, data_list_dm, tsvname)
-            
-            tlactivity = f'Discord -Direct Messages - {csvname}'
-            timeline(report_folder, tlactivity, data_list_dm, data_headers)
-        else:
-            logfunc(f'No Discord - Archived in {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsOnlineArchived": (
-            "Discord Returns Online",
-            ('*/messages/archived/*.csv'),
-            get_discordReturnsOnlineArchived)
+__artifacts_v2__ = {
+    "discordReturnsOnlineArchived": {
+        "name": "Discord Online - Archived",
+        "description": "Archived messages from a Discord law enforcement return with media fetched "
+                       "live from Discord CDN URLs (messages/archived/*.csv).",
+        "author": "Kate (thekatecain)",
+        "creation_date": "2024-04-09",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns Online",
+        "notes": "Media is fetched live over the network from Discord CDN URLs found in the return. "
+                 "Discord CDN attachment links (cdn.discordapp.com / media.discordapp.net) are "
+                 "publicly accessible without any authentication - anyone holding the URL can "
+                 "retrieve the file. Downloaded bytes are embedded via check_in_embedded_media "
+                 "(network requests use a 30s timeout); the original URL is preserved in the "
+                 "Contents column.",
+        "paths": ('*/messages/archived/*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "archive",
+    }
 }
+
+import csv
+import os
+import urllib.parse
+from datetime import datetime, timezone
+
+import requests
+
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
+                               check_in_embedded_media, logfunc)
+
+
+def _discord_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    if value.isdigit():
+        return convert_unix_ts_to_utc(int(value))
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _fetch_embed(url, source_file):
+    url = urllib.parse.unquote(url)
+    try:
+        resp = requests.get(url, stream=True, timeout=30)
+    except requests.RequestException as exc:
+        logfunc(f'Discord Online: request failed for {url}: {exc}')
+        return None
+    if not resp.ok:
+        logfunc(f'Discord Online: HTTP {resp.status_code} for {url}')
+        return None
+    name = os.path.basename(urllib.parse.urlparse(url).path) or 'discord_media'
+    return check_in_embedded_media(source_file, resp.content, name)
+
+
+def _collect_refs(media_field, contents, source_file):
+    refs = []
+    media_field = (media_field or '').strip()
+    if media_field.startswith('https'):
+        ref = _fetch_embed(media_field, source_file)
+        if ref:
+            refs.append(ref)
+    contents = (contents or '').strip()
+    if contents.startswith('http') and ('cdn.discordapp.com' in contents
+                                         or 'media.discordapp.net' in contents):
+        ref = _fetch_embed(contents, source_file)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+@artifact_processor
+def discordReturnsOnlineArchived(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)  # header
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                refs = _collect_refs(item[6], item[5], file_found)
+                data_list.append((_discord_ts(item[3]), item[4], item[5], refs,
+                                  item[0], item[1], item[2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Contents', ('Attachment', 'media'),
+                    'ID', 'Channel ID', 'Author ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsOnlineDMs.py
+++ b/scripts/artifacts/discordReturnsOnlineDMs.py
@@ -1,172 +1,142 @@
-import os
-import datetime
-import csv
-import calendar
-from pathlib import Path
-import requests
-import urllib.parse
+_NOTE = ("Media is fetched live over the network from Discord CDN URLs found in the return. "
+         "Discord CDN attachment links (cdn.discordapp.com / media.discordapp.net) are publicly "
+         "accessible without any authentication - anyone holding the URL can retrieve the file. "
+         "Downloaded bytes are embedded via check_in_embedded_media (network requests use a 30s "
+         "timeout); the original URL is preserved in the Contents column.")
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsdmsOnline(files_found, report_folder, seeker, wrap_text):
-    data_list_dm =[]
-    data_list_dm_four = []
-    
-    counter = 0
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.csv'):
-            
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                reader = csv.reader(f,delimiter=',')
-                ncol = len(next(reader)) # Read first line and count columns
-                f.seek(0)
-                for line in f:
-                    delimited = csv.reader(f, delimiter=',')
-                    delimitedlength = ncol
-                    if delimitedlength == 4:
-                        for item in delimited:
-                            timestamp = item[1]
-                            contents = item[2]
-                            media = item[3]
-                            id = item[0]
-                            thumb = ''
-                            if media.startswith('https'):
-                                url = urllib.parse.unquote(media)
-                                dlpath = Path(report_folder, f'media{counter}')
-                                response = requests.get(url, stream=True)
-                                if not response.ok:
-                                    logfunc(f'{response} on {csvname}')
-                                else:
-                                    with open(dlpath, 'wb') as handle:
-                                        for block in response.iter_content(1024):
-                                            if not block:
-                                                break
-                                            
-                                            handle.write(block)
-                                    datalist_temp =[]
-                                    datalist_temp.append(str(dlpath))
-                                    #print(datalist_temp)
-                                    thumb = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                    print(thumb)
-                                    counter = counter + 1
-                                    
-                            if ('cdn.discordapp.com' or 'media.discordapp.net') in contents and (contents.startswith('http')):
-                                url = urllib.parse.unquote(contents)
-                                dlpath = Path(report_folder, f'media{counter}')
-                                response = requests.get(url, stream=True)
-                                if not response.ok:
-                                    logfunc(f'{response} on {csvname}')
-                                else:
-                                    with open(dlpath, 'wb') as handle:
-                                        for block in response.iter_content(1024):
-                                            if not block:
-                                                break
-                                            
-                                            handle.write(block)
-                                    datalist_temp =[]
-                                    datalist_temp.append(str(dlpath))
-                                    #talist_temp)
-                                    thumb = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                    print(thumb)
-                                    counter = counter + 1
-                            
-                            data_list_dm_four.append((timestamp,id,contents,thumb))
-                    else:
-                        for item in delimited:
-                            timestamp = item[3]
-                            username = item[4]
-                            contents = item[5]
-                            media = item[6]
-                            id = item[0]
-                            channelid = item[1]
-                            authorid = item[2]
-                            thumb = ''
-                            if media.startswith('https'):
-                                url = urllib.parse.unquote(media)
-                                dlpath = Path(report_folder, f'media{counter}')
-                                response = requests.get(url, stream=True)
-                                if not response.ok:
-                                    logfunc(f'{response} on {csvname}')
-                                else:
-                                    with open(dlpath, 'wb') as handle:
-                                        for block in response.iter_content(1024):
-                                            if not block:
-                                                break
-                                            
-                                            handle.write(block)
-                                    datalist_temp =[]
-                                    datalist_temp.append(str(dlpath))
-                                    #print(datalist_temp)
-                                    thumb = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                    print(thumb)
-                                    counter = counter + 1
-                            
-                            if ('cdn.discordapp.com' or 'media.discordapp.net') in contents and (contents.startswith('http')):
-                                url = urllib.parse.unquote(contents)
-                                
-                                dlpath = Path(report_folder, f'media{counter}')
-                                response = requests.get(url, stream=True)
-                                if not response.ok:
-                                    logfunc(f'{response} on {csvname}')
-                                else:
-                                    with open(dlpath, 'wb') as handle:
-                                        for block in response.iter_content(1024):
-                                            if not block:
-                                                break
-                                            
-                                            handle.write(block)
-                                    datalist_temp =[]
-                                    datalist_temp.append(str(dlpath))
-                                    #print(datalist_temp)
-                                    thumb = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                    print(thumb)
-                                    counter = counter + 1
-                                    
-                            data_list_dm.append((timestamp,username,contents,thumb,id,channelid,authorid))
-                            
-        
-        if len(data_list_dm) > 0:
-            report = ArtifactHtmlReport(f'Discord - Direct Messages ')
-            report.start_artifact_report(report_folder, f'Discord - Direct Messages - {csvname}')
-            report.add_script()
-            data_headers = ('Timestamp','Username','Contents','Attachment','ID','Channel ID','Author ID')
-            report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Attachment','Contents'])
-            report.end_artifact_report()
-            
-            tsvname = f'Discord - Direct Messages - {csvname}'
-            tsv(report_folder, data_headers, data_list_dm, tsvname)
-            
-            tlactivity = f'Discord -Direct Messages - {csvname}'
-            timeline(report_folder, tlactivity, data_list_dm, data_headers)
-        else:
-            logfunc(f'No Discord - Direct Messages in {csvname}')
-        
-
-        if len(data_list_dm_four) > 0:
-            report = ArtifactHtmlReport(f'Discord - Direct Messages ')
-            report.start_artifact_report(report_folder, f'Discord - Direct Messages - {csvname}')
-            report.add_script()
-            data_headers = ('Timestamp','ID','Contents','Attachment')
-            report.write_artifact_data_table(data_headers, data_list_dm_four, file_found, html_no_escape=['Attachment','Contents'])
-            report.end_artifact_report()
-            
-            tsvname = f'Discord - Direct Messages - {csvname}'
-            tsv(report_folder, data_headers, data_list_dm_four, tsvname)
-            
-            tlactivity = f'Discord -Direct Messages - {csvname}'
-            timeline(report_folder, tlactivity, data_list_dm_four, data_headers)
-        else:
-            logfunc(f'No Discord - Direct Messages in {csvname}')
-            
-__artifacts__ = {
-        "discordReturnsOnlineDMs": (
-            "Discord Returns Online",
-            ('*/messages/*/*.csv'),
-            get_discordReturnsdmsOnline)
+__artifacts_v2__ = {
+    "discordReturnsOnlineDMs": {
+        "name": "Discord Online - Direct Messages",
+        "description": "Direct messages (7-column export) from a Discord law enforcement return "
+                       "with media fetched live from Discord CDN URLs (messages/*/*.csv).",
+        "author": "Kate (thekatecain)",
+        "creation_date": "2024-04-09",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns Online",
+        "notes": _NOTE,
+        "paths": ('*/messages/*/*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    },
+    "discordReturnsOnlineDMsCompact": {
+        "name": "Discord Online - Direct Messages (Compact)",
+        "description": "Direct messages (4-column export: timestamp, id, contents, attachment) "
+                       "from a Discord law enforcement return with media fetched live from "
+                       "Discord CDN URLs (messages/*/*.csv).",
+        "author": "Kate (thekatecain)",
+        "creation_date": "2024-04-09",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns Online",
+        "notes": _NOTE,
+        "paths": ('*/messages/*/*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
 }
+
+import csv
+import os
+import urllib.parse
+from datetime import datetime, timezone
+
+import requests
+
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
+                               check_in_embedded_media, logfunc)
+
+
+def _discord_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    if value.isdigit():
+        return convert_unix_ts_to_utc(int(value))
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _fetch_embed(url, source_file):
+    url = urllib.parse.unquote(url)
+    try:
+        resp = requests.get(url, stream=True, timeout=30)
+    except requests.RequestException as exc:
+        logfunc(f'Discord Online: request failed for {url}: {exc}')
+        return None
+    if not resp.ok:
+        logfunc(f'Discord Online: HTTP {resp.status_code} for {url}')
+        return None
+    name = os.path.basename(urllib.parse.urlparse(url).path) or 'discord_media'
+    return check_in_embedded_media(source_file, resp.content, name)
+
+
+def _collect_refs(media_field, contents, source_file):
+    refs = []
+    media_field = (media_field or '').strip()
+    if media_field.startswith('https'):
+        ref = _fetch_embed(media_field, source_file)
+        if ref:
+            refs.append(ref)
+    contents = (contents or '').strip()
+    if contents.startswith('http') and ('cdn.discordapp.com' in contents
+                                         or 'media.discordapp.net' in contents):
+        ref = _fetch_embed(contents, source_file)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+@artifact_processor
+def discordReturnsOnlineDMs(context):
+    """Direct messages exported with the 7-column schema."""
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            header = next(reader, None)
+            if header is None or len(header) == 4:
+                continue  # handled by the compact (4-column) artifact
+            source_path = file_found
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                refs = _collect_refs(item[6], item[5], file_found)
+                data_list.append((_discord_ts(item[3]), item[4], item[5], refs,
+                                  item[0], item[1], item[2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Contents', ('Attachment', 'media'),
+                    'ID', 'Channel ID', 'Author ID')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def discordReturnsOnlineDMsCompact(context):
+    """Direct messages exported with the 4-column schema (timestamp, id, contents, attachment)."""
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            header = next(reader, None)
+            if header is None or len(header) != 4:
+                continue  # handled by the 7-column artifact
+            source_path = file_found
+            for item in reader:
+                if len(item) < 4:
+                    continue
+                refs = _collect_refs(item[3], item[2], file_found)
+                data_list.append((_discord_ts(item[1]), item[0], item[2], refs))
+
+    data_headers = (('Timestamp', 'datetime'), 'ID', 'Contents', ('Attachment', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsOnlineServers.py
+++ b/scripts/artifacts/discordReturnsOnlineServers.py
@@ -1,95 +1,98 @@
-import os
-import datetime
-import csv
-import calendar
-from pathlib import Path
-import requests
-import urllib.parse
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_discordReturnsOnlineServers(files_found, report_folder, seeker, wrap_text):
-
-    counter = 0
-    for file_found in files_found:
-        file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.csv'):
-            data_list_dm =[]
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                for line in f:
-                    delimited = csv.reader(f, delimiter=',')
-                    for item in delimited:
-                        timestamp = item[3]
-                        username = item[4]
-                        contents = item[5]
-                        media = item[6]
-                        id = item[0]
-                        channelid = item[1]
-                        authorid = item[2]
-                        thumb = ''
-                        if media.startswith('https'):
-                            url = urllib.parse.unquote(media)
-                            dlpath = Path(report_folder, f'media{counter}')
-                            response = requests.get(url, stream=True)
-                            if not response.ok:
-                                logfunc(f'{response} on {csvname}')
-                            else:
-                                with open(dlpath, 'wb') as handle:
-                                    for block in response.iter_content(1024):
-                                        if not block:
-                                            break
-                                        
-                                        handle.write(block)
-                                datalist_temp =[]
-                                datalist_temp.append(str(dlpath))
-                                thumb = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                counter = counter + 1
-                        
-                        if ('cdn.discordapp.com' or 'media.discordapp.net') in contents and (contents.startswith('http')):
-                            url = urllib.parse.unquote(contents)
-                            dlpath = Path(report_folder, f'media{counter}')
-                            response = requests.get(url, stream=True)
-                            if not response.ok:
-                                logfunc(f'{response} on {csvname}')
-                            else:
-                                with open(dlpath, 'wb') as handle:
-                                    for block in response.iter_content(1024):
-                                        if not block:
-                                            break
-                                        
-                                        handle.write(block)
-                                datalist_temp =[]
-                                datalist_temp.append(str(dlpath))
-                                contents = media_to_html(f'media{counter}', datalist_temp, report_folder)
-                                counter = counter + 1
-                                
-                        data_list_dm.append((timestamp,username,contents,thumb,id,channelid,authorid))
-                            
-        
-        if len(data_list_dm) > 0:
-            report = ArtifactHtmlReport(f'Discord - Servers ')
-            report.start_artifact_report(report_folder, f'Discord - Servers - {csvname}')
-            report.add_script()
-            data_headers = ('Timestamp','Username','Contents','Attachment','ID','Channel ID','Author ID')
-            report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Attachment','Contents'])
-            report.end_artifact_report()
-            
-            tsvname = f'Discord - Servers - {csvname}'
-            tsv(report_folder, data_headers, data_list_dm, tsvname)
-            
-            tlactivity = f'Discord - Servers - {csvname}'
-            timeline(report_folder, tlactivity, data_list_dm, data_headers)
-        else:
-            logfunc(f'No Discord - Servers in {csvname}')
-                
-__artifacts__ = {
-        "discordReturnsOnlineServers": (
-            "Discord Returns Online",
-            ('*/messages/servers/*.csv'),
-            get_discordReturnsOnlineServers)
+__artifacts_v2__ = {
+    "discordReturnsOnlineServers": {
+        "name": "Discord Online - Servers",
+        "description": "Server messages from a Discord law enforcement return with media fetched "
+                       "live from Discord CDN URLs (messages/servers/*.csv).",
+        "author": "Kate (thekatecain)",
+        "creation_date": "2024-04-09",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Discord Returns Online",
+        "notes": "Media is fetched live over the network from Discord CDN URLs found in the return. "
+                 "Discord CDN attachment links (cdn.discordapp.com / media.discordapp.net) are "
+                 "publicly accessible without any authentication - anyone holding the URL can "
+                 "retrieve the file. Downloaded bytes are embedded via check_in_embedded_media "
+                 "(network requests use a 30s timeout); the original URL is preserved in the "
+                 "Contents column.",
+        "paths": ('*/messages/servers/*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "server",
+    }
 }
+
+import csv
+import os
+import urllib.parse
+from datetime import datetime, timezone
+
+import requests
+
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
+                               check_in_embedded_media, logfunc)
+
+
+def _discord_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    if value.isdigit():
+        return convert_unix_ts_to_utc(int(value))
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _fetch_embed(url, source_file):
+    url = urllib.parse.unquote(url)
+    try:
+        resp = requests.get(url, stream=True, timeout=30)
+    except requests.RequestException as exc:
+        logfunc(f'Discord Online: request failed for {url}: {exc}')
+        return None
+    if not resp.ok:
+        logfunc(f'Discord Online: HTTP {resp.status_code} for {url}')
+        return None
+    name = os.path.basename(urllib.parse.urlparse(url).path) or 'discord_media'
+    return check_in_embedded_media(source_file, resp.content, name)
+
+
+def _collect_refs(media_field, contents, source_file):
+    refs = []
+    media_field = (media_field or '').strip()
+    if media_field.startswith('https'):
+        ref = _fetch_embed(media_field, source_file)
+        if ref:
+            refs.append(ref)
+    contents = (contents or '').strip()
+    if contents.startswith('http') and ('cdn.discordapp.com' in contents
+                                         or 'media.discordapp.net' in contents):
+        ref = _fetch_embed(contents, source_file)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+@artifact_processor
+def discordReturnsOnlineServers(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('._'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)  # header
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                refs = _collect_refs(item[6], item[5], file_found)
+                data_list.append((_discord_ts(item[3]), item[4], item[5], refs,
+                                  item[0], item[1], item[2]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Contents', ('Attachment', 'media'),
+                    'ID', 'Channel ID', 'Author ID')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the three **Discord Returns Online** artifacts to the context-based `@artifact_processor` pipeline. The DM export ships in two schemas, so it splits into two artifacts (**four total**).

## Artifacts
| Module | Key | Name | Source |
|---|---|---|---|
| `discordReturnsOnlineArchived` | `discordReturnsOnlineArchived` | Discord Online - Archived | `messages/archived/*.csv` |
| `discordReturnsOnlineServers` | `discordReturnsOnlineServers` | Discord Online - Servers | `messages/servers/*.csv` |
| `discordReturnsOnlineDMs` | `discordReturnsOnlineDMs` | Discord Online - Direct Messages | `messages/*/*.csv` (7-col) |
| `discordReturnsOnlineDMs` | `discordReturnsOnlineDMsCompact` | Discord Online - Direct Messages (Compact) | `messages/*/*.csv` (4-col) |

## ⚠️ Network behavior (preserved by request)
These "Online" artifacts **fetch media live over the network** from Discord CDN URLs found in the return — that is the defining behavior of the category. A note on each artifact documents that **Discord CDN attachment URLs (`cdn.discordapp.com` / `media.discordapp.net`) are publicly accessible without any authentication**, so anyone holding the URL can retrieve the file. Requests now use a **30s timeout**.

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()` for source-file columns.
- **Timestamps → UTC** — parsed to aware-UTC datetimes (unix-seconds, ISO, ISO-`Z`), typed `('Timestamp','datetime')`.
- **Media** — downloaded bytes routed through `check_in_embedded_media` (replacing `media_to_html` + stray `media{n}` files). The `('Attachment','media')` column collects refs from the media field **and** any Discord CDN URL embedded in Contents; the original URL is now **kept as text** in Contents (previously overwritten with rendered HTML).
- **Bug fix** — `('cdn.discordapp.com' or 'media.discordapp.net') in contents` always short-circuited to the first string, so `media.discordapp.net` URLs were never matched; now both hosts are checked.
- **Schema routing** — the 7-column and 4-column DM artifacts each read the header's column count and process only their own schema, skipping the other.
- `._` AppleDouble sidecars skipped.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit via real `CREATE TABLE` + `sanitize_sql_name`: no collisions.
- `PluginLoader` loads all four (total **236**, net +1 vs the prior v1 trio), no duplicate-name error.
- Synthetic round-trip (network stubbed): 7-col routes 3 rows / 4-col routes 1 row with cross-shape files skipped; media refs built from media-field and CDN-in-contents; plain text → no media; both CDN hosts exercised; timestamps tz-aware UTC.

Original author attribution (Kate / thekatecain, 2024-04-09) preserved.