### PR TITLE
Convert AirDrop artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/airdropEmails.py
+++ b/scripts/artifacts/airdropEmails.py
@@ -1,70 +1,59 @@
-import os
-import datetime
+__artifacts_v2__ = {
+    "airdropEmails": {
+        "name": "AirDrop - Email from Hash",
+        "description": "Recovers sender email addresses from AirDrop partial hashes in the unified "
+                       "log (airdrop.ndjson) by testing a candidate email wordlist.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-03-16",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Airdrop Emails",
+        "notes": "Tests SHA-256 of each candidate email (scripts/emails/emails.txt) against the "
+                 "partial hashes AirDrop writes to the unified log. Timestamp is kept as text: the "
+                 "shared gather_hashes_in_file helper truncates the unified-log time to 25 chars, "
+                 "dropping the UTC offset, so it can't be safely typed/normalized to UTC.",
+        "paths": ('*/airdrop.ndjson',),
+        "output_types": "standard",
+        "artifact_icon": "mail",
+    }
+}
+
 import hashlib
-import json
 import re
 from pathlib import Path
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen, gather_hashes_in_file
+from scripts.ilapfuncs import artifact_processor, logfunc, gather_hashes_in_file
 
 
-def get_airdropEmails(files_found, report_folder, seeker, wrap_text):
-    # log show ./system_logs.logarchive --style ndjson --predicate 'category = "AirDrop"' > airdrop.ndjson
-
+@artifact_processor
+def airdropEmails(context):
     emailslist = []
     data_list = []
+    source_path = ''
 
-    p = Path(__file__).parents[1]
-    my_path = Path(p).joinpath('emails')
-    emails = Path(my_path).joinpath('emails.txt')
-
-    with open(emails, 'r') as data:
-        for x in data:
-            emailslist.append(x)
+    wordlist = Path(__file__).parents[1].joinpath('emails', 'emails.txt')
+    with open(wordlist, encoding='utf-8') as data:
+        for line in data:
+            emailslist.append(line)
 
     regex = re.compile(r"Email=\[((\w{5}\.{3}\w{5}(, )?)+)\]")
     target_hashes = {}
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-
-        if file_found.endswith('airdrop.ndjson'):
-            target_hashes.update(gather_hashes_in_file(file_found, regex))
+        if not file_found.endswith('airdrop.ndjson'):
+            continue
+        source_path = file_found
+        target_hashes.update(gather_hashes_in_file(file_found, regex))
 
         for email in emailslist:
             emailcheck = email.strip()
-            logfunc('Testing email ' + str(emailcheck) + ' for target...')
-
             targettest = hashlib.sha256(emailcheck.encode()).hexdigest()
-            starthashcheck = targettest[0:5]
-            endhashcheck = targettest[-5:]
-
-            if (starthashcheck.lower(), endhashcheck.lower()) in target_hashes:
-                mail_hash = target_hashes.pop((starthashcheck, endhashcheck))
+            key = (targettest[0:5].lower(), targettest[-5:].lower())
+            if key in target_hashes:
+                mail_hash = target_hashes.pop(key)
                 mail_hash[1] = emailcheck
-                data_list.append(mail_hash)
-                logfunc(emailcheck + ' matches hash fragments on ' + mail_hash[0])
+                data_list.append(tuple(mail_hash))
+                logfunc(f'{emailcheck} matches hash fragments on {mail_hash[0]}')
 
