### PR TITLE
Convert documentsFolder, offlinePages, whatsappExportedchats to LAVA

### DIFF
--- a/scripts/artifacts/documentsFolder.py
+++ b/scripts/artifacts/documentsFolder.py
@@ -1,62 +1,44 @@
-# Module Description: PDFs
-# Author: infosec.exchange/@abrignoni
-# Date: 2022-02-15
-# Artifact version: 0.0.1
-# Requirements: none
+__artifacts_v2__ = {
+    "documentsFolder": {
+        "name": "iCloud Documents Folders",
+        "description": "Files in iCloud backup Documents folders, with detected type and a media "
+                       "preview.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-02-15",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "iCloud Documents Folders",
+        "notes": "Modified Date is the file's on-disk modification time (UTC).",
+        "paths": ('*/backup/*/Documents/**',),
+        "output_types": "standard",
+        "artifact_icon": "folder",
+    }
+}
 
 import os
-import datetime
+from datetime import datetime, timezone
 
 from scripts.filetype import guess_mime, guess_extension
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
-def get_documentsFolder(files_found, report_folder, seeker, wrap_text):
-    
+@artifact_processor
+def documentsFolder(context):
     data_list = []
-
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
+        if not os.path.isfile(file_found):
+            continue
         filename = os.path.basename(file_found)
-        
-    
-        modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
-        
-        if os.path.isfile(file_found):
-            mime = guess_mime(file_found)
-            ext = guess_extension(file_found)
-            
-            linktofile = media_to_html(file_found, files_found, report_folder)
-            if is_platform_windows:
-                linktofile = linktofile.replace('/?','',1)
-                
-            data_list.append((utc_modified_date, filename, linktofile, ext, mime, file_found))
-        
-    if len(data_list) > 0:
-        description = 'iCloud Documents Folders'
-        note = 'Source location in extraction found in the report for each item.'
-        report = ArtifactHtmlReport(f'iCloud Documents Folders')
-        report.start_artifact_report(report_folder, f'iCloud Documents Folder', description)
-        report.add_script()
-        data_headers = ('Modified Date', 'Filename', 'Media', 'EXT', 'MIME', 'Path')
+        if filename.startswith('.'):
+            continue
+        source_path = file_found
+        modified = datetime.fromtimestamp(os.path.getmtime(file_found), tz=timezone.utc)
+        media = check_in_media(file_found, filename)
+        data_list.append((modified, filename, media, guess_extension(file_found),
+                          guess_mime(file_found), context.get_relative_path(file_found)))
 
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'iCloud Documents Folders'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'iCloud Documents Folders'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc(f'No iCloud Documents Folders')
-
-__artifacts__ = {
-        "documentsFolder": (
-            "iCloud Documents Folders",
-            ('*/backup/*/Documents/**'),
-            get_documentsFolder)
-}
+    data_headers = (('Modified Date', 'datetime'), 'Filename', ('Media', 'media'), 'EXT', 'MIME',
+                    'Path')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -1,45 +1,45 @@
-import datetime
+__artifacts_v2__ = {
+    "offlinePages": {
+        "name": "Offline Pages",
+        "description": "Saved offline web pages (MHTML) with their original web source and a media "
+                       "preview.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-01-25",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Offline Pages",
+        "notes": "Timestamp Modified is the file's on-disk modification time (UTC). MIME Date is the "
+                 "raw Date header from the saved page (kept as text; format varies).",
+        "paths": ('*/*.mhtml', '*/*.mht'),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+    }
+}
+
 import email
 import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
-def get_offlinePages(files_found, report_folder, seeker, wrap_text):
-    
+
+@artifact_processor
+def offlinePages(context):
     data_list = []
-    
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
-        
-        with open(file_found,'r', errors='replace') as fp:
+        if os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        modified = datetime.fromtimestamp(os.path.getmtime(file_found), tz=timezone.utc)
+        with open(file_found, 'r', encoding='utf-8', errors='replace') as fp:
             message = email.message_from_file(fp)
-            sourced = (message['Snapshot-Content-Location'])
-            subjectd = (message['Subject'])
-            dated = (message['Date'])
-            media = media_to_html(file_found, files_found, report_folder)
+        media = check_in_media(file_found, os.path.basename(file_found))
+        data_list.append((modified, media, message['Snapshot-Content-Location'] or '',
+                          message['Subject'] or '', message['Date'] or '',
+                          context.get_relative_path(file_found)))
 
