### PR TITLE
Convert Coinbase Archive to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/coinbaseArchive.py
+++ b/scripts/artifacts/coinbaseArchive.py
@@ -1,270 +1,203 @@
-import os
+def _meta(name, icon):
+    return {"name": f"Coinbase - {name}",
+            "description": f"{name} from a Coinbase law enforcement return (coinbase_data.json).",
+            "author": "Mark McKinnon", "creation_date": "2021-11-25",
+            "last_update_date": "2026-06-28", "requirements": "none",
+            "category": "Coinbase Archive", "notes": "", "paths": ('**/coinbase_data.json',),
+            "output_types": "standard", "artifact_icon": icon}
+
+
+__artifacts_v2__ = {
+    "coinbaseTransactions": _meta("Transactions", "dollar-sign"),
+    "coinbaseCardPayment": _meta("Card Payment", "credit-card"),
+    "coinbaseConfirmedDevices": _meta("Confirmed Devices", "check-circle"),
+    "coinbaseDevicesUsed": _meta("Devices Used", "smartphone"),
+    "coinbaseSiteActivity": _meta("Site Activity", "activity"),
+    "coinbaseThirdParty": _meta("3rd party authorizations", "share-2"),
+    "coinbasePersonalData": _meta("Personal Data", "user"),
+}
+
 import json
+import os
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, usergen, ipgen
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, usergen, ipgen
 
-transaction_history_columns = ["Account_name", "Amount", "Balance", "Coinbase_id",
-                               "Crypto_hash", "Currency", "Instantly_exchanged",
-                               "Notes", "Timestamp", "To", "Transfer_id", "Transfer_payment_method"]
-card_payment_columns = ["Customer_name", "Expiration_month", "Expiration_year", "First6", "Issue_country",
-                        "Issuer", "Last4", "Postal_code", "Type"]
-
+transaction_history_columns = ["Account_name", "Amount", "Balance", "Coinbase_id", "Crypto_hash",
+                               "Currency", "Instantly_exchanged", "Notes", "Timestamp", "To",
+                               "Transfer_id", "Transfer_payment_method"]
+card_payment_columns = ["Customer_name", "Expiration_month", "Expiration_year", "First6",
+                        "Issue_country", "Issuer", "Last4", "Postal_code", "Type"]
 confirmed_devices_columns = ["Confirmed", "Ip_address", "User_agent"]
-
-devices_used_columns = ["Accept", "Accept_encoding", "Accept_language", "Ip_address", "Platform", "Platform_version",
-                        "Timezone_locale", "Timezone_string", "User_agent"]
-
+devices_used_columns = ["Accept", "Accept_encoding", "Accept_language", "Ip_address", "Platform",
+                        "Platform_version", "Timezone_locale", "Timezone_string", "User_agent"]
 site_activity_columns = ["Action", "Ip_address", "Source", "Time"]
-
 third_party_columns = ["Access_granted", "Access_revoked", "Name"]
 
 