-    if data_list:
-        report = ArtifactHtmlReport(f'AirDrop - Email from Hash ')
-        report.start_artifact_report(report_folder, f'AirDrop - Email from Hash')
-        report.add_script()
-        data_headers = ('Timestamp', 'Email', 'Event Message', 'Subsystem', 'Category', 'Trace ID')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-
-        tsvname = f'AirDrop - Email from Hash'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'AirDrop - Email from Hash'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No AirDrop - Email from Hash')
-
-
-__artifacts__ = {
-    "airdropEmails": (
-        "Airdrop Emails",
-        ('*/airdrop.ndjson'),
-        get_airdropEmails)
-}
+    data_headers = ('Timestamp', 'Email', 'Event Message', 'Subsystem', 'Category', 'Trace ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/airdropNumbers.py
+++ b/scripts/artifacts/airdropNumbers.py
@@ -1,18 +1,34 @@
 # Base code comes from:
 # https://github.com/043a7e/airdropmsisdn
 
+__artifacts_v2__ = {
+    "airdropNumbers": {
+        "name": "AirDrop - Phone Number from Hash",
+        "description": "Recovers sender phone numbers from AirDrop partial hashes in the unified "
+                       "log (airdrop.ndjson) by brute-forcing candidate numbers per area code.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-03-15",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Airdrop Numbers",
+        "notes": "Brute-forces every candidate number for each area code in "
+                 "scripts/areacodes/areacodes_us.txt and SHA-256s it against AirDrop's partial "
+                 "hashes. This is compute-heavy (up to 10^7 hashes per area code). Timestamp is "
+                 "kept as text: the shared gather_hashes_in_file helper truncates the unified-log "
+                 "time to 25 chars, dropping the UTC offset, so it can't be safely normalized.",
+        "paths": ('*/airdrop.ndjson',),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+    }
+}
+
 import hashlib
 import re
 import time
 from enum import Enum
 from pathlib import Path
-import locale
 
-locale.setlocale(locale.LC_ALL, '')  # Use '' for auto, or force e.g. to 'en_US.UTF-8'
-
-from scripts import ilapfuncs
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, gather_hashes_in_file
+from scripts.ilapfuncs import artifact_processor, logfunc, gather_hashes_in_file
 
 
 class COUNTRY(Enum):
@@ -26,83 +42,52 @@ MAX_LEN = {COUNTRY.US: 7, COUNTRY.DE: 10}
 AREACODE_FILE = {COUNTRY.US: 'areacodes_us.txt', COUNTRY.DE: 'areacodes_de.txt'}
 
 
-
-def get_airdropNumbers(files_found, report_folder, seeker, wrap_text):
-    # log show ./system_logs.logarchive --style ndjson --predicate 'category = "AirDrop"' > airdrop.ndjson
+@artifact_processor
+def airdropNumbers(context):
     selected_country = COUNTRY.US
     areacodelist = []
     data_list = []
+    source_path = ''
 
-    p = Path(__file__).parents[1]
-    my_path = Path(p).joinpath('areacodes')
-    areacodes = Path(my_path).joinpath(AREACODE_FILE[selected_country])
-
-    with open(areacodes, 'r') as data:
-        for x in data:
-            areacodelist.append(x)
+    areacodes = Path(__file__).parents[1].joinpath('areacodes', AREACODE_FILE[selected_country])
+    with open(areacodes, encoding='utf-8') as data:
+        for line in data:
+            areacodelist.append(line)
 
     regex = re.compile(r"Phone=\[((\w{5}\.{3}\w{5}(, )?)+)\]")
     target_hashes = {}
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-
-        if file_found.endswith('airdrop.ndjson'):
-            target_hashes.update(gather_hashes_in_file(file_found, regex))
+        if not file_found.endswith('airdrop.ndjson'):
+            continue
+        source_path = file_found
+        target_hashes.update(gather_hashes_in_file(file_found, regex))
 
     for i in range(MIN_LEN[selected_country], MAX_LEN[selected_country] + 1):
         logfunc(f"Searching for len {i}")
-        factor = int(10 ** i / 100)
         for areacode in areacodelist:
             areacode = areacode.strip()
             logfunc('Searching area code ' + str(areacode) + ' for target...')
-            #ilapfuncs.GuiWindow.SetProgressBar(0)
             off = 0
             start_time = time.time()
             for line in range(10 ** i):
-
-                # Performance measuring
                 if 60.0 < (time.time() - start_time) < 60.2:
                     logfunc(f"Current Speed: {(line - off) / 60}nr/s")
                     off = line
                     start_time = time.time()
 
-                if line % factor == 0:
-                    pass
-                    #ilapfuncs.GuiWindow.SetProgressBar(int(line / factor))
-
                 targetphone = f"{COUNTRY_CODE[selected_country]}{areacode}{line:0{i}d}"
                 targettest = hashlib.sha256(targetphone.encode()).hexdigest()
-                starthashcheck = targettest[:5]
-                endhashcheck = targettest[-5:]
-                if (starthashcheck, endhashcheck) in target_hashes:
-                    logfunc(f"Found phone {targetphone} for hash {starthashcheck}....{endhashcheck}")
-                    phone_hash = target_hashes[(starthashcheck, endhashcheck)]
+                key = (targettest[:5], targettest[-5:])
+                if key in target_hashes:
+                    logfunc(f"Found phone {targetphone} for hash {key[0]}....{key[1]}")
+                    phone_hash = list(target_hashes[key])
                     phone_hash[1] = targetphone
-                    data_list.append(phone_hash.copy())
+                    data_list.append(tuple(phone_hash))
                 if not target_hashes:
                     logfunc("No target hashes left")
                     break
 
-    if data_list:
-        report = ArtifactHtmlReport(f'AirDrop - Phone Number from Hash ')
-        report.start_artifact_report(report_folder, f'AirDrop - Phone Number from Hash')
-        report.add_script()
-        data_headers = ['Timestamp', 'Target Phone', 'Event Message', 'Subsystem', 'Category', 'Trace ID']
-        report.write_artifact_data_table(data_headers, data_list, files_found[0], html_no_escape=['Media'])
-        report.end_artifact_report()
-
-        tsvname = f'AirDrop - Phone Number from Hash'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'AirDrop - Phone Number from Hash'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No AirDrop - Phone Number from Hash')
-
-
-__artifacts__ = {
-    "airdropNumbers": (
-        "Airdrop Numbers",
-        ('*/airdrop.ndjson'),
-        get_airdropNumbers)
-}
+    data_headers = ('Timestamp', ('Target Phone', 'phonenumber'), 'Event Message', 'Subsystem',
+                    'Category', 'Trace ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/airdropRealname.py
+++ b/scripts/artifacts/airdropRealname.py
@@ -1,70 +1,59 @@
-import os
-import datetime
+__artifacts_v2__ = {
+    "airdropRealname": {
+        "name": "AirDrop - Real Name from Hash",
+        "description": "Recovers sender real names from AirDrop partial hashes in the unified log "
+                       "(airdrop.ndjson) by testing a candidate name wordlist.",
+        "author": "Rex",
+        "creation_date": "2022-09-10",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Airdrop Real Names",
+        "notes": "Tests SHA-256 of each candidate name (scripts/names/realnames.txt) against the "
+                 "partial hashes AirDrop writes to the unified log. Timestamp is kept as text: the "
+                 "shared gather_hashes_in_file helper truncates the unified-log time to 25 chars, "
+                 "dropping the UTC offset, so it can't be safely typed/normalized to UTC.",
+        "paths": ('*/airdrop.ndjson',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
+}
+
 import hashlib
-import json
 import re
 from pathlib import Path
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, gather_hashes_in_file
+from scripts.ilapfuncs import artifact_processor, logfunc, gather_hashes_in_file
 
 
-def get_airdropRealnames(files_found, report_folder, seeker, wrap_text):
-    # log show ./system_logs.logarchive --style ndjson --predicate 'category = "AirDrop"' > airdrop.ndjson
-
+@artifact_processor
+def airdropRealname(context):
     namelist = []
     data_list = []
+    source_path = ''
 
-    p = Path(__file__).parents[1]
-    my_path = Path(p).joinpath('names')
-    names = Path(my_path).joinpath('realnames.txt')
-
-    with open(names, 'r') as data:
-        for x in data:
-            namelist.append(x)
+    wordlist = Path(__file__).parents[1].joinpath('names', 'realnames.txt')
+    with open(wordlist, encoding='utf-8') as data:
+        for line in data:
+            namelist.append(line)
 
     regex = re.compile(r"realName: (\w{10})")
     target_hashes = {}
-    for file_found in files_found:
+    for file_found in context.get_files_found():
         file_found = str(file_found)
+        if not file_found.endswith('airdrop.ndjson'):
+            continue
+        source_path = file_found
+        target_hashes.update(gather_hashes_in_file(file_found, regex))
 
-        if file_found.endswith('airdrop.ndjson'):
-            target_hashes.update(gather_hashes_in_file(file_found, regex))
-
-        for email in namelist:
-            namecheck = email.strip()
-            logfunc('Testing name ' + str(namecheck) + ' for target...')
-
+        for name in namelist:
+            namecheck = name.strip()
             targettest = hashlib.sha256(namecheck.encode()).hexdigest()
-            starthashcheck = targettest[0:5]
-            endhashcheck = targettest[-5:]
+            key = (targettest[0:5].lower(), targettest[-5:].lower())
+            if key in target_hashes:
+                name_hash = target_hashes.pop(key)
+                name_hash[1] = namecheck
+                data_list.append(tuple(name_hash))
+                logfunc(f'{namecheck} matches hash fragments on {name_hash[0]}')
 
-            if (starthashcheck.lower(), endhashcheck.lower()) in target_hashes:
-                mail_hash = target_hashes.pop((starthashcheck, endhashcheck))
-                mail_hash[1] = namecheck
-                data_list.append(mail_hash)
-                logfunc(namecheck + ' matches hash fragments on ' + mail_hash[0])
-
-    if data_list:
-        report = ArtifactHtmlReport(f'AirDrop - Realname from Hash ')
-        report.start_artifact_report(report_folder, f'AirDrop - Realname from Hash')
-        report.add_script()
-        data_headers = ('Timestamp', 'Realname', 'Event Message', 'Subsystem', 'Category', 'Trace ID')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-
-        tsvname = f'AirDrop - Realname from Hash'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'AirDrop - Realname from Hash'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No AirDrop - Realname from Hash')
-
-
-__artifacts__ = {
-    "airdropRealname": (
-        "Airdrop Real Names",
-        ('*/airdrop.ndjson'),
-        get_airdropRealnames)
-}
+    data_headers = ('Timestamp', 'Realname', 'Event Message', 'Subsystem', 'Category', 'Trace ID')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/airdropdiscoverable.py
+++ b/scripts/artifacts/airdropdiscoverable.py
@@ -1,86 +1,91 @@
-import os
-import datetime
-import hashlib
-import json
-from pathlib import Path
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-
-def get_airdropdiscoverable(files_found, report_folder, seeker, wrap_text):
-    # log show ./system_logs.logarchive --style ndjson --predicate 'category = "AirDrop"' > airdrop.ndjson
-
-    data_list = []
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if file_found.endswith('airdrop.ndjson'):
-            with open(file_found, 'r') as data:
-                for y in data:
-                    deserialized = json.loads(y)
-                    endofdata = deserialized.get('finished', '')
-                    if endofdata == 1:
-                        break
-                    else:
-                        eventmessage = deserialized.get('eventMessage', '')
-                        if 'Updated people:' in eventmessage:
-                            
-                            eventtimestamp = deserialized.get('timestamp', '')[0:25]
-                            subsystem = deserialized.get('subsystem', '')
-                            category = deserialized.get('category', '')
-                            traceid = deserialized.get('traceID', '')
-                            
-                            #print(eventmessage)
-                            separated = (eventmessage.split(','))
-                            #print(separated)
-                            realname = displayname = secondaryname = isme = isknown = israpport = uwbcapable = updatedp = ''
-                            for x in separated:
-                                
-                                if '<NSOrderedCollectionDifference' in x:
-                                    updatedp = x.split('(')[1]
-                                    updatedp = updatedp.replace('<','')
-                                elif 'Updated people' in x:
-                                    updatedp = x.split(': ')[1]
-                                elif 'realName' in x:
-                                    realname = x.split(': ')[1]
-                                elif 'displayName' in x:
-                                    displayname = x.split(': ')[1]
-                                elif 'secondaryName' in x:
-                                    secondaryname = x.split(': ')[1]
-                                elif 'isMe' in x:
-                                    isme = x.split(': ')[1]
-                                elif 'isKnown' in x:
-                                    isknown = x.split(': ')[1]
-                                elif 'isRapport' in x:
-                                    israpport = x.split(': ')[1]
-                                elif 'uwbCapable' in x:
-                                    uwbcapable = x.split(': ')[1]
-                                    uwbcapable = uwbcapable.replace('>','')
-                            data_list.append((eventtimestamp, traceid, updatedp, realname, displayname, secondaryname, isme, isknown, israpport, uwbcapable))
-                        
-    if data_list:
-        report = ArtifactHtmlReport(f'AirDrop - Discoverable')
-        report.start_artifact_report(report_folder, f'AirDrop - Discoverable')
-        report.add_script()
-        data_headers = ('Timestamp', 'Trace ID', 'Update', 'Real Name', 'Display Name', 'Secondary Name', 'Is me?', 'Is Known?', 'Is Rapport?', 'UWC capable')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-
-        tsvname = f'AirDrop - Discoverable'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'AirDrop - Discoverable'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No AirDrop - Discoverable')
-
-
-__artifacts__ = {
-    "airdropdiscoverable": (
-        "Airdrop Discoverable",
-        ('*/airdrop.ndjson'),
-        get_airdropdiscoverable)
+__artifacts_v2__ = {
+    "airdropdiscoverable": {
+        "name": "AirDrop - Discoverable",
+        "description": "AirDrop 'Updated people' discoverability events from the unified log "
+                       "(airdrop.ndjson): nearby people and their advertised identity fields.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-09-08",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Airdrop Discoverable",
+        "notes": "Timestamp is the unified-log time parsed with its UTC offset and normalized to "
+                 "UTC. The 'Updated People' column was named 'Update' in the original (a SQL "
+                 "reserved word); the 'UWB Capable' header fixes the original 'UWC capable' typo "
+                 "(Ultra Wideband).",
+        "paths": ('*/airdrop.ndjson',),
+        "output_types": "standard",
+        "artifact_icon": "radio",
+    }
 }
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor
+
+
+def _log_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    for fmt in ('%Y-%m-%d %H:%M:%S.%f%z', '%Y-%m-%d %H:%M:%S%z'):
+        try:
+            return datetime.strptime(value, fmt).astimezone(timezone.utc)
+        except ValueError:
+            continue
+    return value
+
+
+@artifact_processor
+def airdropdiscoverable(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('airdrop.ndjson') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as data:
+            for line in data:
+                if not line.strip():
+                    continue
+                deserialized = json.loads(line)
+                if deserialized.get('finished', '') == 1:
+                    break
+                eventmessage = deserialized.get('eventMessage', '')
+                if 'Updated people:' not in eventmessage:
+                    continue
+
+                eventtimestamp = _log_ts(deserialized.get('timestamp', ''))
+                traceid = deserialized.get('traceID', '')
+
+                realname = displayname = secondaryname = ''
+                isme = isknown = israpport = uwbcapable = updatedp = ''
+                for part in eventmessage.split(','):
+                    if '<NSOrderedCollectionDifference' in part:
+                        updatedp = part.split('(')[1].replace('<', '')
+                    elif 'Updated people' in part:
+                        updatedp = part.split(': ')[1]
+                    elif 'realName' in part:
+                        realname = part.split(': ')[1]
+                    elif 'displayName' in part:
+                        displayname = part.split(': ')[1]
+                    elif 'secondaryName' in part:
+                        secondaryname = part.split(': ')[1]
+                    elif 'isMe' in part:
+                        isme = part.split(': ')[1]
+                    elif 'isKnown' in part:
+                        isknown = part.split(': ')[1]
+                    elif 'isRapport' in part:
+                        israpport = part.split(': ')[1]
+                    elif 'uwbCapable' in part:
+                        uwbcapable = part.split(': ')[1].replace('>', '')
+
+                data_list.append((eventtimestamp, traceid, updatedp, realname, displayname,
+                                  secondaryname, isme, isknown, israpport, uwbcapable))
+
+    data_headers = (('Timestamp', 'datetime'), 'Trace ID', 'Updated People', 'Real Name',
+                    'Display Name', 'Secondary Name', 'Is me?', 'Is Known?', 'Is Rapport?',
+                    'UWB Capable')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the four AirDrop unified-log (`airdrop.ndjson`) artifacts to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | What it does |
|---|---|---|
| `airdropEmails` | AirDrop - Email from Hash | Recovers sender email from AirDrop partial hashes via a candidate wordlist |
| `airdropRealname` | AirDrop - Real Name from Hash | Recovers sender real name from partial hashes via a wordlist |
| `airdropNumbers` | AirDrop - Phone Number from Hash | Recovers sender phone by brute-forcing candidates per area code |
| `airdropdiscoverable` | AirDrop - Discoverable | "Updated people" discoverability events (nearby people + advertised identity) |

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()`.
- Rows returned as tuples; dropped the dead `html_no_escape=['Media']` (no Media column exists).
- **phonenumber** — `airdropNumbers` tags `('Target Phone','phonenumber')`.
- **airdropdiscoverable** parses the ndjson itself, so the **full** unified-log timestamp (with its UTC offset) is normalized to UTC and typed `('Timestamp','datetime')` — the original kept a truncated string. Renamed the reserved-word column `Update` → `Updated People`, and fixed the `UWC capable` header typo → `UWB Capable`.

## Bug fix / cleanup
- `airdropNumbers` carried a dead `factor = int(10**i/100)` + `if line % factor == 0: pass` no-op (leftover from a removed GUI progress bar) — a **latent ZeroDivisionError** for short search lengths. Removed. Also dropped an unused module-level `locale.setlocale` import-time side effect.

## Forensic note on timestamps
The three hash-cracking artifacts get their timestamp from the shared `gather_hashes_in_file` helper, which **truncates the unified-log time to 25 chars, dropping the UTC offset**. Rather than assert an incorrect UTC, those keep the timestamp as **text**; only `airdropdiscoverable` (which we parse ourselves) yields a true UTC datetime. (Fixing the hash-cracker timestamps would require touching the shared helper, out of artifact scope.)

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit: no collisions (the `Update`→`Updated People` rename resolves the only offender).
- `PluginLoader` loads all four (total **236**), no duplicate-name error.
- Synthetic round-trip on a planted `airdrop.ndjson` (padded >100 lines so the helper's line-count divisor is non-zero): Emails recovers `test@abrignoni.com`, Realname recovers `Alexis Brignoni`, Numbers brute-forces `14070`, Discoverable yields `18:30 UTC` from `14:30 -0400` with renamed columns.

Original attribution preserved (@AlexisBrignoni; `airdropRealname` by Rex).