### PR TITLE
get_relative_path: shorten data_folder everywhere it appears

### DIFF
--- a/scripts/context.py
+++ b/scripts/context.py
@@ -361,9 +361,14 @@ class Context:
         if not full_path or not Context._data_folder:
             return full_path
 
-        if full_path.startswith(Context._data_folder):
-            # Strip the base path and any leading separators
-            return full_path[len(Context._data_folder):].lstrip('/\\')
+        if Context._data_folder in full_path:
+            # Strip the base path everywhere it appears, including inside path
+            # strings concatenated with arbitrary separators (', ', '; ', ...)
+            base = Context._data_folder
+            return (full_path.replace(base + '/', '')
+                             .replace(base + '\\', '')
+                             .replace(base, '')
+                             .lstrip('/\\'))
 
         return full_path
 


### PR DESCRIPTION
Follow-up to the relative-source-paths fix, prompted by @JamesHabben's question about concatenated source paths.

**The gap:** the decorator shortens `source_path` per **newline** segment. Artifacts that join multiple **absolute** paths with other separators (`', '`, `'; '`, `' '`) only had the *first* path shortened — `startswith` matches the head of the concatenated string, strips one prefix, and the rest stayed absolute:

```
in : <data>/a.db, <data>/b.db
out: a.db, /Users/examiner/.../b.db   <- second path leaked
```

**The fix:** `Context.get_relative_path` now globally replaces the data_folder prefix wherever it appears, separator-agnostic — same spirit as the old `file_found.replace(seeker.data_folder, '')` idiom. Artifacts that already relativize before joining (Oops-style, ~24 in iLEAPP) are unaffected: relative segments pass through untouched.

**Verified:** unit tests cover exact path, path == data_folder, literals, already-relative, None, comma/semicolon/space-joined absolute paths, newline decorator path, and no-data_folder passthrough. pylint 10.00/10, byte-compile, PluginLoader smoke test all pass.

Affected artifacts that this transparently fixes: iLEAPP box/home_depot/idstatuscache/sysdiagnose (+skg_archive if its parts are paths), ALEAPP FCM family/siminfo/wifiConfigstore2/wifiProfiles. RLEAPP/VLEAPP have no current emitters — this keeps the four frameworks identical and future-proof.