### PR TITLE
sysShutdown: shorten per-row Source File paths (follow-up to #345)

### DIFF
--- a/scripts/artifacts/sysShutdown.py
+++ b/scripts/artifacts/sysShutdown.py
@@ -13,18 +13,17 @@ __artifacts_v2__ = {
     }
 }
 
-from datetime import datetime
-import os
 import re
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, convert_ts_int_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import logfunc, tsv, timeline, convert_ts_int_to_utc, convert_utc_human_to_timezone
 from scripts.context import Context
 
-def get_sysShutdown(files_found, report_folder, seeker, wrap_text):
+def get_sysShutdown(files_found, report_folder, seeker, wrap_text):  # pylint: disable=unused-argument
     
     data_list_shutdown_log = []
     data_list_shutdown_reboot = []
+    file_found = ''
     
     for file_found in files_found:
         file_found = str(file_found)
@@ -66,10 +65,10 @@ def get_sysShutdown(files_found, report_folder, seeker, wrap_text):
         report.write_artifact_data_table(data_headers, data_list_shutdown_log, file_found)
         report.end_artifact_report()
         
-        tsvname = f'Sysdiagnose - Shutdown Log Processes'
+        tsvname = 'Sysdiagnose - Shutdown Log Processes'
         tsv(report_folder, data_headers, data_list_shutdown_log, tsvname)
         
-        tlactivity = f'Sysdiagnose - Shutdown Log Processes'
+        tlactivity = 'Sysdiagnose - Shutdown Log Processes'
         timeline(report_folder, tlactivity, data_list_shutdown_log, data_headers)
     else:
         logfunc('No Sysdiagnose - Shutdown Log Processes data available')
@@ -84,10 +83,10 @@ def get_sysShutdown(files_found, report_folder, seeker, wrap_text):
         report.write_artifact_data_table(data_headers, data_list_shutdown_reboot, file_found)
         report.end_artifact_report()
         
-        tsvname = f'Sysdiagnose - Shutdown Log Reboots'
+        tsvname = 'Sysdiagnose - Shutdown Log Reboots'
         tsv(report_folder, data_headers, data_list_shutdown_reboot, tsvname)
         
-        tlactivity = f'Sysdiagnose - Shutdown Log Reboots'
+        tlactivity = 'Sysdiagnose - Shutdown Log Reboots'
         timeline(report_folder, tlactivity, data_list_shutdown_reboot, data_headers)
     else:
         logfunc('No Sysdiagnose - Shutdown Log Reboots data available')

--- a/scripts/artifacts/sysShutdown.py
+++ b/scripts/artifacts/sysShutdown.py
@@ -19,6 +19,7 @@ import re
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, convert_ts_int_to_utc, convert_utc_human_to_timezone
+from scripts.context import Context
 
 def get_sysShutdown(files_found, report_folder, seeker, wrap_text):
     
@@ -46,11 +47,11 @@ def get_sysShutdown(files_found, report_folder, seeker, wrap_text):
                     timestamp = int(sigterm_match.group(1))
                     #reboot_time = datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
                     reboot_time = convert_utc_human_to_timezone(convert_ts_int_to_utc(timestamp),'UTC')
-                    data_list_shutdown_reboot.append((reboot_time,reboots,file_found))
+                    data_list_shutdown_reboot.append((reboot_time,reboots,Context.get_relative_path(file_found)))
                     reboots += 1
                     
                     for pid, path in entries:
-                        data_list_shutdown_log.append((reboot_time,entry_num,pid,path,file_found))
+                        data_list_shutdown_log.append((reboot_time,entry_num,pid,path,Context.get_relative_path(file_found)))
                         
                         entry_num += 1
                     entries = []


### PR DESCRIPTION
Counterpart of ALEAPP #932 / iLEAPP row-level fix: wraps the `file_found` copies placed in per-record Source File columns with `Context.get_relative_path`. Full RLEAPP audit found only this file as a true positive — google_health already emits basenames, and **kik.py is deliberately deferred** to avoid conflicting with the open migration PR #287 (it should adopt relative paths as part of that rework).

pylint 10.00/10; byte-compile clean.