-        data_list.append((utc_modified_date, media, sourced, subjectd, dated, file_found))
-        
-    if len(data_list) > 0:
-        note = 'Source location in extraction found in the report for each item.'
-        report = ArtifactHtmlReport('Offline Pages')
-        report.start_artifact_report(report_folder, f'Offline Pages')
-        report.add_script()
-        data_headers = ('Timestamp Modified', 'File', 'Web Source', 'Subject', 'MIME Date', 'Source in Extraction')
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['File'])
-        report.end_artifact_report()
-        
-        tsvname = f'Offline Pages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-__artifacts__ = {
-        "pages": (
-                "Offline Pages",
-                ('*/*.mhtml', '*/*.mht'),
-                get_offlinePages)
-}
-            
+    data_headers = (('Timestamp Modified', 'datetime'), ('File', 'media'), 'Web Source', 'Subject',
+                    'MIME Date', 'Source in Extraction')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/whatsappExportedchats.py
+++ b/scripts/artifacts/whatsappExportedchats.py
@@ -1,75 +1,56 @@
+__artifacts_v2__ = {
+    "whatsappExportedchats": {
+        "name": "Whatsapp Exported Chat",
+        "description": "Messages from a WhatsApp exported chat text file (_chat.txt) with attached "
+                       "media.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-03-12",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Whatsapp Exported Chat",
+        "notes": "Timestamp is the bracketed time from each exported line, kept as text because the "
+                 "WhatsApp export date format is locale-dependent.",
+        "paths": ('*/*_chat.txt',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    }
+}
+
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
-def get_whatsappExportedchats(files_found, report_folder, seeker, wrap_text):
-    
+@artifact_processor
+def whatsappExportedchats(context):
     data_list = []
-    for file_found in files_found:
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
+        if not file_found.endswith('_chat.txt') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
         count = 0
-        if file_found.endswith('_chat.txt'):
-            with open(file_found, 'r') as f:
-                for line in f:
-                    count = count + 1
-                    line = line.replace(u'\u200e', '')
-                    line = line.strip()
-                    dividido = (line.strip().split(']'))
-                    thumb = ''
-                    if len(dividido) > 1:
-                        fecha = dividido[0].replace('[','')
-                        
-                        if ':' in dividido[1]:
-                            name = (dividido[1].split(':')[0])
-                            mensaje = (dividido[1].split(':',1)[1])
-                            
-                        else:
-                            name = ''
-                            mensaje = dividido[1]
-                            
-                        if '<attached: ' in mensaje:
-                            attach = mensaje.split('<attached: ')[1].replace('>','')
-                            thumb = media_to_html(attach, files_found, report_folder)
-                        else:
-                            attach = ''
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for line in f:
+                count += 1
+                line = line.replace(chr(0x200e), '').strip()
+                dividido = line.split(']')
+                fecha = name = thumb = ''
+                if len(dividido) > 1:
+                    fecha = dividido[0].replace('[', '')
+                    if ':' in dividido[1]:
+                        name = dividido[1].split(':')[0]
+                        mensaje = dividido[1].split(':', 1)[1]
                     else:
-                        mensaje = line
-                        
-                        
-                    if mensaje != '':
-                        data_list.append((fecha, count, name, mensaje, thumb))
-                    
-        
-        
-        
-    
-    if data_list:
-        report = ArtifactHtmlReport(f'Whatsapp Exported Chat')
-        report.start_artifact_report(report_folder, f'Whatsapp Exported Chat')
-        report.add_script()
-        data_headers = ('Timestamp','Count','Username','Message','Media')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-        report.end_artifact_report()
-        
-        tsvname = f'Whatsapp Exported Chat'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Whatsapp Exported Chat'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        #kmlactivity = f'Snapchat - Geolocations  - {username}'
-        #kmlgen(report_folder, kmlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No Whatsapp Exported Chat')
-    
-__artifacts__ = {
-        "whatsappExportedchats": (
-            "Whatsapp Exported Chat",
-            ('*/*.*'),
-            get_whatsappExportedchats)
-}
+                        mensaje = dividido[1]
+                    if '<attached: ' in mensaje:
+                        attach = mensaje.split('<attached: ')[1].replace('>', '')
+                        thumb = check_in_media(attach, attach)
+                else:
+                    mensaje = line
+                if mensaje != '':
+                    data_list.append((fecha, count, name, mensaje, thumb))
+
+    data_headers = ('Timestamp', 'Count', 'Username', 'Message', ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Migrates three single-report file/media artifacts to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `documentsFolder` | iCloud Documents Folders | `*/backup/*/Documents/**` |
| `offlinePages` | Offline Pages | `*.mhtml`, `*.mht` |
| `whatsappExportedchats` | Whatsapp Exported Chat | `*/*_chat.txt` |

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()` for source/path columns.
- **Media** — `media_to_html` → `check_in_media` into a typed `('Media'/'File','media')` column.
- **Timestamps** — `documentsFolder`/`offlinePages` modified-time typed `('Col','datetime')` as an aware-UTC datetime (was `datetime.utcfromtimestamp`, a naive value).
- `documentsFolder` skips directories/dotfiles up front.
- `offlinePages` key renamed from `"pages"` to the module name; MIME Date kept as text (raw header, variable format).

## 🐞 whatsappExportedchats fixes
- Narrowed the path glob from `'*/*.*'` (which matched **every file** in the extraction, then filtered) to `'*/*_chat.txt'`.
- Fixed a latent **unbound-variable** bug: `fecha` was only set inside the `len(dividido) > 1` branch, so a line without a `]` would reuse the previous line's timestamp (or raise on the first line). Now reset per line.
- Timestamp kept as text (WhatsApp export date format is locale-dependent).

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- `PluginLoader` loads all three (total **236**), no duplicate-name error.
- Synthetic round-trip: documentsFolder lists a real file (dir skipped) with UTC mtime + media ref; offlinePages parses MHTML headers + UTC mtime; whatsapp parses an exported chat incl. an `<attached:>` line and a no-bracket line (empty timestamp, no carry-over).

Original attribution (@AlexisBrignoni) preserved.