### PR TITLE
Convert Google Returns HTML-page artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/googleAccChangeHist.py
+++ b/scripts/artifacts/googleAccChangeHist.py
@@ -1,49 +1,39 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googleAccChangeHist": {
+        "name": "Google Returns - Account Change History",
+        "description": "Google Account change history page from a Google law enforcement return "
+                       "(Google Account/*.ChangeHistory.html).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Account Change History",
+        "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
+                 "verbatim in the Account Change History column (rendered, not escaped).",
+        "paths": ('*/*GoogleAccount.ChangeHistory_*.Preserved/Google Account/*.ChangeHistory.html',
+                  '*/*GoogleAccount.ChangeHistory_*/Google Account/*.ChangeHistory.html'),
+        "output_types": "standard",
+        "html_columns": ["Account Change History"],
+        "artifact_icon": "clock",
+    }
+}
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_googleAccChangeHist(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googleAccChangeHist(context):
     data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.read()
+        if not file_found.endswith('.html') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data_list.append((f.read(), context.get_relative_path(file_found)))
 
-        data_list.append((data,))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Acc Change History Report {reportcount}')
-            report.add_script()
-            data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googleAccChangeHist": (
-            "Google Returns Account Change History",
-            (('*/*GoogleAccount.ChangeHistory_*.Preserved/Google Account/*.ChangeHistory.html','*/*GoogleAccount.ChangeHistory_*/Google Account/*.ChangeHistory.html')),
-            get_googleAccChangeHist)
-}
+    data_headers = ('Account Change History', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleDeviceconfig.py
+++ b/scripts/artifacts/googleDeviceconfig.py
@@ -1,49 +1,39 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googleDeviceconfig": {
+        "name": "Google Returns - Android Device Config",
+        "description": "Android Device Configuration Service profile page from a Google law "
+                       "enforcement return (Android Device Configuration Service/Device-*.html).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Android Device Config",
+        "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
+                 "verbatim in the Device Configuration column (rendered, not escaped).",
+        "paths": ('*/*AndroidDeviceConfigurationService.DeviceAndUserProfile_*/'
+                  'Android Device Configuration Service/Device-*.html',),
+        "output_types": "standard",
+        "html_columns": ["Device Configuration"],
+        "artifact_icon": "settings",
+    }
+}
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_googleDeviceconfig(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googleDeviceconfig(context):
     data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.read()
+        if not file_found.endswith('.html') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data_list.append((f.read(), context.get_relative_path(file_found)))
 
-        data_list.append((data,))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Android Device Config Report {reportcount}')
-            report.add_script()
-            data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googleDeviceconfig": (
-            "Google Returns Android Device Config",
-            (('*/*AndroidDeviceConfigurationService.DeviceAndUserProfile_*/Android Device Configuration Service/Device-*.html')),
-            get_googleDeviceconfig)
-}
+    data_headers = ('Device Configuration', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleMyactisearch.py
+++ b/scripts/artifacts/googleMyactisearch.py
@@ -1,49 +1,38 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googleMyactisearch": {
+        "name": "Google Returns - My Activity Image Search",
+        "description": "My Activity > Image Search page from a Google law enforcement return "
+                       "(My Activity/Image Search/MyActivity.html).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns My Activity Image Search",
+        "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
+                 "verbatim in the Image Search Activity column (rendered, not escaped).",
+        "paths": ('*/*MyActivity.MyActivity_*/My Activity/Image Search/MyActivity.html',),
+        "output_types": "standard",
+        "html_columns": ["Image Search Activity"],
+        "artifact_icon": "image",
+    }
+}
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_googleMyactisearch(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googleMyactisearch(context):
     data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.read()
+        if not file_found.endswith('.html') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data_list.append((f.read(), context.get_relative_path(file_found)))
 
-        data_list.append((data,))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Act. Image Search Report {reportcount}')
-            report.add_script()
-            data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googleMyactisearch": (
-            "Google Returns My Activity Image Search",
-            (('*/*MyActivity.MyActivity_*/My Activity/Image Search/MyActivity.html')),
-            get_googleMyactisearch)
-}
+    data_headers = ('Image Search Activity', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleMyactssearch.py
+++ b/scripts/artifacts/googleMyactssearch.py
@@ -1,49 +1,38 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googleMyactssearch": {
+        "name": "Google Returns - My Activity Search",
+        "description": "My Activity > Search page from a Google law enforcement return "
+                       "(My Activity/Search/MyActivity.html).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns My Activity Search",
+        "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
+                 "verbatim in the Search Activity column (rendered, not escaped).",
+        "paths": ('*/*MyActivity.MyActivity_*/My Activity/Search/MyActivity.html',),
+        "output_types": "standard",
+        "html_columns": ["Search Activity"],
+        "artifact_icon": "search",
+    }
+}
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_googleMyactssearch(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googleMyactssearch(context):
     data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.read()
+        if not file_found.endswith('.html') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data_list.append((f.read(), context.get_relative_path(file_found)))
 
-        data_list.append((data,))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Act. Search Report {reportcount}')
-            report.add_script()
-            data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googleMyactssearch": (
-            "Google Returns My Activity Search",
-            (('*/*MyActivity.MyActivity_*/My Activity/Search/MyActivity.html')),
-            get_googleMyactssearch)
-}
+    data_headers = ('Search Activity', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleSubinfo.py
+++ b/scripts/artifacts/googleSubinfo.py
@@ -1,49 +1,38 @@
-# Module Description: Parses Google data from a search warrant
-# Author: @Alexis Brignoni
-# Date: 2023-05-16
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "googleSubinfo": {
+        "name": "Google Returns - Subscriber Info",
+        "description": "Google Account subscriber info page from a Google law enforcement return "
+                       "(Google Account/*.SubscriberInfo.html).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-05-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns Subscriber Info",
+        "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
+                 "verbatim in the Subscriber Info column (rendered, not escaped).",
+        "paths": ('*/*GoogleAccount.SubscriberInfo_*/Google Account/*.SubscriberInfo.html',),
+        "output_types": "standard",
+        "html_columns": ["Subscriber Info"],
+        "artifact_icon": "user",
+    }
+}
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor
 