-def get_coinbaseArchive(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
+def _coinbase_json(context):
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
+        if os.path.basename(file_found).lower().startswith('coinbase_data.json'):
+            with open(file_found, encoding='utf-8') as f:
+                return file_found, json.load(f)
+    return '', {}
 
-        if filename.lower().startswith('coinbase_data.json'):
-            transaction_data_list = []
-            card_payment_data_list = []
-            confirmed_data_list = []
-            devices_used_data_list = []
-            site_activity_data_list = []
-            third_party_data_list = []
-            personal_data_list = []
-            with open(file_found, 'r', encoding='utf-8') as f:
-                coinbaseData = json.load(f)
-                for allData in coinbaseData:
-                    if 'Financial' in allData:
-                        for financialData in coinbaseData[allData]:
-                            if 'transaction' in financialData:
-                                user_list = []
-                                report = ArtifactHtmlReport('Coinbase - Transactions')
-                                report.start_artifact_report(report_folder, 'Coinbase - Transactions')
-                                html_report = report.get_report_file_path()
-                                transaction_history = coinbaseData['Financial Data'][financialData]
-                                for trans_history in transaction_history:
-                                    temp_list = []
-                                    for column_name in transaction_history_columns:
-                                        if column_name == 'To' and trans_history[column_name] != None and '@' in trans_history[column_name]:
-                                            user_list.append(
-                                                (trans_history[column_name], 'Coinbase Archive', 'Coinbase - Transactions', html_report, None))
-                                        temp_list.append(trans_history[column_name])
-                                    transaction_data_list.append(temp_list)
 
-                                if transaction_data_list:
-                                    report.add_script()
-                                    data_headers = transaction_history_columns
-                                    report.write_artifact_data_table(data_headers, transaction_data_list, file_found)
-                                    report.end_artifact_report()
+def _ts(value):
+    if value in (None, ''):
+        return ''
+    text = str(value).strip()
+    if text.isdigit():
+        return convert_unix_ts_to_utc(int(text))
+    try:
+        dt = datetime.fromisoformat(text.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
 
-                                    tsvname = f'Coinbase - Transactions'
-                                    tsv(report_folder, data_headers, transaction_data_list, tsvname)
 
-                                    usergen(report_folder, user_list)
+def _financial_section(data, which):
+    for top_key, top_val in (data or {}).items():
+        if 'Financial' in top_key and isinstance(top_val, dict):
+            for sub_key, sub_val in top_val.items():
+                bucket = 'transaction' if 'transaction' in sub_key.lower() else (
+                    'cards' if 'cards' in sub_key.lower() else None)
+                if bucket == which:
+                    return sub_val
+    return None
 
-                                    tlactivity = f'Coinbase - Transactions'
-                                    timeline(report_folder, tlactivity, transaction_data_list, data_headers)
-                                else:
-                                    logfunc('No Coinbase Transactions data available')
 
-                            elif 'cards' in financialData.lower():
-                                card_payment = coinbaseData['Financial Data'][financialData]
-                                for card in card_payment:
-                                    temp_list = []
-                                    for column_name in card_payment_columns:
-                                        temp_list.append(card[column_name])
-                                    card_payment_data_list.append(temp_list)
+def _interaction_section(data, which):
+    for top_key, top_val in (data or {}).items():
+        if 'Interaction' in top_key and isinstance(top_val, dict):
+            for sub_key, sub_val in top_val.items():
+                if 'Confirmed' in sub_key:
+                    bucket = 'confirmed'
+                elif 'Devices' in sub_key:
+                    bucket = 'devices'
+                elif 'Site' in sub_key:
+                    bucket = 'site'
+                elif 'Third' in sub_key:
+                    bucket = 'third'
+                else:
+                    bucket = None
+                if bucket == which:
+                    return sub_val
+    return None
 
-                                if card_payment_data_list:
-                                    report = ArtifactHtmlReport('Coinbase - Card Payment')
-                                    report.start_artifact_report(report_folder, 'Coinbase - Card Payment')
-                                    report.add_script()
-                                    data_headers = card_payment_columns
-                                    report.write_artifact_data_table(data_headers, card_payment_data_list, file_found)
-                                    report.end_artifact_report()
 
-                                    tsvname = f'Coinbase - Card Payment'
-                                    tsv(report_folder, data_headers, card_payment_data_list, tsvname)
+def _simple_headers(columns):
+    return tuple(('Timestamp', 'datetime') if c == 'Timestamp'
+                 else ('Time', 'datetime') if c == 'Time'
+                 else ('To Address' if c == 'To' else c) for c in columns)
 
-                                else:
-                                    logfunc('No Card Payment data available')
 
-                    elif 'Interactions' in allData:
-                        interactionData = coinbaseData[allData]
-                        for interactions in interactionData:
-                            if 'Confirmed' in interactions:
-                                ipaddress_list = []
-                                report = ArtifactHtmlReport('Coinbase - Confirmed Devices')
-                                report.start_artifact_report(report_folder, 'Coinbase - Confirmed Devices')
-                                html_report = report.get_report_file_path()
-                                confirmed_history = interactionData[interactions]
-                                for conf_history in confirmed_history:
-                                    temp_list = []
-                                    for column_name in confirmed_devices_columns:
-                                        if "Ip_address" in column_name and conf_history[column_name] != None:
-                                            ipaddress_list.append(
-                                                (conf_history[column_name], 'Coinbase Archive', 'Coinbase Confirmed Devices', html_report, None))
-                                        temp_list.append(conf_history[column_name])
-                                    confirmed_data_list.append(temp_list)
+def _ip_rows(section, columns, artifact_key, context):
+    data_list, ip_list = [], []
+    for item in section or []:
+        row = []
+        for col in columns:
+            val = item.get(col)
+            if col == 'Ip_address' and val is not None:
+                ip_list.append((val, 'Coinbase Archive', artifact_key, '', None))
+            row.append(_ts(val) if col in ('Timestamp', 'Time') else val)
+        data_list.append(row)
+    if ip_list:
+        ipgen(context.get_report_folder(), ip_list)
+    return data_list
 
-                                if confirmed_data_list:
-                                    report.add_script()
-                                    data_headers = confirmed_devices_columns
-                                    report.write_artifact_data_table(data_headers, confirmed_data_list, file_found)
-                                    report.end_artifact_report()
 
-                                    tsvname = f'Coinbase - Confirmed Devices'
-                                    tsv(report_folder, data_headers, confirmed_data_list, tsvname)
+@artifact_processor
+def coinbaseTransactions(context):
+    source_path, data = _coinbase_json(context)
+    section = _financial_section(data, 'transaction')
+    data_list, user_list = [], []
+    for item in section or []:
+        row = []
+        for col in transaction_history_columns:
+            val = item.get(col)
+            if col == 'To' and val and '@' in str(val):
+                user_list.append((val, 'Coinbase Archive', 'coinbaseTransactions', '', None))
+            row.append(_ts(val) if col == 'Timestamp' else val)
+        data_list.append(row)
+    if user_list:
+        usergen(context.get_report_folder(), user_list)
+    return _simple_headers(transaction_history_columns), data_list, \
+        context.get_relative_path(source_path)
 
-                                    ipgen(report_folder, ipaddress_list)
 
-                                else:
-                                    logfunc('No Coinbase Confirmed Device data available')
-                            elif 'Devices' in interactions:
-                                ipaddress_list = []
-                                report = ArtifactHtmlReport('Coinbase - Devices Used')
-                                report.start_artifact_report(report_folder, 'Coinbase - Devices Used')
-                                html_report = report.get_report_file_path()
-                                devices_used_history = interactionData[interactions]
-                                for devices_history in devices_used_history:
-                                    temp_list = []
-                                    for column_name in devices_used_columns:
-                                        if "Ip_address" in column_name and devices_history[column_name] != None:
-                                            ipaddress_list.append(
-                                                (devices_history[column_name], 'Coinbase Archive', 'Coinbase Devices Used', html_report, None))
-                                        temp_list.append(devices_history[column_name])
-                                    devices_used_data_list.append(temp_list)
+@artifact_processor
+def coinbaseCardPayment(context):
+    source_path, data = _coinbase_json(context)
+    section = _financial_section(data, 'cards')
+    data_list = [[item.get(col) for col in card_payment_columns] for item in section or []]
+    return _simple_headers(card_payment_columns), data_list, context.get_relative_path(source_path)
 
-                                if devices_used_data_list:
-                                    report.add_script()
-                                    data_headers = devices_used_columns
-                                    report.write_artifact_data_table(data_headers, devices_used_data_list, file_found)
-                                    report.end_artifact_report()
 
-                                    tsvname = f'Coinbase - Devices Used'
-                                    tsv(report_folder, data_headers, devices_used_data_list, tsvname)
+@artifact_processor
+def coinbaseConfirmedDevices(context):
+    source_path, data = _coinbase_json(context)
+    section = _interaction_section(data, 'confirmed')
+    data_list = _ip_rows(section, confirmed_devices_columns, 'coinbaseConfirmedDevices', context)
+    return _simple_headers(confirmed_devices_columns), data_list, \
+        context.get_relative_path(source_path)
 
-                                    ipgen(report_folder, ipaddress_list)
 
-                                    tlactivity = f'Coinbase - Devices Used'
-                                    timeline(report_folder, tlactivity, devices_used_data_list, data_headers)
-                                else:
-                                    logfunc('No Coinbase Confirmed Device data available')
-                            elif 'Site' in interactions:
-                                ipaddress_list = []
-                                report = ArtifactHtmlReport('Coinbase - Site Activity')
-                                report.start_artifact_report(report_folder, 'Coinbase - Site Activity')
-                                html_report = report.get_report_file_path()
-                                site_activity_history = interactionData[interactions]
-                                for site_history in site_activity_history:
-                                    temp_list = []
-                                    for column_name in site_activity_columns:
-                                        if "Ip_address" in column_name and site_history[column_name] != None:
-                                            ipaddress_list.append(
-                                                (site_history[column_name], 'Coinbase Archive', 'Coinbase Site Activity', html_report, None))
-                                        temp_list.append(site_history[column_name])
-                                    site_activity_data_list.append(temp_list)
+@artifact_processor
+def coinbaseDevicesUsed(context):
+    source_path, data = _coinbase_json(context)
+    section = _interaction_section(data, 'devices')
+    data_list = _ip_rows(section, devices_used_columns, 'coinbaseDevicesUsed', context)
+    return _simple_headers(devices_used_columns), data_list, context.get_relative_path(source_path)
 
-                                if site_activity_data_list:
-                                    report.add_script()
-                                    data_headers = site_activity_columns
-                                    report.write_artifact_data_table(data_headers, site_activity_data_list, file_found)
-                                    report.end_artifact_report()
 
-                                    tsvname = f'Coinbase - Site Activity'
-                                    tsv(report_folder, data_headers, site_activity_data_list, tsvname)
+@artifact_processor
+def coinbaseSiteActivity(context):
+    source_path, data = _coinbase_json(context)
+    section = _interaction_section(data, 'site')
+    data_list = _ip_rows(section, site_activity_columns, 'coinbaseSiteActivity', context)
+    return _simple_headers(site_activity_columns), data_list, context.get_relative_path(source_path)
 
-                                    ipgen(report_folder, ipaddress_list)
 
-                                    tlactivity = f'Coinbase - Site Activity'
-                                    timeline(report_folder, tlactivity, site_activity_data_list, data_headers)
-                                else:
-                                    logfunc('No Coinbase Site Activity data available')
-                            elif 'Third' in interactions:
-                                third_party_activity_history = interactionData[interactions]
-                                for third_party_history in third_party_activity_history:
-                                    temp_list = []
-                                    for column_name in third_party_columns:
-                                        temp_list.append(third_party_history[column_name])
-                                    third_party_data_list.append(temp_list)
+@artifact_processor
+def coinbaseThirdParty(context):
+    source_path, data = _coinbase_json(context)
+    section = _interaction_section(data, 'third')
+    data_list = [[item.get(col) for col in third_party_columns] for item in section or []]
+    return tuple(third_party_columns), data_list, context.get_relative_path(source_path)
 
-                                if third_party_data_list:
-                                    report = ArtifactHtmlReport('Coinbase - 3rd party authorizations')
-                                    report.start_artifact_report(report_folder, 'Coinbase - 3rd party authorizations')
-                                    report.add_script()
-                                    data_headers = third_party_columns
-                                    report.write_artifact_data_table(data_headers, third_party_data_list, file_found)
-                                    report.end_artifact_report()
 
-                                    tsvname = f'Coinbase - 3rd party authorizations'
-                                    tsv(report_folder, data_headers, third_party_data_list, tsvname)
+@artifact_processor
+def coinbasePersonalData(context):
+    source_path, data = _coinbase_json(context)
+    personal_section = None
+    for top_key, top_val in (data or {}).items():
+        if 'Personal' in top_key:
+            personal_section = top_val
+            break
 
-                                else:
-                                    logfunc('No Coinbase 3rd party auths data available')
-                    elif 'Personal' in allData:
-                        report = ArtifactHtmlReport('Coinbase - Personal Data')
-                        report.start_artifact_report(report_folder, 'Coinbase - Personal Data')
-                        html_report = report.get_report_file_path()
-                        personalData = coinbaseData[allData]
-                        for personal in personalData:
-                            if 'Addresses' in personal:
-                                address_history = personalData[personal]
-                                for addr_history in address_history:
-                                    temp_list = []
-                                    temp_list.append("Address")
-                                    address_string = ""
-                                    for column_name in addr_history.keys():
-                                        if addr_history[column_name] != None:
-                                            address_string = address_string + addr_history[column_name] + "\n"
-                                    temp_list.append(address_string)
-                                    personal_data_list.append(temp_list)
-                            elif 'Employers' in personal:
-                                employer_history = personalData[personal]
-                                for emp_history in employer_history:
-                                    for column_name in emp_history.keys():
-                                        temp_list = []
-                                        temp_list.append(column_name)
-                                        temp_list.append(emp_history[column_name])
-                                        personal_data_list.append(temp_list)
-                            else:
-                                if 'Section' in personal:
-                                    pass
-                                elif 'Emails' in personal:
-                                    temp_list = []
-                                    temp_list.append(personal)
-                                    temp_list.append(personalData[personal])
-                                    personal_data_list.append(temp_list)
-                                    user_list.append(
-                                        (personalData[personal], 'Coinbase Archive', 'Coinbase - Personal Data',
-                                         html_report, None))
-
-                                else:
-                                    temp_list = []
-                                    temp_list.append(personal)
-                                    temp_list.append(personalData[personal])
-                                    personal_data_list.append(temp_list)
-
-                        if personal_data_list:
-                            report.add_script()
-                            data_headers = ('Name', 'Value')
-                            report.write_artifact_data_table(data_headers, personal_data_list, file_found)
-                            report.end_artifact_report()
-
-                            tsvname = f'Coinbase - Personal Data'
-                            tsv(report_folder, data_headers, personal_data_list, tsvname)
-
-                            usergen(report_folder, user_list)
-
-                        else:
-                            logfunc('No Coinbase Personal data available')
-
-__artifacts__ = {
-        "coinbaseArchive": (
-            "Coinbase Archive",
-            ('**/coinbase_data.json'),
-            get_coinbaseArchive)
-}
+    data_list, user_list = [], []
+    for personal in (personal_section or {}):
+        value = personal_section[personal]
+        if 'Addresses' in personal:
+            for addr in value:
+                address_string = ''
+                for col in addr:
+                    if addr[col] is not None:
+                        address_string += str(addr[col]) + '\n'
+                data_list.append(['Address', address_string])
+        elif 'Employers' in personal:
+            for emp in value:
+                for col in emp:
+                    data_list.append([col, emp[col]])
+        elif 'Section' in personal:
+            continue
+        elif 'Emails' in personal:
+            data_list.append([personal, value])
+            user_list.append((value, 'Coinbase Archive', 'coinbasePersonalData', '', None))
+        else:
+            data_list.append([personal, value])
+    if user_list:
+        usergen(context.get_report_folder(), user_list)
+    return ('Name', 'Value'), data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts `coinbaseArchive` (`coinbase_data.json`) to the context-based `@artifact_processor` pipeline. The one legacy function emitted **seven** ArtifactHtmlReports, so it splits into seven artifacts.

## Artifacts
| Key | Name |
|---|---|
| `coinbaseTransactions` | Coinbase - Transactions |
| `coinbaseCardPayment` | Coinbase - Card Payment |
| `coinbaseConfirmedDevices` | Coinbase - Confirmed Devices |
| `coinbaseDevicesUsed` | Coinbase - Devices Used |
| `coinbaseSiteActivity` | Coinbase - Site Activity |
| `coinbaseThirdParty` | Coinbase - 3rd party authorizations |
| `coinbasePersonalData` | Coinbase - Personal Data |

## Changes
- **Context API** — `context.get_files_found()` / `context.get_relative_path()`.
- **Reserved word** — `To` → `To Address` (Transactions).
- **Timestamps** — `Timestamp` (Transactions) and `Time` (Site Activity) typed `('Col','datetime')`, parsed to aware UTC.
- **Correlation DBs preserved** — `ipgen`/`usergen` called with `context.get_report_folder()` (Confirmed/Devices/Site → ipgen; Transactions/Personal emails → usergen), matching the converted Takeout pattern.
- JSON section lookup factored into helpers that preserve the original substring-matching + `if/elif` precedence (so `"Confirmed Devices"` maps to *Confirmed*, not *Devices*).

## 🐞 Bug fix
In the original, Personal Data's `usergen` referenced a `user_list` that was only defined inside the **Transactions** branch — a `NameError` unless Transactions ran first. Splitting into independent artifacts removes the coupling.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit across all 7 tables: clean (the `To` rename resolves the only offender).
- `PluginLoader` loads all seven (total **242**, net +6), no duplicate-name error.
- Synthetic round-trip on a full `coinbase_data.json`: timestamps → UTC, `To`→`To Address` email routed to usergen, IPs routed to ipgen, Personal Data Addresses/Employers/Emails/other → Name/Value rows.

Original attribution (Mark McKinnon, 2021-11-25) preserved.