### PR TITLE
Convert Google Returns Play Store artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/googlePlaystoredevices.py
+++ b/scripts/artifacts/googlePlaystoredevices.py
@@ -1,58 +1,67 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_googlePlaystoredevices(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, 'r') as f:
-            delimited = csv.reader(f, delimiter=',')
-            firsrowindicator = 0
-            
-            for item in delimited:
-                if firsrowindicator == 0:
-                    data_headers = item
-                    firsrowindicator = 1
-                elif item == []:
-                    pass
-                else:
-                    data_list.append((item))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Play Store Devices Report {reportcount}')
-            report.add_script()
-            #data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googlePlaystoredevices": (
-            "Google Returns Google Play Store Devices",
-            (('*/*GooglePlayStore.Devices_*/Google Play Store/Devices.csv')),
-            get_googlePlaystoredevices)
+__artifacts_v2__ = {
+    "googlePlaystoredevices": {
+        "name": "Google Returns - Play Store Devices",
+        "description": "Google Play Store device list from a Google law enforcement return "
+                       "(Google Play Store/Devices.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Google Play Store Devices",
+        "notes": "Dynamic-schema CSV: column headers are read from the file's first row and made "
+                 "LAVA-safe (blanks/duplicates/SQL reserved words). Values are kept as exported "
+                 "(TEXT) since the column set varies per return.",
+        "paths": ('*/*GooglePlayStore.Devices_*/Google Play Store/Devices.csv',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+@artifact_processor
+def googlePlaystoredevices(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        file_headers = None
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if not item:
+                    continue
+                if file_headers is None:
+                    file_headers = _safe_headers(item)
+                    continue
+                row = list(item) + [''] * len(file_headers)
+                data_list.append(tuple(row[:len(file_headers)]))
+        if file_headers:
+            headers = file_headers
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googlePlaystoreinstalls.py
+++ b/scripts/artifacts/googlePlaystoreinstalls.py
@@ -1,58 +1,67 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_googlePlaystoreinstalls(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, 'r') as f:
-            delimited = csv.reader(f, delimiter=',')
-            firsrowindicator = 0
-            
-            for item in delimited:
-                if firsrowindicator == 0:
-                    data_headers = item
-                    firsrowindicator = 1
-                elif item == []:
-                    pass
-                else:
-                    data_list.append((item))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Play Store Installs Report {reportcount}')
-            report.add_script()
-            #data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googlePlaystoreinstalls": (
-            "Google Returns Google Play Installs",
-            (('*/*GooglePlayStore.Installs_*/Google Play Store/Installs.csv')),
-            get_googlePlaystoreinstalls)
+__artifacts_v2__ = {
+    "googlePlaystoreinstalls": {
+        "name": "Google Returns - Play Store Installs",
+        "description": "Google Play Store install history from a Google law enforcement return "
+                       "(Google Play Store/Installs.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Google Play Installs",
+        "notes": "Dynamic-schema CSV: column headers are read from the file's first row and made "
+                 "LAVA-safe (blanks/duplicates/SQL reserved words). Values are kept as exported "
+                 "(TEXT) since the column set varies per return.",
+        "paths": ('*/*GooglePlayStore.Installs_*/Google Play Store/Installs.csv',),
+        "output_types": "standard",
+        "artifact_icon": "download",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+@artifact_processor
+def googlePlaystoreinstalls(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        file_headers = None
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if not item:
+                    continue
+                if file_headers is None:
+                    file_headers = _safe_headers(item)
+                    continue
+                row = list(item) + [''] * len(file_headers)
+                data_list.append(tuple(row[:len(file_headers)]))
+        if file_headers:
+            headers = file_headers
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googlePlaystorelibrary.py
+++ b/scripts/artifacts/googlePlaystorelibrary.py
@@ -1,58 +1,67 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_googlePlaystorelibrary(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, 'r') as f:
-            delimited = csv.reader(f, delimiter=',')
-            firsrowindicator = 0
-            
-            for item in delimited:
-                if firsrowindicator == 0:
-                    data_headers = item
-                    firsrowindicator = 1
-                elif item == []:
-                    pass
-                else:
-                    data_list.append((item))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Play Store Library Report {reportcount}')
-            report.add_script()
-            #data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googlePlaystorelibrary": (
-            "Google Returns Google Play Library",
-            (('*/*GooglePlayStore.Library_*/Google Play Store/Library.csv')),
-            get_googlePlaystorelibrary)
+__artifacts_v2__ = {
+    "googlePlaystorelibrary": {
+        "name": "Google Returns - Play Store Library",
+        "description": "Google Play Store library (acquired items) from a Google law enforcement "
+                       "return (Google Play Store/Library.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Google Play Library",
+        "notes": "Dynamic-schema CSV: column headers are read from the file's first row and made "
+                 "LAVA-safe (blanks/duplicates/SQL reserved words). Values are kept as exported "
+                 "(TEXT) since the column set varies per return.",
+        "paths": ('*/*GooglePlayStore.Library_*/Google Play Store/Library.csv',),
+        "output_types": "standard",
+        "artifact_icon": "book",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+@artifact_processor
+def googlePlaystorelibrary(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        file_headers = None
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if not item:
+                    continue
+                if file_headers is None:
+                    file_headers = _safe_headers(item)
+                    continue
+                row = list(item) + [''] * len(file_headers)
+                data_list.append(tuple(row[:len(file_headers)]))
+        if file_headers:
+            headers = file_headers
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googlePlaystoreuserreviews.py
+++ b/scripts/artifacts/googlePlaystoreuserreviews.py
@@ -1,58 +1,67 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import csv
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
-
-def get_googlePlaystoreuserreviews(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, 'r') as f:
-            delimited = csv.reader(f, delimiter=',')
-            firsrowindicator = 0
-            
-            for item in delimited:
-                if firsrowindicator == 0:
-                    data_headers = item
-                    firsrowindicator = 1
-                elif item == []:
-                    pass
-                else:
-                    data_list.append((item))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Play Store User Reviews Report {reportcount}')
-            report.add_script()
-            #data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googlePlaystoreuserreviews": (
-            "Google Returns Google Play User Reviews",
-            (('*/*GooglePlayStore.UserReviews_*/Google Play Store/User Reviews.csv')),
-            get_googlePlaystoreuserreviews)
+__artifacts_v2__ = {
+    "googlePlaystoreuserreviews": {
+        "name": "Google Returns - Play Store User Reviews",
+        "description": "Google Play Store user reviews from a Google law enforcement return "
+                       "(Google Play Store/User Reviews.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Google Play User Reviews",
+        "notes": "Dynamic-schema CSV: column headers are read from the file's first row and made "
+                 "LAVA-safe (blanks/duplicates/SQL reserved words). Values are kept as exported "
+                 "(TEXT) since the column set varies per return.",
+        "paths": ('*/*GooglePlayStore.UserReviews_*/Google Play Store/User Reviews.csv',),
+        "output_types": "standard",
+        "artifact_icon": "star",
+    }
 }
+
+import csv
+import os
+
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+@artifact_processor
+def googlePlaystoreuserreviews(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        file_headers = None
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if not item:
+                    continue
+                if file_headers is None:
+                    file_headers = _safe_headers(item)
+                    continue
+                row = list(item) + [''] * len(file_headers)
+                data_list.append(tuple(row[:len(file_headers)]))
+        if file_headers:
+            headers = file_headers
+
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googlePlayuseract.py
+++ b/scripts/artifacts/googlePlayuseract.py
@@ -1,49 +1,38 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googlePlayuseract": {
+        "name": "Google Returns - Play Store User Activity",
+        "description": "Google Play Store user activity page from a Google law enforcement return "
+                       "(Google Play Store/User Activity.html).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Play User Act",
+        "notes": "The return ships this activity as a pre-rendered HTML page; the full document is "
+                 "embedded verbatim in the User Activity column (rendered, not escaped).",
+        "paths": ('*/*GooglePlayStore.UserActivity_*/Google Play Store/User Activity.html',),
+        "output_types": "standard",
+        "html_columns": ["User Activity"],
+        "artifact_icon": "activity",
+    }
+}
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_googlePlayuseract(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googlePlayuseract(context):
     data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.read()
+        if not file_found.endswith('.html') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data_list.append((f.read(), context.get_relative_path(file_found)))
 
-        data_list.append((data,))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Play User Act. Report {reportcount}')
-            report.add_script()
-            data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googlePlayuseract": (
-            "Google Returns Play User Act",
-            (('*/*GooglePlayStore.UserActivity_*/Google Play Store/User Activity.html')),
-            get_googlePlayuseract)
-}
+    data_headers = ('User Activity', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the five legacy **Google Play Store** warrant-return parsers to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `googlePlaystoredevices` | Google Returns - Play Store Devices | `GooglePlayStore.Devices_*/…/Devices.csv` |
| `googlePlaystoreinstalls` | Google Returns - Play Store Installs | `GooglePlayStore.Installs_*/…/Installs.csv` |
| `googlePlaystorelibrary` | Google Returns - Play Store Library | `GooglePlayStore.Library_*/…/Library.csv` |
| `googlePlaystoreuserreviews` | Google Returns - Play Store User Reviews | `GooglePlayStore.UserReviews_*/…/User Reviews.csv` |
| `googlePlayuseract` | Google Returns - Play Store User Activity | `GooglePlayStore.UserActivity_*/…/User Activity.html` |

## Naming / coexistence note
A newer module `google_playstore.py` already parses the **Takeout JSON** form (`*/Google Play Store/*.json`) under names like "Google Play Store - Devices". These legacy artifacts parse the **warrant-return CSV/HTML** form from a different folder structure, so they're complementary — not duplicates. To avoid a name collision (the loader enforces globally-unique artifact names) this set uses a **"Google Returns - Play Store …"** prefix. If the CSV return format is obsolete in your workflow, these could instead be retired — your call.

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()`.
- **Dynamic schema** — the 4 CSV artifacts read their headers from the file's first row and make them LAVA-safe via `_safe_headers` (blanks → `Column N`, SQL reserved words → ` Value`, duplicates → ` (n)`), reusing the vetted Pinger/iCloud helper. Each row is aligned to the header width so LAVA's column count always matches.
- **User Activity** — embeds the return's pre-rendered HTML page in a single `html_column` plus a Source File column.
- Values kept as exported (TEXT) — the dynamic column set means specific timestamp columns can't be reliably typed across returns.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- `PluginLoader` loads all five (total **236**), no duplicate-name error after the prefix rename.
- Synthetic round-trip on a deliberately nasty CSV (reserved-word `From`, a blank header, duplicate `Type`, and short/long/empty rows): headers → `('Device','From Value','Column 3','Type','Type (1)')`, all rows aligned to width, sanitized names build a valid `CREATE TABLE`; HTML passthrough returns the raw document + source path.

Original attribution (@AlexisBrignoni, 2023-05-16) preserved.