-def get_googleSubinfo(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def googleSubinfo(context):
     data_list = []
-    reportcount = 0
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        reportname = file_found.split('/')
-        reportname = reportname[-3]
-        
-        with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-            data = f.read()
+        if not file_found.endswith('.html') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            data_list.append((f.read(), context.get_relative_path(file_found)))
 
-        data_list.append((data,))
-
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{reportname}')
-            report.start_artifact_report(report_folder, f'Subscriber Info Report {reportcount}')
-            report.add_script()
-            data_headers = ('HTML File',)
-    
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['HTML File'])
-            report.end_artifact_report()
-            
-            reportcount = reportcount + 1
-            data_list = []
-    
-        else:
-            logfunc(f'No Google data for {reportname}')
- 
-__artifacts__ = {
-        "googleSubinfo": (
-            "Google Returns Subscriber Info",
-            (('*/*GoogleAccount.SubscriberInfo_*/Google Account/*.SubscriberInfo.html')),
-            get_googleSubinfo)
-}
+    data_headers = ('Subscriber Info', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the five legacy Google warrant-return **HTML-page** parsers to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `googleAccChangeHist` | Google Returns - Account Change History | `Google Account/*.ChangeHistory.html` |
| `googleDeviceconfig` | Google Returns - Android Device Config | `Android Device Configuration Service/Device-*.html` |
| `googleMyactisearch` | Google Returns - My Activity Image Search | `My Activity/Image Search/MyActivity.html` |
| `googleMyactssearch` | Google Returns - My Activity Search | `My Activity/Search/MyActivity.html` |
| `googleSubinfo` | Google Returns - Subscriber Info | `Google Account/*.SubscriberInfo.html` |

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()`.
- Each return ships these as **pre-rendered HTML pages**, so (matching the already-merged `googlePlayuseract`) the full document is embedded verbatim in a single `html_column`, plus a **Source File** column for provenance.
- `paths` normalized to proper tuples — several originals wrapped a single path string in double parens, which is a bare string (would iterate per character), not a 1-tuple.
- Names use a `"Google Returns - …"` prefix; verified unique (these warrant-return paths are matched by no other module).

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- `PluginLoader` loads all five (total **236**), no duplicate-name error.
- Synthetic round-trip: each returns the raw HTML document in its named column + the relative source path.

Original attribution (@AlexisBrignoni, 2023-05-16) preserved.