### PR TITLE
Convert Netflix Archive to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/netflixArchive.py
+++ b/scripts/artifacts/netflixArchive.py
@@ -1,319 +1,189 @@
-import os
-import datetime
-import csv
-import codecs
-import shutil
+def _meta(name, paths, icon):
+    return {"name": f"Netflix - {name}",
+            "description": f"{name} from a Netflix law enforcement return.",
+            "author": "Mark McKinnon", "creation_date": "2021-09-01",
+            "last_update_date": "2026-06-28", "requirements": "none",
+            "category": "Netflix Archive", "notes": "", "paths": paths,
+            "output_types": "standard", "artifact_icon": icon}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, usergen, ipgen
 
-def get_netflixArchive(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        
-        if filename.startswith('Profiles.csv'):
-            data_list =[]
-            user_list = []
-            report = ArtifactHtmlReport('Netflix - Profiles')
-            report.start_artifact_report(report_folder, 'Netflix - Profiles')
-            html_report = report.get_report_file_path()
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                    else:
-                        user = item[0]
-                        email_address = item[1]
-                        profile_creation_time = item[2]
-                        data_list.append((user, email_address, profile_creation_time))
-                        if email_address != "":
-                            user_list.append((email_address, 'Netflix', 'Netflix_Profiles', html_report, None))
-
-            if data_list:
-                data_headers = ('Profile_Name', 'Email_Address', 'Profile_Creation_Time')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Netflix - Profiles'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                usergen(report_folder, user_list)
-
-                tlactivity = f'Netflix - Profiles'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Profiles data available')
-
-        if filename.startswith('BillingHistory.csv'):
-            data_list = []
-            header_list = []
-            report = ArtifactHtmlReport('Netflix - Billing History')
-            report.start_artifact_report(report_folder, 'Netflix - Billing History')
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                        header_list = item
-                    else:
-                        data_list.append(item)
-
-            if data_list:
-                data_headers = header_list
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - Billing History'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Netflix - Billing History'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Billing History data available')
-
-        if filename.startswith('IpAddressesLogin.csv'):
-            data_list = []
-            ipaddress_list = []
-            report = ArtifactHtmlReport('Netflix - IP Address Login')
-            report.start_artifact_report(report_folder, 'Netflix - IP Address Login')
-            html_report = report.get_report_file_path()
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                    else:
-                        esn = item[0]
-                        country = item[1]
-                        region_code = item[2]
-                        device_desc = item[3]
-                        ipaddress = item[4]
-                        timestamp = item[5]
-                        data_list.append((timestamp, ipaddress, esn, country, region_code, device_desc))
-                        if ipaddress != None:
-                            ipaddress_list.append(
-                                (ipaddress, 'Netflix', 'Netflix_Ipaddress_logins', html_report, None))
-
-            if data_list:
-                data_headers = ('Timestamp', 'Ip Address', 'Esn', 'Country', 'Region code', 'Device description')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - IP Address Login'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                ipgen(report_folder, ipaddress_list)
-
-                tlactivity = f'Netflix - IP Address Login'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Ipaddress Logins data available')
-
-        if filename.startswith('IpAddressesStreaming.csv'):
-            data_list = []
-            ipaddress_list = []
-            report = ArtifactHtmlReport('Netflix - IP Address Streaming')
-            report.start_artifact_report(report_folder, 'Netflix - IP Address Streaming')
-            html_report = report.get_report_file_path()
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                    else:
-                        esn = item[0]
-                        country = item[1]
-                        localized_device_desc = item[2]
-                        device_desc = item[3]
-                        ipaddress = item[4]
-                        region_code_display_name = item[5]
-                        timestamp = item[6]
-                        data_list.append((timestamp, ipaddress, device_desc, localized_device_desc, region_code_display_name, esn, country))
-                        if ipaddress != None:
-                            ipaddress_list.append(
-                                (ipaddress, 'Netflix', 'Netflix_Ipaddress_streaming', html_report, None))
-
-            if data_list:
-                data_headers = ('Timestamp', 'Ip Address', 'Device Description', 'Localized Device Description', 'Region Code Display Name', 'esn', 'Country')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - IP Address Streaming'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                ipgen(report_folder, ipaddress_list)
-
-                tlactivity = f'Netflix - IP Address Streaming'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Ipaddress Streaming data available')
-
-        if filename.startswith('Devices.csv'):
-            data_list = []
-            header_list = []
-            report = ArtifactHtmlReport('Netflix - Devices')
-            report.start_artifact_report(report_folder, 'Netflix - Devices')
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                        header_list = item
-                    else:
-                        data_list.append(item)
-
-            if data_list:
-                data_headers = header_list
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - Devices'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Netflix - Devices'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Devices data available')
-
-        if filename.startswith('ViewingActivity.csv'):
-            data_list = []
-            header_list = []
-            report = ArtifactHtmlReport('Netflix - Viewing Activity')
-            report.start_artifact_report(report_folder, 'Netflix - Viewing Activity')
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                        header_list = item
-                    else:
-                        data_list.append(item)
-
-            if data_list:
-                data_headers = header_list
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - Viewing Activity'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Netflix - Viewing Activity'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Viewing Activity data available')
-
-        if filename.startswith('SearchHistory.csv'):
-            data_list = []
-            header_list = []
-            report = ArtifactHtmlReport('Netflix - Search History')
-            report.start_artifact_report(report_folder, 'Netflix - Search History')
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                        header_list = item
-                    else:
-                        data_list.append(item)
-
-            if data_list:
-                data_headers = header_list
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - Search History'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Netflix - Search History'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Search History data available')
-
-        if filename.startswith('AccountDetails.csv'):
-            data_list = []
-            user_list = []
-            header_list = []
-            report = ArtifactHtmlReport('Netflix - Account Details')
-            report.start_artifact_report(report_folder, 'Netflix - Account Details')
-            html_report = report.get_report_file_path()
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                        header_list = item
-                    else:
-                        data_list.append(item)
-                        if item[2] != "":
-                            user_list.append((item[2], 'Netflix', 'Netflix_Account_Details', html_report, None))
-
-            if data_list:
-                data_headers = header_list
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - Account Details'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                usergen(report_folder, user_list)
-
-                tlactivity = f'Netflix - Account Details'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Account Details data available')
-
-        if filename.startswith('MessagesSentByNetflix.csv'):
-            data_list = []
-            header_list = []
-            report = ArtifactHtmlReport('Netflix - Messages Sent By Netflix')
-            report.start_artifact_report(report_folder, 'Netflix - Messages Sent By Netflix')
-            report.add_script()
-            has_header = True
-            with open(file_found, 'r', encoding='utf-8') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    if has_header:
-                        has_header = False
-                        header_list = item
-                    else:
-                        data_list.append(item)
-
-            if data_list:
-                data_headers = header_list
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-
-                tsvname = f'Netflix - Messages Sent By Netflix'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'Netflix - Messages Sent By Netflix'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Netflix - Messages Sent By Netflix data available')
-
-__artifacts__ = {
-        "netflixArchive": (
-            "Netflix Archive",
-            ('**/Profiles.csv', '**/BillingHistory.csv', '**/IpAddressesLogin.csv', '**/IpAddressesStreaming.csv', '**/Devices.csv', '**/ViewingActivity.csv', '**/SearchHistory.csv', '**/AccountDetails.csv', '**/MessagesSentByNetflix.csv'),
-            get_netflixArchive)
+__artifacts_v2__ = {
+    "netflixProfiles": _meta("Profiles", ('**/Profiles.csv',), "users"),
+    "netflixBillingHistory": _meta("Billing History", ('**/BillingHistory.csv',), "credit-card"),
+    "netflixIpLogin": _meta("IP Address Login", ('**/IpAddressesLogin.csv',), "log-in"),
+    "netflixIpStreaming": _meta("IP Address Streaming", ('**/IpAddressesStreaming.csv',), "cast"),
+    "netflixDevices": _meta("Devices", ('**/Devices.csv',), "smartphone"),
+    "netflixViewingActivity": _meta("Viewing Activity", ('**/ViewingActivity.csv',), "play"),
+    "netflixSearchHistory": _meta("Search History", ('**/SearchHistory.csv',), "search"),
+    "netflixAccountDetails": _meta("Account Details", ('**/AccountDetails.csv',), "user"),
+    "netflixMessagesSent": _meta("Messages Sent By Netflix", ('**/MessagesSentByNetflix.csv',),
+                                 "mail"),
 }
+
+import csv
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, usergen, ipgen
+from scripts.lavafuncs import sanitize_sql_name
+
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+def _ts(value):
+    if value in (None, ''):
+        return ''
+    text = str(value).strip()
+    if text.isdigit():
+        return convert_unix_ts_to_utc(int(text))
+    try:
+        dt = datetime.fromisoformat(text.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+def _dynamic(context, basename, user_col=None, user_key=None):
+    headers, data_list, source_path = [], [], ''
+    user_list = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith(basename):
+            continue
+        source_path = file_found
+        file_headers = None
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if not item:
+                    continue
+                if file_headers is None:
+                    file_headers = _safe_headers(item)
+                    continue
+                if user_col is not None and len(item) > user_col and item[user_col]:
+                    user_list.append((item[user_col], 'Netflix', user_key, '', None))
+                row = list(item) + [''] * len(file_headers)
+                data_list.append(tuple(row[:len(file_headers)]))
+        if file_headers:
+            headers = file_headers
+    if user_list:
+        usergen(context.get_report_folder(), user_list)
+    return tuple(headers), data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def netflixProfiles(context):
+    data_list, user_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('Profiles.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)
+            for item in reader:
+                if len(item) < 3:
+                    continue
+                data_list.append((item[0], item[1], _ts(item[2])))
+                if item[1]:
+                    user_list.append((item[1], 'Netflix', 'netflixProfiles', '', None))
+    if user_list:
+        usergen(context.get_report_folder(), user_list)
+    data_headers = ('Profile_Name', 'Email_Address', ('Profile_Creation_Time', 'datetime'))
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def netflixIpLogin(context):
+    data_list, ip_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('IpAddressesLogin.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)
+            for item in reader:
+                if len(item) < 6:
+                    continue
+                data_list.append((_ts(item[5]), item[4], item[0], item[1], item[2], item[3]))
+                if item[4]:
+                    ip_list.append((item[4], 'Netflix', 'netflixIpLogin', '', None))
+    if ip_list:
+        ipgen(context.get_report_folder(), ip_list)
+    data_headers = (('Timestamp', 'datetime'), 'Ip Address', 'Esn', 'Country', 'Region code',
+                    'Device description')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def netflixIpStreaming(context):
+    data_list, ip_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('IpAddressesStreaming.csv'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            reader = csv.reader(f, delimiter=',')
+            next(reader, None)
+            for item in reader:
+                if len(item) < 7:
+                    continue
+                data_list.append((_ts(item[6]), item[4], item[3], item[2], item[5], item[0],
+                                  item[1]))
+                if item[4]:
+                    ip_list.append((item[4], 'Netflix', 'netflixIpStreaming', '', None))
+    if ip_list:
+        ipgen(context.get_report_folder(), ip_list)
+    data_headers = (('Timestamp', 'datetime'), 'Ip Address', 'Device Description',
+                    'Localized Device Description', 'Region Code Display Name', 'esn', 'Country')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def netflixBillingHistory(context):
+    return _dynamic(context, 'BillingHistory.csv')
+
+
+@artifact_processor
+def netflixDevices(context):
+    return _dynamic(context, 'Devices.csv')
+
+
+@artifact_processor
+def netflixViewingActivity(context):
+    return _dynamic(context, 'ViewingActivity.csv')
+
+
+@artifact_processor
+def netflixSearchHistory(context):
+    return _dynamic(context, 'SearchHistory.csv')
+
+
+@artifact_processor
+def netflixMessagesSent(context):
+    return _dynamic(context, 'MessagesSentByNetflix.csv')
+
+
+@artifact_processor
+def netflixAccountDetails(context):
+    return _dynamic(context, 'AccountDetails.csv', user_col=2, user_key='netflixAccountDetails')


### PR DESCRIPTION
Converts `netflixArchive` to the context-based `@artifact_processor` pipeline. The one legacy function emitted **nine** ArtifactHtmlReports, so it splits into nine artifacts, each scoped to its own CSV.

## Artifacts
`netflixProfiles`, `netflixBillingHistory`, `netflixIpLogin`, `netflixIpStreaming`, `netflixDevices`, `netflixViewingActivity`, `netflixSearchHistory`, `netflixAccountDetails`, `netflixMessagesSent` → **Netflix - Profiles / Billing History / IP Address Login / IP Address Streaming / Devices / Viewing Activity / Search History / Account Details / Messages Sent By Netflix**

## Two sub-patterns
- **Fixed schema** (Profiles, IP Login, IP Streaming): explicit columns; timestamps typed `('Timestamp'/'Profile_Creation_Time','datetime')` and parsed to aware UTC; IP/email correlation kept via `ipgen`/`usergen` using `context.get_report_folder()`.
- **Dynamic schema** (Billing History, Devices, Viewing Activity, Search History, Account Details, Messages): headers read from the file's first row and made LAVA-safe via `_safe_headers` (blanks/duplicates/SQL reserved words); rows aligned to header width. Account Details also feeds `usergen` from column 2.

## Changes
- `context.get_files_found()` / `context.get_relative_path()`.
- Each artifact narrowed to its own path (the legacy artifact matched all nine CSV names at once).

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- `PluginLoader` loads all nine (total **250**, net +8), no duplicate-name error.
- Synthetic round-trip: Profiles creation-time → UTC + email→usergen; IP Login/Streaming reorder + timestamp→UTC + ip→ipgen; Billing History dynamic header with reserved `To`→`To Value` (valid `CREATE TABLE`); Account Details dynamic + usergen.

Original attribution (Mark McKinnon, 2021-09-01) preserved.