### PR TITLE
Fix datetime.UTC import breaking Python 3.10

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -11,7 +11,7 @@ import shutil
 import sqlite3
 import sys
 
-from datetime import datetime, timezone, timedelta, UTC
+from datetime import datetime, timezone, timedelta
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import quote
@@ -1049,7 +1049,7 @@ def convert_unix_ts_to_utc(ts):
 def convert_unix_ts_to_str(ts):
     if ts:
         ts = convert_unix_ts_in_seconds(ts)
-        return datetime.fromtimestamp(ts, UTC).strftime('%Y-%m-%d %H:%M:%S')
+        return datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
     else:
         return ts
 


### PR DESCRIPTION
`datetime.UTC` is 3.11+, so the explicit import in `ilapfuncs.py` crashed 3.10 at startup. Switched the one use to `timezone.utc` — same value, already used elsewhere in the file. Same fix as iLEAPP #1677, verified on 3.10.