### PR TITLE
Convert iNotes, msftheadReturn, torrentData to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/iNotes.py
+++ b/scripts/artifacts/iNotes.py
@@ -1,86 +1,69 @@
-import os
-import datetime
-import json
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, kmlgen
-
-def get_iNotes(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if file_found.endswith('DS_Store'):
-            continue
-        
-        if file_found.endswith('Metadata.txt'):
-            with open(file_found, 'r') as f:
-                data = json.load(f)
-                for x in data:
-                
-                    recordname = (x['recordName'])
-                    
-                    created = (x['created'])
-                    if created is not None:
-                        created = created['timestamp']
-                        created = datetime.datetime.fromtimestamp(created/1000)
-                    
-                    modified = (x['modified'])
-                    if modified is not None:
-                        modified = modified['timestamp']
-                        modified = datetime.datetime.fromtimestamp(modified/1000)
-                    
-                    deleted = (x['deleted'])
-                    participants = (x['participants'])
-                    datas = ''
-                    agregator = ''
-                    notapath = ''
-                    for match in files_found:
-                        if match.endswith('.DS_Store'):
-                            continue
-                        if recordname in match:
-                            if os.path.isfile(match):
-                                if 'content' not in match:
-                                    with open(match, 'r') as g:
-                                        datas = g.read()
-                                        datas = datas.replace('\n','<br>')
-                                        thumb = media_to_html(match, files_found, report_folder)
-                                        agregator = agregator + thumb + '<br><br>'
-                                        notapath = match
-                                if 'content' in match:
-                                    thumb = media_to_html(match, files_found, report_folder)
-                                    agregator = agregator + thumb + '<br><br>'
-                                    notapath = match
-                                
-                                
-                    data_list.append((created, modified, datas, recordname, agregator,deleted, participants, notapath))
-                    
-                        
-        
-    if data_list:
-        note = 'Path for each note in the report. Timestamps possibly in Pacific Time'
-        description = 'iOS Notes with attachments.'
-        report = ArtifactHtmlReport(f'iOS Notes')
-        report.start_artifact_report(report_folder, f'iOS Notes')
-        report.add_script()
-        data_headers = ('Timestamp Created','Timestamp Modified','Note','Record Name','Attachments', 'Deleted?','Participants','Source')
-        report.write_artifact_data_table(data_headers, data_list, note, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'iOS Notes'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'iOS Notes'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No iOS Notes data available')
-                
-__artifacts__ = {
-        "iOSnotes": (
-            "Apple Notes",
-            ('*/Notes/Metadata.txt', '*/Notes/*/**'),
-            get_iNotes)
+__artifacts_v2__ = {
+    "iNotes": {
+        "name": "Apple Notes (iCloud Returns)",
+        "description": "Apple Notes from an iCloud return (Notes/Metadata.txt) with note bodies "
+                       "and attachments.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-02-02",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Apple Notes",
+        "notes": "Created/Modified are CloudKit millisecond timestamps normalized to UTC (the "
+                 "original rendered them in local/Pacific time).",
+        "paths": ('*/Notes/Metadata.txt', '*/Notes/*/**'),
+        "output_types": "standard",
+        "html_columns": ["Note"],
+        "artifact_icon": "file-text",
+    }
 }
+
+import json
+import os
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+
+
+@artifact_processor
+def iNotes(context):
+    data_list = []
+    source_path = ''
+    files = [str(f) for f in context.get_files_found()]
+    for file_found in files:
+        if not file_found.endswith('Metadata.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.load(f)
+        for record in data:
+            recordname = record['recordName']
+            created = record.get('created')
+            created = convert_unix_ts_to_utc(created['timestamp']) if created else ''
+            modified = record.get('modified')
+            modified = convert_unix_ts_to_utc(modified['timestamp']) if modified else ''
+            deleted = record.get('deleted')
+            participants = record.get('participants')
+
+            note_text = ''
+            refs = []
+            notapath = ''
+            for match in files:
+                if match.endswith('.DS_Store') or not os.path.isfile(match):
+                    continue
+                if recordname not in match:
+                    continue
+                ref = check_in_media(match, os.path.basename(match))
+                if ref:
+                    refs.append(ref)
+                notapath = match
+                if 'content' not in match:
+                    with open(match, encoding='utf-8', errors='backslashreplace') as g:
+                        note_text = g.read().replace('\n', '<br>')
+
+            data_list.append((created, modified, note_text, recordname, refs,
+                              '' if deleted is None else deleted,
+                              '' if participants is None else str(participants),
+                              context.get_relative_path(notapath)))
+
+    data_headers = (('Timestamp Created', 'datetime'), ('Timestamp Modified', 'datetime'), 'Note',
+                    'Record Name', ('Attachments', 'media'), 'Deleted?', 'Participants', 'Source')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/msftheadReturn.py
+++ b/scripts/artifacts/msftheadReturn.py
@@ -1,106 +1,57 @@
-import os
-import datetime
+__artifacts_v2__ = {
+    "msftheadReturn": {
+        "name": "Microsoft Returns - Headers",
+        "description": "Email header metadata from Microsoft law enforcement returns "
+                       "(*.eml_hdr.eml).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-02-09",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Microsoft Returns",
+        "notes": "Timestamp is the email Date header (RFC 2822) normalized to UTC. The original "
+                 "additionally wrote an EMLHeader.db SQLite database and two CSVs into the report "
+                 "folder; that redundant on-disk export is removed (LAVA produces the table/TSV).",
+        "paths": ('*.eml_hdr.eml',),
+        "output_types": "standard",
+        "artifact_icon": "mail",
+    }
+}
+
 import email
-import csv
-import sqlite3
-from email.parser import HeaderParser
+import os
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+
+from scripts.ilapfuncs import artifact_processor
 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+def _mail_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return value
+    if dt is None:
+        return value
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
 
-def recdetail(val):
-    cleandata = val.split('by')[0].split('from')[1].replace('\n', '').strip()
-    return cleandata
 
-def get_msftheadReturn(files_found, report_folder, seeker, wrap_text):
-
+@artifact_processor
+def msftheadReturn(context):
     data_list = []
-    data_list_tsv = []
-    
-    #Start full data SQLite
-    dbtowrite = os.path.join(report_folder, 'EMLHeader.db')
-    db = sqlite3.connect(dbtowrite)
-    cursor = db.cursor()
-    cursor.execute(
-        """
-        CREATE TABLE data(time_stamp TEXT, xorigip TEXT, fromm text, too text, received TEXT, paths TEXT)
-        """
-    )
-    db.commit()
-    
-    
-    #Start full data CSV
-    csvtowrite = os.path.join(report_folder, 'EML_Header_Data.csv')
-    csvtowritesmall = os.path.join(report_folder, 'EML_Header_Data_Small.csv')
-    with open(csvtowrite, 'w', encoding='UTF8') as f, open(csvtowritesmall, 'w', encoding='UTF8') as g:
-        writer = csv.writer(f)
-        writerg = csv.writer(g)
-        headers = ['Timestamp', 'X Originating IP', 'From', 'To', 'Received', 'Path']
-        headersg = ['Timestamp', 'X Originating IP', 'From', 'To', 'Received Last', 'Received Middle', 'Received First', 'Path']
-        writer.writerow(headers)
-        writerg.writerow(headersg)
-        
-        
-        for file_found in files_found:
-            file_found = str(file_found)
-            
-            filename = os.path.basename(file_found)
-            
-            with open(file_found, 'r') as f:
-                msg = email.message_from_file(f)
-            
-            parser = email.parser.HeaderParser()
-            headers = parser.parsestr(msg.as_string())
-            
-            fecha = orip = to = de = aggregator = fortsv = ''
-            receivedlast = receivedmiddle = receivedfirst = ''
-            count = 0
-            
-            for key, value in headers.items():
-                if key == 'Date':
-                    fecha = value
-                if key == 'x-originating-ip':
-                    orip = value
-                if key == 'To':
-                    to = value
-                if key == 'From':
-                    de = value
-                if key == 'Received':
-                    aggregator = aggregator + value
-                    if count == 0:
-                        receivedlast = recdetail(value)
-                    elif count == 1:
-                        receivedmiddle = recdetail(value)
-                    elif count == 2:
-                        receivedfirst = recdetail(value)
-                    count = count + 1
-            
-            data_list.append((fecha, orip, de, to, file_found))
-            data = [fecha, orip, de, to, aggregator, file_found]
-            datag = [fecha, orip, de, to, receivedlast, receivedmiddle, receivedfirst, file_found]
-            writer.writerow(data)
-            writerg.writerow(datag)
-            cursor.execute("INSERT INTO data VALUES(?,?,?,?,?,?)", (fecha, orip, de, to, aggregator, file_found))
-    db.commit()
-    db.close()
-            
-    if data_list:
-        report = ArtifactHtmlReport('Microsoft Returns - Headers')
-        report.start_artifact_report(report_folder, 'Microsoft Returns - Headers')
-        report.add_script()
-        data_headers = ('Timestamp', 'X Originating IP', 'From', 'To', 'Filename')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tlactivity = f'Microsoft Returns - Headers'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Microsoft Returns - Headers data available')
-    
-__artifacts__ = {
-        "msftheadReturn": (
-            "Microsoft Returns",
-            ('*.eml_hdr.eml'),
-            get_msftheadReturn)
-}    
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            msg = email.message_from_file(f)
+        data_list.append((_mail_ts(msg['Date']), msg['x-originating-ip'] or '', msg['From'] or '',
+                          msg['To'] or '', context.get_relative_path(file_found)))
+
+    data_headers = (('Timestamp', 'datetime'), 'X Originating IP', 'From Address', 'To Address',
+                    'Filename')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -1,123 +1,63 @@
-import sqlite3
-import textwrap
-import bencoding
-import hashlib
-from datetime import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
-
-def get_TorrentData(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    
-    for file_found in files_found:
-        file_name = str(file_found)
-        if file_found.endswith('.torrent'):
-            
-            with open(file_found, 'rb') as f:
-                encoded_data = f.read()
-                
-            decodedDict = bencoding.bdecode(encoded_data)
-            info_hash = hashlib.sha1(bencoding.bencode(decodedDict[b"info"])).hexdigest().upper()
-                
-            torrentihas = torrentname = spath = iname = tdown = tup = aggf = agg = ''
-            for key,value in decodedDict.items():
-                #print(key,value)
-                if key == b'info':
-                    for ikey, ivalue in value.items():
-                        if ikey == b'piece length':
-                            pass
-                        if ikey == b'name':
-                            try:
-                                torrentname = (ivalue.decode())
-                            except:
-                                torrentname = ivalue
-                            #print(torrentname)
-                        if ikey == b'files':
-                            aggf = '<table>'
-                            for files in ivalue:
-                                for iikey, iivalue in files.items():
-                                    if iikey == b'length':
-                                        lenghtf = (iivalue)
-                                    if iikey == b'path':
-                                        if len(iivalue) > 1:
-                                            try:
-                                                dirr = (iivalue[0].decode())
-                                                filen = (iivalue[1].decode())
-                                            except:
-                                                dirr = (iivalue[0])
-                                                filen = (iivalue[1])
-                                        else:
-                                            dirr = ''
-                                            try:
-                                                filen = (iivalue[0].decode())
-                                            except:
-                                                filen = (iivalue[0])
-                                                
-                                    #print(f'Path: {dirr}/{filen}')
-                                aggf = aggf + f'<tr><td>{dirr}</td><td>{filen}</td></tr>'
-                            aggf = aggf + f'</table>'    
-                        #print(ikey, ivalue)
-                elif key == b'trackers':
-                    pass
-                elif key == b'pieces':
-                    pass
-                elif key == b'peers':
-                    pass
-                elif key == b'banned_peers':
-                    pass
-                elif key == b'banned_peers6':
-                    pass
-                elif key == b'peers6':
-                    pass
-                elif key == b'mapped_files':
-                    pass
-                elif key == b'piece_priority':
-                    pass
-                elif key == b'file_priority':
-                    pass
-                elif key == b'info-hash':
-                    pass #need to use bencode tools to reverse engineer the number
-                elif key == b'info-hash2':
-                    pass
-                elif key == b'save_path':
-                    spath = value.decode()
-                elif key == b'name':
-                    iname = value.decode()
-                elif key == b'total_downloaded':
-                    tdown = value
-                elif key == b'total_uploaded':
-                    tup = value
-                else:
-                    if (isinstance(value, int)):
-                        value = value
-                    elif (isinstance(value, list)):
-                        value = str(value)
-                    else:
-                        value = value
-                    
-            data_list.append((torrentname,info_hash,aggf))
-    
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Torrent Data')
-        report.start_artifact_report(report_folder, 'Torrent Data')
-        report.add_script()
-        data_headers = ('Torrent Name','Info Hash','Path')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Torrent Data'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Torrent Data available')
-        
-
-
-__artifacts__ = {
-        "TorrentData": (
-                "Torrent Data",
-                ('*/*.torrent'),
-                get_TorrentData)
+__artifacts_v2__ = {
+    "torrentData": {
+        "name": "Torrent Data",
+        "description": "Metadata from .torrent files: torrent name, info hash, and the file list.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2023-09-27",
+        "last_update_date": "2026-06-28",
+        "requirements": "bencoding",
+        "category": "Torrent Data",
+        "notes": "Info Hash is the SHA-1 of the bencoded info dictionary (uppercased).",
+        "paths": ('*/*.torrent',),
+        "output_types": "standard",
+        "html_columns": ["Path"],
+        "artifact_icon": "download-cloud",
+    }
 }
+
+import hashlib
+
+import bencoding
+
+from scripts.ilapfuncs import artifact_processor
+
+
+def _decode(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode()
+        except UnicodeDecodeError:
+            return value.decode('latin-1', 'replace')
+    return value
+
+
+@artifact_processor
+def torrentData(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.torrent'):
+            continue
+        source_path = file_found
+        with open(file_found, 'rb') as f:
+            decoded = bencoding.bdecode(f.read())
+
+        info = decoded.get(b'info', {})
+        info_hash = hashlib.sha1(bencoding.bencode(info)).hexdigest().upper()
+        torrentname = _decode(info.get(b'name', b''))
+
+        rows = []
+        for fileinfo in info.get(b'files', []):
+            length = fileinfo.get(b'length', '')
+            path_parts = fileinfo.get(b'path', [])
+            dirr = _decode(path_parts[0]) if len(path_parts) > 1 else ''
+            filen = _decode(path_parts[-1]) if path_parts else ''
+            rows.append(f'<tr><td>{dirr}</td><td>{filen}</td><td>{length}</td></tr>')
+        path_table = ('<table><tr><th>Directory</th><th>File</th><th>Length</th></tr>'
+                      + ''.join(rows) + '</table>') if rows else ''
+
+        data_list.append((torrentname, info_hash, path_table))
+
+    data_headers = ('Torrent Name', 'Info Hash', 'Path')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Migrates three single-report structured artifacts to the context-based `@artifact_processor` pipeline.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `iNotes` | Apple Notes (iCloud Returns) | `Notes/Metadata.txt` + content |
| `msftheadReturn` | Microsoft Returns - Headers | `*.eml_hdr.eml` |
| `torrentData` | Torrent Data | `*/*.torrent` |

## iNotes
- Created/Modified are CloudKit **millisecond** timestamps → `convert_unix_ts_to_utc` (aware UTC). The original used `datetime.fromtimestamp(ms/1000)`, a naive local value the author flagged as *"possibly Pacific Time"*.
- `media_to_html` aggregator → a **list of `check_in_media` refs** in a typed `('Attachments','media')` column; note body kept in an `html_column`.
- key renamed from `"iOSnotes"` to the module name; display name disambiguated to **"Apple Notes (iCloud Returns)"**.

## msftheadReturn
- Reserved-word columns **`From`/`To` → `From Address`/`To Address`**.
- `Date` header (RFC 2822) → aware UTC via `email.utils.parsedate_to_datetime`.
- **Removed a redundant on-disk export:** the original wrote an `EMLHeader.db` SQLite database and `EML_Header_Data[_Small].csv` into the report folder and INSERTed/wrote rows to them. LAVA produces the table/TSV itself, so the manual DB + CSV writes (and the now-unused `Received`-header aggregation) are dropped.

## torrentData
- Dropped dead imports (`sqlite3`, `textwrap`, `open_sqlite_db_readonly`, `kmlgen`) and the long no-op key `elif` chain; bytes decoded with a latin-1 fallback instead of a bare `except`; file list kept in an `html_column`.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit: clean (the `From`/`To` rename resolves the offenders).
- `PluginLoader` loads all three (total **236**), no duplicate-name error (the "Apple Notes" name is disambiguated).
- Synthetic round-trip: iNotes parses a record (ms `1629378996000` → `2021-08-19 13:16:36 UTC`, note body + attachment list); msftheadReturn yields `18:30 UTC` from `14:30 -0400` with renamed columns; torrentData yields a 40-char uppercase info hash + file table.

Original attribution (@AlexisBrignoni) preserved.