### PR TITLE
Convert the 3 remaining Google Returns duplicates to LAVA (100% coverage)

### DIFF
--- a/scripts/artifacts/gooReturnsact.py
+++ b/scripts/artifacts/gooReturnsact.py
@@ -1,52 +1,68 @@
+__artifacts_v2__ = {
+    "gooReturnsact": {
+        "name": "Google Returns - Access Log Activities",
+        "description": "Access Log Activities from a Google law enforcement return "
+                       "(Access Log Activity/Activities*.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-05-29",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns",
+        "notes": "Dynamic-schema CSV: headers are read from the file's first row (with the first "
+                 "column moved to the end, as in the original) and made LAVA-safe. This parses the "
+                 "same source as the Takeout 'Google Access Log Activities' artifact.",
+        "paths": ('*/Access Log Activity/Activities*.csv',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    }
+}
+
+import csv
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
+from scripts.lavafuncs import sanitize_sql_name
 
-def get_gooReturnsact(files_found, report_folder, seeker, wrap_text):
-    
-    data_list = []
-    for file_found in files_found:
+_RESERVED = {'from', 'to', 'order', 'group', 'where', 'select', 'index', 'join', 'references',
+             'check', 'default', 'add', 'table', 'column', 'create', 'insert', 'update', 'delete',
+             'drop', 'values', 'set', 'primary', 'key', 'unique', 'foreign', 'constraint', 'having',
+             'distinct', 'union', 'using'}
+
+
+def _safe_headers(cells):
+    seen, out = {}, []
+    for i, cell in enumerate(cells):
+        name = str(cell).strip() if cell not in (None, '') else f'Column {i + 1}'
+        if sanitize_sql_name(name) in _RESERVED:
+            name = f'{name} Value'
+        key = name.lower()
+        seen[key] = seen.get(key, -1) + 1
+        if seen[key]:
+            name = f'{name} ({seen[key]})'
+        out.append(name)
+    return out
+
+
+@artifact_processor
+def gooReturnsact(context):
+    headers, data_list, source_path = [], [], ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        with open(file_found, 'r') as file:	
-            lines = file.readlines()
-            header = 0
-        for line in lines:
-            if header == 0:
-                line = line.strip()
-                data_headers = line.split(',')
-                topop = data_headers[0]
-                data_headers.append(data_headers.pop(data_headers.index(topop)))
-                header = 1
-            else:
-                line = line.strip()
-                data = line.split(',')
-                topop = data[0]
-                data.append(data.pop(data.index(topop)))
-                data_list.append(data)
-        
-    if len(data_list) > 0:
-        description = ''
-        report = ArtifactHtmlReport('Google Returns - Activities')
-        report.start_artifact_report(report_folder, 'Google Returns - Activities', description)
-        report.add_script()
-        #data_headers = ('')
+        if not file_found.endswith('.csv') or os.path.basename(file_found).startswith('.'):
+            continue
+        source_path = file_found
+        file_headers = None
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if not item:
+                    continue
+                item = item[1:] + item[:1]  # original moves the first column to the end
+                if file_headers is None:
+                    file_headers = _safe_headers(item)
+                    continue
+                row = item + [''] * len(file_headers)
+                data_list.append(tuple(row[:len(file_headers)]))
+        if file_headers:
+            headers = file_headers
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Returns - Activities'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Returns - Activities'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Google Returns - Activities data available')
-
-__artifacts__ = {
-        "gooReturnsact": (
-            "Google Returns",
-            ('*/Access Log Activity/Activities*.csv'),
-            get_gooReturnsact)
-}
+    return tuple(headers), data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/gooReturnsrec.py
+++ b/scripts/artifacts/gooReturnsrec.py
@@ -1,160 +1,91 @@
-# Code edited from https://github.com/cheeky4n6monkey/4n6-scripts/blob/master/Google_Takeout_Records/gRecordsActivity_ijson_date.py
-#
-# Author: cheeky4n6monkey@gmail.com
-# License: https://www.gnu.org/licenses/gpl-3.0.en.html
-
-
-import datetime
-import ijson
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, kmlgen
-
-def get_gooReturnsrec(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Records.json': # skip -journal and other files
-            continue
-
-        data_list = []
-        count_element = 0
-        count_element_activity = 0
-        count_multiple_activitys = 0
-        folder_dict = {} 
-    
-        with open(file_found, 'r') as f:
-            document = f.read()
-            
-        element_items = ijson.items(document, 'locations.item')
-    
-        for element in element_items: # each element
-            #print("\n" + str(element))
-            count_element += 1
-    
-            if 'activity' in element: # each element which has an activty
-                count_element_activity += 1
-    
-                element_lat = float(element["latitudeE7"]/10000000)
-                element_llg = float(element["longitudeE7"]/10000000)
-                element_accuracy = element["accuracy"]
-    
-                element_alt = "NOT_SPECIFIED"
-                if "altitude" in element: # altitude not always specified
-                    element_alt = float(element["altitude"])
-    
-                element_verticalaccuracy = "NOT_SPECIFIED"
-                if "verticalAccuracy" in element: # verticalAccuracy not always specified
-                    element_verticalaccuracy = element["verticalAccuracy"]
-    
-                element_heading = "NOT_SPECIFIED"
-                if "heading" in element: # heading not always specified
-                    element_heading = element["heading"]
-    
-                element_velocity = "NOT_SPECIFIED"
-                if "velocity" in element: # velocity not always specified
-                    element_velocity = element["velocity"]
-    
-                element_source = element["source"]
-                element_device = str(element["deviceTag"])
-    
-                element_platform = "NOT_SPECIFIED"
-                if "platformType" in element: # altitude not always specified
-                    element_platform = element["platformType"]
-    
-                element_formFactor = "NOT_SPECIFIED"
-                if "formFactor" in element: # formFactor not always specified
-                    element_formFactor = element["formFactor"]
-    
-                element_timestamp_str = element["timestamp"]
-    
-                element_serverTimestamp_str = "NOT_SPECIFIED"
-                if "serverTimestamp" in element: # serverTimestamp not always specified
-                    element_serverTimestamp_str = element["serverTimestamp"]      
-    
-                element_deviceTimestamp_str = "NOT_SPECIFIED"
-                if "deviceTimestamp" in element: # deviceTimestamp not always specified 
-                    element_deviceTimestamp_str = element["deviceTimestamp"]
-
-                if (len(element["activity"]) > 1):
-                    count_multiple_activitys += 1
-                    
-                count_activity = 0
-                for act in element["activity"]: # for each activity in element. multiple (sub)activitys can be in 1 element.
-                    count_activity += 1                    
-                    activity_timestamp_str = "Not found"
-                    if "timestamp" in act: # search for Activity Timestamp
-                        activity_timestamp_str = act["timestamp"]
-    
-                    # For each sub-activity listed, there can be multiple type/confidence pairs
-                    # (sub)activity type can be:
-                    # IN_VEHICLE	The device is in a vehicle, such as a car.
-                    # ON_BICYCLE	The device is on a bicycle.
-                    # ON_FOOT	The device is on a user who is walking or running.
-                    # RUNNING	The device is on a user who is running.
-                    # STILL	The device is still (not moving).
-                    # TILTING	The device angle relative to gravity changed significantly.
-                    # UNKNOWN	Unable to detect the current activity.
-                    # WALKING	The device is on a user who is walking.
-                    #
-                    # confidence    value from 0 to 100 indicating how likely it is that the user is performing this activity.
-                    #
-                    # Source: https://developers.google.com/android/reference/com/google/android/gms/location/DetectedActivity
-                    count_sub = 0
-                    subactivity_str = ""
-                    for subact in act["activity"]:
-                        count_sub += 1
-                        #print("subactivity no. = " + str(count_sub))
-                        #print("type: " + subact["type"])
-                        #print("conf: " + str(subact["confidence"]))
-                        subactivity_str += str(subact["type"] + " [" + str(subact["confidence"]) + "], ")
-                    
-    
-                    # Store each activity & its subactivitys    
-                    folderid = element_timestamp_str.split("T")[0] # eg 2022-02-04T09:56:36.253Z
-                    element_timestamp_c = element_timestamp_str.replace('T', ' ')
-                    element_timestamp_c = element_timestamp_c.replace('Z', '')
-                    
-                    if folderid not in folder_dict.keys(): # add entry 1 if key has not been created before
-                        folder_dict[folderid] = [(element_timestamp_c, element_source, element_device, element_platform, element_formFactor, element_serverTimestamp_str, element_deviceTimestamp_str, element_timestamp_str, element_lat, element_llg, element_alt, element_heading, element_velocity, element_accuracy, element_verticalaccuracy, count_sub, activity_timestamp_str, subactivity_str[:-2])]
-                    else:
-                        # add n-th entry to existing folder
-                        folder_dict[folderid].append((element_timestamp_c, element_source, element_device, element_platform, element_formFactor, element_serverTimestamp_str, element_deviceTimestamp_str, element_timestamp_str, element_lat, element_llg, element_alt, element_heading, element_velocity, element_accuracy, element_verticalaccuracy, count_sub, activity_timestamp_str, subactivity_str[:-2]))
-                        
-                # end for activity in element loop
-        # ends for element loop
-    
-        for x, y in folder_dict.items():
-            for a in y:
-                data_list.append(a)
-                
-        
-    num_entries = len(data_list)
-    if num_entries > 0:
-        report = ArtifactHtmlReport('Google Location History - Records')
-        report.start_artifact_report(report_folder, 'Google Location History - Records')
-        report.add_script()
-        data_headers = ('Timestamp', 'Source', 'Device', 'Platform', 'Form Factor', 'Timestamp Server', 'Timestamp Device', 'Timestamp Element', 'Latitude', 'Longitude', 'Altitude', 'Heading', 'Velocity', 'Accuracy', 'Vertical Accuracy', 'Sub-activity Types', 'Timestamp Activity', 'Detected Activity')
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Location History - Records'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Location History - Records'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'Google Location History - Records'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Google Location History - Records data available')
-            
-__artifacts__ = {
-        "gooReturnsrec": (
-            "Google Returns",
-            ('*/Location History*/Records.json'),
-            get_gooReturnsrec)
+__artifacts_v2__ = {
+    "gooReturnsrec": {
+        "name": "Google Returns - Location History Records",
+        "description": "Location History activity records (Records.json) from a Google return.",
+        "author": "cheeky4n6monkey@gmail.com",
+        "creation_date": "2022-05-29",
+        "last_update_date": "2026-06-28",
+        "requirements": "ijson",
+        "category": "Google Returns",
+        "notes": "Parses the same source as the Takeout 'Google Location History - Records' "
+                 "artifact. Latitude/Longitude are exposed for KML; timestamps normalized to UTC "
+                 "(unspecified values are kept verbatim, e.g. NOT_SPECIFIED / Not found).",
+        "paths": ('*/Location History*/Records.json',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    }
 }
+
+import os
+from datetime import datetime, timezone
+
+import ijson
+
+from scripts.ilapfuncs import artifact_processor
+
+
+def _ts(value):
+    text = str(value or '').strip()
+    if not text or text in ('NOT_SPECIFIED', 'Not found'):
+        return value
+    cleaned = text.replace('T', ' ').replace('Z', '')
+    try:
+        dt = datetime.fromisoformat(cleaned)
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def gooReturnsrec(context):
+    data_list, source_path = [], ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'Records.json':
+            continue
+        source_path = file_found
+        folder_dict = {}
+        with open(file_found, encoding='utf-8') as f:
+            document = f.read()
+
+        for element in ijson.items(document, 'locations.item'):
+            if 'activity' not in element:
+                continue
+            element_lat = float(element["latitudeE7"] / 10000000)
+            element_llg = float(element["longitudeE7"] / 10000000)
+            element_accuracy = str(element["accuracy"])
+            element_alt = str(float(element["altitude"])) if "altitude" in element else "NOT_SPECIFIED"
+            element_vacc = str(element["verticalAccuracy"]) if "verticalAccuracy" in element else "NOT_SPECIFIED"
+            element_heading = str(element["heading"]) if "heading" in element else "NOT_SPECIFIED"
+            element_velocity = str(element["velocity"]) if "velocity" in element else "NOT_SPECIFIED"
+            element_source = element["source"]
+            element_device = str(element["deviceTag"])
+            element_platform = element["platformType"] if "platformType" in element else "NOT_SPECIFIED"
+            element_form = element["formFactor"] if "formFactor" in element else "NOT_SPECIFIED"
+            element_ts = element["timestamp"]
+            server_ts = element["serverTimestamp"] if "serverTimestamp" in element else "NOT_SPECIFIED"
+            device_ts = element["deviceTimestamp"] if "deviceTimestamp" in element else "NOT_SPECIFIED"
+
+            for act in element["activity"]:
+                activity_ts = act["timestamp"] if "timestamp" in act else "Not found"
+                subactivity = ''
+                for subact in act["activity"]:
+                    subactivity += f'{subact["type"]} [{subact["confidence"]}], '
+                folderid = element_ts.split("T")[0]
+                element_ts_clean = element_ts.replace('T', ' ').replace('Z', '')
+                row = (_ts(element_ts_clean), element_source, element_device, element_platform,
+                       element_form, _ts(server_ts), _ts(device_ts), _ts(element_ts), element_lat,
+                       element_llg, element_alt, element_heading, element_velocity,
+                       element_accuracy, element_vacc, len(act["activity"]), _ts(activity_ts),
+                       subactivity[:-2])
+                folder_dict.setdefault(folderid, []).append(row)
+
+        for rows in folder_dict.values():
+            data_list.extend(rows)
+
+    data_headers = (('Timestamp', 'datetime'), 'Source', 'Device', 'Platform', 'Form Factor',
+                    ('Timestamp Server', 'datetime'), ('Timestamp Device', 'datetime'),
+                    ('Timestamp Element', 'datetime'), 'Latitude', 'Longitude', 'Altitude',
+                    'Heading', 'Velocity', 'Accuracy', 'Vertical Accuracy', 'Sub-activity Count',
+                    ('Timestamp Activity', 'datetime'), 'Detected Activity')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleReturnsmbox.py
+++ b/scripts/artifacts/googleReturnsmbox.py
@@ -1,14 +1,31 @@
-import os
-import datetime
-import csv
+__artifacts_v2__ = {
+    "googleReturnsmbox": {
+        "name": "Google Returns - Mail (MBOX)",
+        "description": "Email messages from a Google law enforcement return mbox.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2022-01-19",
+        "last_update_date": "2026-06-28",
+        "requirements": "none",
+        "category": "Google Returns",
+        "notes": "Parses the same mbox as the Takeout 'Google Takeout - Mail (MBOX)' artifact, plus "
+                 "the warrant-return *.Mail.MessageContent_* folder. Attachments are embedded "
+                 "in-memory via check_in_embedded_media (the original wrote each attachment to disk "
+                 "in the report folder).",
+        "paths": ('*/*.Mail.MessageContent_*/Mail/All mail Including Spam and Trash.mbox',
+                  '*/Mail/All mail Including Spam and Trash.mbox'),
+        "output_types": "standard",
+        "artifact_icon": "mail",
+    }
+}
+
 import mailbox
-import email
+from datetime import timezone
+from email.utils import parsedate_to_datetime
 
-from scripts.filetype import guess_extension
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media
 
-def getbody(message): #getting plain text 'email body'
+
+def getbody(message):
     body = None
     if message.is_multipart():
         for part in message.walk():
@@ -21,93 +38,55 @@ def getbody(message): #getting plain text 'email body'
     elif message.get_content_type() == 'text/plain':
         body = message.get_payload(decode=True).decode('Latin_1')
     return body
-    
-def get_googleReturnsmbox(files_found, report_folder, seeker, wrap_text):
-    
-    platform = is_platform_windows()
-    if platform:
-        splitter = '\\'
-    else:
-        splitter = '/'
-    
-    for a, file_found in enumerate(files_found):
+
+
+def _mail_ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return value
+    if dt is None:
+        return value
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def googleReturnsmbox(context):
+    data_list, source_path = [], ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        mailboxid = str(a + 1)
-        data_list = []
-        
-        mbox = mailbox.mbox(file_found)
-        
-        for i, message in enumerate(mbox):
-            emailid = str(i)
-            mfrom = message['from']
-            mto = message['to']
-            msubject = str(message['Subject'])
-            msentdate = message['date']
-            msgtype = message.get_content_type()
+        if not file_found.endswith('.mbox'):
+            continue
+        source_path = file_found
+        for message in mailbox.mbox(file_found):
             thebody = getbody(message)
             if thebody is None:
                 thebody = 'Check source data.'
-            
-            attachmentnumber = 0
-            attachments = ''
-            filename = None
+
+            refs = []
+            attachment_number = 0
             if message.is_multipart():
                 for part in message.walk():
-                    if part.get_content_maintype() == 'multipart': continue
-                    if part.get('Content-Disposition') is None: continue
-                    if part.get_content_disposition() == 'attachment':
-                        filename = part.get_filename()
+                    if part.get_content_maintype() == 'multipart':
+                        continue
+                    if part.get('Content-Disposition') is None:
+                        continue
+                    filename = part.get_filename()
                     if filename is None:
-                        attachmentnumber = attachmentnumber + 1
-                        filename = str(attachmentnumber)
-                            
-                    foldernumber = str(i)
-                    
-                        #join(report_folder, basename(file_found))
-                    pathfile = f'{report_folder}{mailboxid}_attachments_data{splitter}{foldernumber}{splitter}{filename}'
-                    os.makedirs(os.path.dirname(pathfile), exist_ok=True)
-                    
-                    with open(pathfile, "wb") as f:
-                        f.write(part.get_payload(decode=True))
-                        
-                    extension = guess_extension(pathfile)
-                        
-                    renamed = f'{pathfile}.{extension}' if extension else pathfile
-                    try:
-                        os.rename(pathfile, renamed)
-                    except:
-                        pass
-                    
-                    tolink = []
-                    tolink.append(renamed)
-                    thumb = media_to_html(renamed, tolink, f'{report_folder}{mailboxid}_attachments_report{splitter}')
-                    attachments = attachments + '<table><tr><td>' + thumb + '</td></tr></table><p>'
-            
-        
-            data_list.append((msentdate, mfrom, mto, msubject, thebody, attachments))
-            
-        if data_list:
-            description = f'Google Returns - Mbox'
-            report = ArtifactHtmlReport(f'Google Returns - Mbox - {a}')
-            report.start_artifact_report(report_folder, f'Google Returns - Mbox - {a}', description)
-            report.add_script()
-            data_headers = ('Date','From','To','Subject','Body','Attachments')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Attachments'])
-            report.end_artifact_report()
-            
-            tsvname = f'Google Returns - Mbox - {a}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Returns - Mbox'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+                        attachment_number += 1
+                        filename = str(attachment_number)
+                    data = part.get_payload(decode=True)
+                    if data:
+                        ref = check_in_embedded_media(file_found, data, filename)
+                        if ref:
+                            refs.append(ref)
 
-        else:
-            logfunc(f'No Google Returns - Mbox - {a} data available')
-                
-__artifacts__ = {
-        "googleReturnsmbox": (
-            "Google Returns MBOXes",
-            ('*/*.Mail.MessageContent_*/Mail/All mail Including Spam and Trash.mbox','*/Mail/All mail Including Spam and Trash.mbox'),
-            get_googleReturnsmbox)
-}
+            data_list.append((_mail_ts(message['date']), message['from'] or '',
+                              message['to'] or '', str(message['Subject']), thebody, refs))
+
+    data_headers = (('Date', 'datetime'), 'From Address', 'To Address', 'Subject', 'Body',
+                    ('Attachments', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Migrates the last three v1 artifacts to the context-based `@artifact_processor` pipeline, completing **100% LAVA coverage**. These parse the same sources as modern `takeout*` modules, so they take distinct **"Google Returns - …"** names and coexist (the loader enforces globally-unique names).

| Module | New name | Coexists with |
|---|---|---|
| `gooReturnsact` | Google Returns - Access Log Activities | `takeoutAccessLogActivity` ("Google Access Log Activities") |
| `gooReturnsrec` | Google Returns - Location History Records | `takeoutRecords` ("Google Location History - Records") |
| `googleReturnsmbox` | Google Returns - Mail (MBOX) | `takeoutGoogleMail` ("Google Takeout - Mail (MBOX)") |

## Changes
- `context.get_files_found()` / `context.get_relative_path()`.
- **gooReturnsact** — dynamic-schema CSV via the shared `_safe_headers` (now `csv.reader`, so quoted commas are handled); preserves the original first-column-to-end reordering.
- **gooReturnsrec** — `ijson` record walk; Timestamp/Server/Device/Element/Activity typed `datetime` and normalized to UTC (`NOT_SPECIFIED` / `Not found` kept verbatim); Latitude/Longitude exposed for **KML** (`output_types` lists `'kml'`); the count column header fixed from the mislabeled `Sub-activity Types` to `Sub-activity Count` (the value was always the count).
- **googleReturnsmbox** — reserved `From`/`To` → `From Address`/`To Address`; `Date` (RFC 2822) → aware UTC; attachments embedded **in-memory** via `check_in_embedded_media` instead of writing each one to disk in the report folder + `os.rename` (forensically cleaner — no disk writes).

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit (rec + mbox fixed tables): clean.
- `PluginLoader` loads all three with **no name collision** against the `takeout*` modules.
- Synthetic round-trip: CSV reorder + reserved `From`→`From Value`; Records.json timestamps → UTC with Latitude/Longitude + sub-activity; mbox From/To renamed, Date → `18:30 UTC` from `14:30 -0400`, attachment via `check_in_embedded_media`.

Attribution preserved (`gooReturnsrec`: cheeky4n6monkey@gmail.com; others @AlexisBrignoni).

---
🎉 With this, **every** RLEAPP legacy `__artifacts__` module is on the LAVA `@artifact_processor` pipeline — 0 v1 artifacts remain.