### PR TITLE
Convert TikTok Returns artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/tikTokipdata.py
+++ b/scripts/artifacts/tikTokipdata.py
@@ -1,57 +1,72 @@
+__artifacts_v2__ = {
+    "tikTokipdata": {
+        "name": "TikTok - IP Data",
+        "description": "IP login/activity data from a TikTok law enforcement return (*- IP Data.xlsx).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-09-29",
+        "last_update_date": "2026-06-28",
+        "requirements": "openpyxl",
+        "category": "TikTok Returns",
+        "notes": "Source File column added so per-subscriber provenance (originally encoded in the "
+                 "report title) survives when multiple returns are merged into one table.",
+        "paths": ('*/*/*- IP Data.xlsx',),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+    }
+}
+
 import os
+from datetime import datetime, timezone
+
 import openpyxl
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-def get_tikTokipdata(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+
+def _to_utc(value):
+    if value is None or value == '':
+        return ''
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+    s = str(value).strip()
+    if not s:
+        return ''
+    if s.isdigit():
+        return convert_unix_ts_to_utc(int(s))
+    try:
+        dt = datetime.fromisoformat(s.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _cell(value):
+    return '' if value is None else value
+
+
+@artifact_processor
+def tikTokipdata(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
         filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
+        if filename.startswith('~') or filename.startswith('.') or not filename.endswith('.xlsx'):
             continue
-        if filename.startswith('.'):
-            continue
-        
-        dth = []
-        listtemp = []
-        data_headers = []
-        data_list =[]
-        
-        subscriber = filename.split('-')
-        
-        wb_obj = openpyxl.load_workbook(file_found)
-        sheet_obj = wb_obj.active
-        
-        max_col = sheet_obj.max_column
-        m_row = sheet_obj.max_row
-        
-        # Will print a particular row value
-        for j in range(1, m_row + 1):
-            for i in range(1, max_col + 1):
-                cell_obj = sheet_obj.cell(row = j, column = i)
-                value = (cell_obj.value)
-                listtemp.append(value)
-            data_list.append((listtemp))
-            listtemp = []
-            
-        if data_list:
-            data_list.pop(0) #eliminate headers from excel file
-            report = ArtifactHtmlReport(f'TikTok - IP Data [{subscriber[0]}] ')
-            report.start_artifact_report(report_folder, f'TikTok - IP Data [{subscriber[0]}] ')
-            report.add_script()
-            data_headers = ('Timestamp', 'Active Start Time', 'IP', 'IP Country' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-        else:
-            logfunc(f'No TikTok - IP Data [{subscriber[0]}]  available')
+        source_path = file_found
+        rel = context.get_relative_path(file_found)
+        wb = openpyxl.load_workbook(file_found, read_only=True, data_only=True)
+        try:
+            sheet = wb.active
+            for idx, row in enumerate(sheet.iter_rows(values_only=True)):
+                if idx == 0:
+                    continue  # header row inside the spreadsheet
+                cells = list(row) + ['', '', '', '']
+                data_list.append((_to_utc(cells[0]), _to_utc(cells[1]), _cell(cells[2]),
+                                  _cell(cells[3]), rel))
+        finally:
+            wb.close()
 
-__artifacts__ = {
-        "tikTokipdata": (
-            "TikTok Returns",
-            ('*/*/*- IP Data.xlsx'),
-            get_tikTokipdata)
-}
+    data_headers = (('Timestamp', 'datetime'), ('Active Start Time', 'datetime'), 'IP',
+                    'IP Country', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/tikToksubsinfo.py
+++ b/scripts/artifacts/tikToksubsinfo.py
@@ -1,70 +1,83 @@
+__artifacts_v2__ = {
+    "tikToksubsinfo": {
+        "name": "TikTok - Subscriber Info",
+        "description": "Subscriber/registration information from a TikTok law enforcement return "
+                       "((Subscriber information).pdf).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-09-29",
+        "last_update_date": "2026-06-28",
+        "requirements": "PyMuPDF",
+        "category": "TikTok Returns",
+        "notes": "Source File column added so per-subscriber provenance (originally encoded in the "
+                 "report title) survives when multiple returns are merged into one table.",
+        "paths": ('*/*/*(Subscriber information).pdf',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
+}
+
 import os
+from datetime import datetime, timezone
+
 import fitz
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-def get_tikToksubsinfo(files_found, report_folder, seeker, wrap_text):
-    files = 0
-    for file_found in files_found:
+
+def _to_utc(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def tikToksubsinfo(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
         filename = os.path.basename(file_found)
-        
-        if filename.startswith('~'):
+        if filename.startswith('~') or filename.startswith('.') or not filename.endswith('.pdf'):
             continue
-        if filename.startswith('.'):
-            continue
-        
-        subscriber = filename.split(' ')
-        
-        dth = []
-        listtemp = []
-        data_headers = []
-        data_list =[]
-        
-        with fitz.open(file_found) as doc:
-            text = ""
-            for page in doc:
-                pagedata = page.getText()
-                
-        items = pagedata.split('\n')
-        username = registrationmethod = phone = registrationdate = registrationip = registrationdeviceinfo = ''
-        for x in items:
-            if x == ' ':
-                continue
-            else:
-                value = x.strip()
-                value = value.split(':')
-                if 'username' in value[0]:
-                    username = value[1].strip()
-                elif 'registration method' in value[0]:
-                    registrationmethod = value[1].strip()
-                elif 'phone' in value[0]:
-                    phone = value[1].strip()
-                elif 'registration date' in value[0]:
-                    registrationdate = f'{value[1].strip()}:{value[2]}:{value[3]}'
-                elif 'registration ip' in value[0]:
-                    registrationip = value[1].strip()
-                elif 'registration device info' in value[0]:
-                    registrationdeviceinfo = value[1].strip()
-        
-        data_list.append((registrationdate, username, registrationmethod, phone, registrationip, registrationdeviceinfo))
-        
-        if data_list:
-            report = ArtifactHtmlReport(f'TikTok - Subscriber Info [{subscriber[0]}]')
-            report.start_artifact_report(report_folder, f'TikTok - Subscriber Info [{subscriber[0]}]')
-            report.add_script()
-            data_headers = ('Registration Date','Username','Registration Method','Phone','Registration IP','Registration Device Info' )
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            files = files + 1
-        else:
-            logfunc(f'No TikTok - Subscriber [{subscriber[0]}] available')
+        source_path = file_found
 
-__artifacts__ = {
-        "tikToksubsinfo": (
-            "TikTok Returns",
-            ('*/*/*(Subscriber information).pdf'),
-            get_tikToksubsinfo)
-}
+        text = ''
+        with fitz.open(file_found) as doc:
+            for page in doc:
+                text += page.get_text()  # get_text(); getText() was removed in modern PyMuPDF
+
+        username = registrationmethod = phone = ''
+        registrationdate = registrationip = registrationdeviceinfo = ''
+        for line in text.split('\n'):
+            line = line.strip()
+            if ':' not in line:
+                continue
+            key, _, rest = line.partition(':')  # split on FIRST colon so values keep their colons
+            key = key.strip().lower()
+            rest = rest.strip()
+            if 'username' in key:
+                username = rest
+            elif 'registration method' in key:
+                registrationmethod = rest
+            elif 'phone' in key:
+                phone = rest
+            elif 'registration date' in key:
+                registrationdate = rest
+            elif 'registration ip' in key:
+                registrationip = rest
+            elif 'registration device info' in key:
+                registrationdeviceinfo = rest
+
+        data_list.append((_to_utc(registrationdate), username, registrationmethod, phone,
+                          registrationip, registrationdeviceinfo,
+                          context.get_relative_path(file_found)))
+
+    data_headers = (('Registration Date', 'datetime'), 'Username', 'Registration Method',
+                    ('Phone', 'phonenumber'), 'Registration IP', 'Registration Device Info',
+                    'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/tikTokvideometa.py
+++ b/scripts/artifacts/tikTokvideometa.py
@@ -1,65 +1,72 @@
+__artifacts_v2__ = {
+    "tikTokvideometa": {
+        "name": "TikTok - Video Metadata",
+        "description": "Video metadata (with linked media) from a TikTok law enforcement return "
+                       "(*- video metadata.xlsx + Video Content/*).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2021-09-29",
+        "last_update_date": "2026-06-28",
+        "requirements": "openpyxl",
+        "category": "TikTok Returns",
+        "notes": "Source File column added so per-subscriber provenance (originally encoded in the "
+                 "report title) survives when multiple returns are merged into one table.",
+        "paths": ('*/*/*- video metadata.xlsx', '*/*/*/Video Content/*'),
+        "output_types": "standard",
+        "artifact_icon": "video",
+    }
+}
+
 import os
+from datetime import datetime, timezone
+
 import openpyxl
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
 
-def get_tikTokvideometa(files_found, report_folder, seeker, wrap_text):
 
-    for file_found in files_found:
+def _to_utc(value):
+    if value is None or value == '':
+        return ''
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+    s = str(value).strip()
+    if not s:
+        return ''
+    if s.isdigit():
+        return convert_unix_ts_to_utc(int(s))
+    try:
+        dt = datetime.fromisoformat(s.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def tikTokvideometa(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
         filename = os.path.basename(file_found)
-        
-        
-        if filename.startswith('~'):
+        if filename.startswith('~') or filename.startswith('.') or not filename.endswith('.xlsx'):
             continue
-        if filename.startswith('.'):
-            continue
-        if not filename.endswith('.xlsx'):
-            continue
-        
-        dth = []
-        listtemp = []
-        data_headers = []
-        data_list =[]
-        
-        subscriber = filename.split('-')
-        
-        wb_obj = openpyxl.load_workbook(file_found)
-        sheet_obj = wb_obj.active
-        
-        max_col = sheet_obj.max_column
-        m_row = sheet_obj.max_row
-        
-        # Will print a particular row value
-        for j in range(1, m_row + 1):
-            for i in range(1, max_col + 1):
-                cell_obj = sheet_obj.cell(row = j, column = i)
-                value = (cell_obj.value)
-                listtemp.append(value)
-            videoid = listtemp[0]
-            uploadtime = listtemp[1]
-            videocaption = listtemp[2]
-            media = media_to_html(videoid, files_found, report_folder)
-            data_list.append((media, uploadtime, videoid, videocaption ))
-            listtemp = []
-            
-        if data_list:
-            data_list.pop(0) #eliminate headers from excel file
-            report = ArtifactHtmlReport(f'TikTok - Video Metadata [{subscriber[0]}] ')
-            report.start_artifact_report(report_folder, f'TikTok - Video Metadata [{subscriber[0]}]')
-            report.add_script()
-            data_headers = ('Media', 'Timestamp Upload', 'Media ID', 'Media Caption' )
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-        else:
-            logfunc(f'No TikTok - Video Metadata [{subscriber[0]}] available')
+        source_path = file_found
+        rel = context.get_relative_path(file_found)
+        wb = openpyxl.load_workbook(file_found, read_only=True, data_only=True)
+        try:
+            sheet = wb.active
+            for idx, row in enumerate(sheet.iter_rows(values_only=True)):
+                if idx == 0:
+                    continue  # header row inside the spreadsheet
+                cells = list(row) + ['', '', '']
+                videoid = cells[0]
+                media = check_in_media(str(videoid), str(videoid)) if videoid not in (None, '') else ''
+                data_list.append((media, _to_utc(cells[1]),
+                                  '' if videoid is None else videoid,
+                                  '' if cells[2] is None else cells[2], rel))
+        finally:
+            wb.close()
 
-__artifacts__ = {
-        "tikTokvideometa": (
-            "TikTok Returns",
-            ('*/*/*- video metadata.xlsx', '*/*/*/Video Content/*'),
-            get_tikTokvideometa)
-}
+    data_headers = (('Media', 'media'), ('Timestamp Upload', 'datetime'), 'Media ID',
+                    'Media Caption', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the three **TikTok Returns** artifacts to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `tikTokipdata` | TikTok - IP Data | `*- IP Data.xlsx` |
| `tikToksubsinfo` | TikTok - Subscriber Info | `(Subscriber information).pdf` |
| `tikTokvideometa` | TikTok - Video Metadata | `*- video metadata.xlsx` + `Video Content/*` |

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()`.
- **Timestamps → UTC** — emitted as aware-UTC `datetime` objects, typed `('Col','datetime')`. Excel date cells (openpyxl) are treated as UTC.
- **phonenumber** — `Phone` tagged `('Phone','phonenumber')` in Subscriber Info.
- **Media** — `tikTokvideometa` swaps `media_to_html` for `check_in_media` into a `('Media','media')` column.
- **xlsx** — `openpyxl` `read_only`/`data_only` + `iter_rows`; rows aligned to header width so LAVA's column count always matches.

## 🐞 Bug fixes (originals were non-functional / lossy)
- **`tikToksubsinfo` was broken on modern PyMuPDF** — it called `page.getText()`, which was **removed** (raises `AttributeError` on the installed 1.23.7). Fixed to `page.get_text()`. It also only retained the **last** page's text — now accumulates all pages.
- **`tikToksubsinfo` colon-splitting** — it split each line on *every* `:` and rebuilt the timestamp from fixed indices, truncating any value containing a colon. Now partitions on the **first** `:`, so timestamp / IPv6 / device-info values are preserved intact.

## New column
- Added a **Source File** column (`context.get_relative_path`) to each artifact so the per-subscriber provenance the originals encoded in the *report title* survives when multiple returns merge into one LAVA table.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit via real `CREATE TABLE` + `sanitize_sql_name`: no collisions.
- `PluginLoader` loads all three (total **236**), no duplicate-name error.
- Synthetic round-trip on a real `.xlsx` (Excel datetime cells), a real `fitz`-generated `.pdf`, and a stubbed `check_in_media`: Excel datetimes → aware UTC; media ref built; Media ID/caption preserved; subscriber fields parsed with colon-containing values intact.

Original attribution (@AlexisBrignoni, 2021-09-29) preserved.