### PR TITLE
Snapchat returns: map all CSV artifacts by header name, not position

### DIFF
--- a/scripts/artifacts/snapGeo.py
+++ b/scripts/artifacts/snapGeo.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Geolocation (latitude,longitude,timestamp format) from a Snapchat law enforcement return (geo_locations.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "Update by Shawn Ramsey 2024-08-05.",
@@ -17,16 +17,30 @@ __artifacts_v2__ = {
         "description": "Geolocation (latitude,longitude,accuracy,timestamp,is_live_location format) from a Snapchat law enforcement return (geo_locations.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "Update by Shawn Ramsey 2024-08-05.",
         "paths": ('*/geo_locations.csv',),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
         "artifact_icon": "map-pin",
+    },
+    "snapGeoCity": {
+        "name": "Snapchat - Geolocation City",
+        "description": "Country, region, and city derived from device GPS (country,region,city,timestamp format) from a Snapchat law enforcement return (geo_locations.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-09",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/geo_locations.csv',),
+        "output_types": "standard",
+        "artifact_icon": "map",
     }
 }
 
+import csv
 import os
 from datetime import datetime, timezone
 
@@ -37,7 +51,14 @@ _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -45,44 +66,67 @@ def _snap_ts(value):
         return value
 
 
-def _clean_and_group(input_data):
-    sections, current, exclude = [], [], False
-    for line in input_data.split('\n'):
-        if line.startswith('---') or line.startswith('==='):
-            exclude = not exclude
-            if not exclude and current:
-                sections.append(current)
-                current = []
-            continue
-        if not exclude and line.strip():
-            current.append(line.strip())
-    if current:
-        sections.append(current)
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
+                rows.append(row)
     return sections
 
 
-@artifact_processor
-def snapGeolocation(context):
-    data_list = []
+def _matching_sections(context, required_fields, excluded_fields=()):
+    # Sections are identified by the column names in their header, never by position
+    # or by order in the file (the layout changes across return versions).
     source_path = ''
+    matches = []
+    parsed = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not os.path.basename(file_found).startswith('geo_locations.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        with open(file_found, encoding='utf-8') as f:
-            for section in _clean_and_group(f.read()):
-                if not section[0].startswith('latitude,longitude,timestamp'):
-                    continue
-                for line in section[1:]:
-                    item = line.strip().split(',')
-                    if len(item) < 3:
-                        continue
-                    lat_parts = item[0].split(' ')
-                    lat = lat_parts[0]
-                    accuracy = lat_parts[2] + ' meters' if len(lat_parts) > 2 else ''
-                    lon = item[1].split(' ')[0]
-                    data_list.append((_snap_ts(item[2]), lat, lon, accuracy))
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            if not set(required_fields).issubset(header):
+                continue
+            if any(name in header for name in excluded_fields):
+                continue
+            for raw in rows:
+                if any(cell.strip() for cell in raw):
+                    matches.append(dict(zip(header, raw)))
+    return source_path, matches
+
+
+@artifact_processor
+def snapGeolocation(context):
+    source_path, rows = _matching_sections(context, ('latitude', 'longitude', 'timestamp'),
+                                           excluded_fields=('accuracy', 'is_live_location',
+                                                            'country', 'city'))
+    data_list = []
+    for values in rows:
+        # Coordinates come as "34.47359 ± 39.66 meters"; the accuracy is embedded.
+        lat_parts = values.get('latitude', '').split(' ')
+        lat = lat_parts[0]
+        accuracy = lat_parts[2] + ' meters' if len(lat_parts) > 2 else ''
+        lon = values.get('longitude', '').split(' ')[0]
+        data_list.append((_snap_ts(values.get('timestamp', '')), lat, lon, accuracy))
 
     data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Accuracy')
     return data_headers, data_list, context.get_relative_path(source_path)
@@ -90,23 +134,24 @@ def snapGeolocation(context):
 
 @artifact_processor
 def snapGeoAdditional(context):
-    data_list = []
-    source_path = ''
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
-        if not os.path.basename(file_found).startswith('geo_locations.csv'):
-            continue
-        source_path = file_found
-        with open(file_found, encoding='utf-8') as f:
-            for section in _clean_and_group(f.read()):
-                if not section[0].startswith('latitude,longitude,accuracy,timestamp,is_live_location'):
-                    continue
-                for line in section[1:]:
-                    item = line.strip().split(',')
-                    if len(item) < 5:
-                        continue
-                    data_list.append((_snap_ts(item[3]), item[0], item[1], item[2], item[4]))
+    source_path, rows = _matching_sections(
+        context, ('latitude', 'longitude', 'accuracy', 'timestamp', 'is_live_location'))
+    data_list = [(_snap_ts(values.get('timestamp', '')), values.get('latitude', ''),
+                  values.get('longitude', ''), values.get('accuracy', ''),
+                  values.get('is_live_location', ''))
+                 for values in rows]
 
     data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Accuracy',
                     'Is Live Location')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def snapGeoCity(context):
+    source_path, rows = _matching_sections(context, ('country', 'region', 'city', 'timestamp'))
+    data_list = [(_snap_ts(values.get('timestamp', '')), values.get('country', ''),
+                  values.get('region', ''), values.get('city', ''))
+                 for values in rows]
+
+    data_headers = (('Timestamp', 'datetime'), 'Country', 'Region', 'City')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapIPd.py
+++ b/scripts/artifacts/snapIPd.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "IP data parsed from a Snapchat law enforcement return (ip_data.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
@@ -14,6 +14,7 @@ __artifacts_v2__ = {
     }
 }
 
+import csv
 import os
 from datetime import datetime, timezone
 
@@ -22,9 +23,21 @@ from scripts.ilapfuncs import artifact_processor
 _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
            'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
+# Older returns use headers like "first seen time"; newer ones "first_seen_time".
+_DISPLAY = {'ip': 'IP', 'asn': 'ASN', 'url': 'URL',
+            'first seen time': 'First Seen Time', 'last seen time': 'Last Seen Time',
+            'first_seen_time': 'First Seen Time', 'last_seen_time': 'Last Seen Time'}
+
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -32,42 +45,70 @@ def _snap_ts(value):
         return value
 
 
-def _clean_and_group(input_data):
-    sections, current, exclude = [], [], False
-    for line in input_data.split('\n'):
-        if line.startswith('---') or line.startswith('==='):
-            exclude = not exclude
-            if not exclude and current:
-                sections.append(current)
-                current = []
-            continue
-        if not exclude and line.strip():
-            current.append(line.strip())
-    if current:
-        sections.append(current)
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
+                rows.append(row)
     return sections
+
+
+def _is_time_field(name):
+    return name.endswith('time') or name.endswith('timestamp')
+
+
+def _column(name):
+    display = _DISPLAY.get(name, name.capitalize())
+    return (display, 'datetime') if _is_time_field(name) else display
 
 
 @artifact_processor
 def snapIPd(context):
-    data_list = []
+    # Columns are mapped by header name, never by position: newer returns replaced the
+    # separate per-source sections with one consolidated table of 20+ columns, and the
+    # layout keeps changing. Every section in the file is parsed into the union of the
+    # columns seen; fields Snapchat adds later are appended as they appear.
+    field_names = ['ip', 'timestamp', 'first_seen_time', 'last_seen_time']
+    records = []
     source_path = ''
+    parsed = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not os.path.basename(file_found).startswith('ip_data.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        with open(file_found, encoding='utf-8') as f:
-            for section in _clean_and_group(f.read()):
-                if not section[0].startswith('ip,first seen time,last seen time'):
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            for name in header:
+                if name not in field_names:
+                    field_names.append(name)
+            for raw in rows:
+                if not any(cell.strip() for cell in raw):
                     continue
-                for line in section[1:]:
-                    item = line.strip().split(',')
-                    if len(item) < 3:
-                        continue
-                    first_seen = _snap_ts(item[1]) if item[1] else ''
-                    last_seen = _snap_ts(item[2]) if item[2] else ''
-                    data_list.append((item[0], first_seen, last_seen))
+                values = dict(zip(header, raw))
+                for name in header:
+                    if _is_time_field(name) and values.get(name):
+                        values[name] = _snap_ts(values[name])
+                records.append(values)
 
-    data_headers = ('IP', ('First Seen Time', 'datetime'), ('Last Seen Time', 'datetime'))
+    data_headers = tuple(_column(name) for name in field_names)
+    data_list = [[values.get(name, '') for name in field_names] for values in records]
+
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapIncCom.py
+++ b/scripts/artifacts/snapIncCom.py
@@ -1,16 +1,42 @@
 __artifacts_v2__ = {
     "snapIncCom": {
         "name": "Snapchat - Inc Comms",
-        "description": "Incoming communications parsed from a Snapchat law enforcement return (snap_inc_communications.csv).",
+        "description": "Incoming email communications parsed from a Snapchat law enforcement return (snap_inc_communications.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
         "paths": ('*/snap_inc_communications.csv',),
         "output_types": "standard",
         "artifact_icon": "mail",
+    },
+    "snapIncComSms": {
+        "name": "Snapchat - Inc Comms SMS",
+        "description": "SMS events parsed from a Snapchat law enforcement return (snap_inc_communications.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-09",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/snap_inc_communications.csv',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    },
+    "snapIncComAppeals": {
+        "name": "Snapchat - In App Appeals",
+        "description": "In-app account appeals parsed from a Snapchat law enforcement return (snap_inc_communications.csv).",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-09",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Snapchat Returns",
+        "notes": "",
+        "paths": ('*/snap_inc_communications.csv',),
+        "output_types": "standard",
+        "artifact_icon": "help-circle",
     }
 }
 
@@ -25,7 +51,14 @@ _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -33,43 +66,107 @@ def _snap_ts(value):
         return value
 
 
-def _clean_and_group(input_data):
-    sections, current, exclude = [], [], False
-    for line in input_data.split('\n'):
-        if line.startswith('---') or line.startswith('==='):
-            exclude = not exclude
-            if not exclude and current:
-                sections.append(current)
-                current = []
-            continue
-        if not exclude and line.strip():
-            current.append(line.strip())
-    if current:
-        sections.append(current)
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
+                rows.append(row)
     return sections
 
 
-@artifact_processor
-def snapIncCom(context):
-    data_list = []
+def _section_data(context, required_fields, ordered):
+    """Build (data_headers, data_list, source_path) from every section whose header
+    holds required_fields (the file carries Email Events, SMS Events, and In App
+    Appeals sections). Columns are mapped by header name, never by position; a
+    header tuple typed 'datetime' also converts the value with _snap_ts. Fields
+    Snapchat adds later are appended as they appear."""
+    known = [field for field, _ in ordered]
+    extras = []
+    records = []
     source_path = ''
+    parsed = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not os.path.basename(file_found).startswith('snap_inc_communications.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        with open(file_found, encoding='utf-8') as f:
-            for section in _clean_and_group(f.read()):
-                if not section[0].startswith('user_id,email_address,user_agent,campaign_name,type,event_timestamp'):
-                    continue
-                for line in section[1:]:
-                    rows = list(csv.reader([line], skipinitialspace=True))
-                    if not rows or len(rows[0]) < 6:
-                        continue
-                    x = rows[0]
-                    # source order: user_id, email, user_agent, campaign, type, event_timestamp
-                    data_list.append((_snap_ts(x[5]), x[0], x[1], x[2], x[3], x[4]))
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            if not set(required_fields).issubset(header):
+                continue
+            for name in header:
+                if name not in known and name not in extras:
+                    extras.append(name)
+            for raw in rows:
+                if any(cell.strip() for cell in raw):
+                    records.append(dict(zip(header, raw)))
 
-    data_headers = (('Timestamp', 'datetime'), 'User ID', 'Email Address', 'User Agent',
-                    'Campaign Name', 'Type')
+    data_headers = tuple(h for _, h in ordered) + tuple(n.capitalize() for n in extras)
+    data_list = []
+    for values in records:
+        entry = []
+        for field, spec in ordered:
+            value = values.get(field, '')
+            if isinstance(spec, tuple) and spec[1] == 'datetime' and value:
+                value = _snap_ts(value)
+            entry.append(value)
+        entry.extend(values.get(name, '') for name in extras)
+        data_list.append(entry)
     return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def snapIncCom(context):
+    return _section_data(
+        context, ('email_address', 'campaign_name', 'event_timestamp'),
+        [('event_timestamp', ('Timestamp', 'datetime')),
+         ('user_id', 'User ID'),
+         ('email_address', 'Email Address'),
+         ('user_agent', 'User Agent'),
+         ('campaign_name', 'Campaign Name'),
+         ('type', 'Type')])
+
+
+@artifact_processor
+def snapIncComSms(context):
+    return _section_data(
+        context, ('phone_number', 'feature', 'vendor'),
+        [('message_timestamp', ('Timestamp', 'datetime')),
+         ('user_id', 'User ID'),
+         ('phone_number', ('Phone Number', 'phonenumber')),
+         ('strategy', 'Strategy'),
+         ('feature', 'Feature'),
+         ('vendor', 'Vendor'),
+         ('vendor_status', 'Vendor Status'),
+         ('message_id', 'Message ID'),
+         ('message_tracker_id', 'Message Tracker ID')])
+
+
+@artifact_processor
+def snapIncComAppeals(context):
+    return _section_data(
+        context, ('appeal_id', 'appeal_justification'),
+        [('created_timestamp', ('Timestamp', 'datetime')),
+         ('requester_user_id', 'Requester User ID'),
+         ('requester_username', 'Requester Username'),
+         ('requester_mutable_username', 'Requester Mutable Username'),
+         ('requester_email', 'Requester Email'),
+         ('appeal_id', 'Appeal ID'),
+         ('appeal_justification', 'Appeal Justification')])

--- a/scripts/artifacts/snapLocprivsets.py
+++ b/scripts/artifacts/snapLocprivsets.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Location privacy settings parsed from a Snapchat law enforcement return (loc_priv_sets.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
@@ -14,6 +14,7 @@ __artifacts_v2__ = {
     }
 }
 
+import csv
 import os
 from datetime import datetime, timezone
 
@@ -22,9 +23,20 @@ from scripts.ilapfuncs import artifact_processor
 _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
            'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
+_DISPLAY = {'allowlist': 'Allow List', 'blocklist': 'Block List', 'ghost_mode': 'Ghost Mode',
+            'ghost_mode_expiration': 'Ghost Mode Expiration', 'live_session_ids': 'Live Session IDS',
+            'live_session_expirations': 'Live Session Expirations'}
+
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -32,42 +44,63 @@ def _snap_ts(value):
         return value
 
 
-def _clean_and_group(input_data):
-    sections, current, exclude = [], [], False
-    for line in input_data.split('\n'):
-        if line.startswith('---') or line.startswith('==='):
-            exclude = not exclude
-            if not exclude and current:
-                sections.append(current)
-                current = []
-            continue
-        if not exclude and line.strip():
-            current.append(line.strip())
-    if current:
-        sections.append(current)
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
+                rows.append(row)
     return sections
 
 
 @artifact_processor
 def snapLocprivsets(context):
-    data_list = []
+    # Columns are mapped by header name, never by position (the layout changes across
+    # return versions). Known fields are pre-seeded to keep a stable column order;
+    # any new fields Snapchat adds are appended as they appear.
+    field_names = ['audience', 'allowlist', 'blocklist', 'ghost_mode', 'ghost_mode_expiration',
+                   'live_session_ids', 'live_session_expirations']
+    records = []
     source_path = ''
+    parsed = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not os.path.basename(file_found).startswith('loc_priv_sets.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        with open(file_found, encoding='utf-8') as f:
-            for section in _clean_and_group(f.read()):
-                if not section[0].startswith('timestamp,audience,allowlist,blocklist,ghost_mode'):
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            if not {'timestamp', 'audience', 'ghost_mode'}.issubset(header):
+                continue
+            for name in header:
+                if name != 'timestamp' and name not in field_names:
+                    field_names.append(name)
+            for raw in rows:
+                if not any(cell.strip() for cell in raw):
                     continue
-                for line in section[1:]:
-                    item = line.strip().split(',')
-                    if len(item) < 8:
-                        continue
-                    data_list.append((_snap_ts(item[0]), item[1], item[2], item[3], item[4],
-                                      item[5], item[6], item[7]))
+                values = dict(zip(header, raw))
+                timestamp = _snap_ts(values.pop('timestamp', ''))
+                records.append((timestamp, values))
 
-    data_headers = (('Timestamp', 'datetime'), 'Audience', 'Allow List', 'Block List', 'Ghost Mode',
-                    'Ghost Mode Expiration', 'Live Session IDS', 'Live Session Expirations')
+    data_headers = tuple([('Timestamp', 'datetime')]
+                         + [_DISPLAY.get(name, name.capitalize()) for name in field_names])
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
+                 for timestamp, values in records]
+
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapMemN.py
+++ b/scripts/artifacts/snapMemN.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Memories parsed from a Snapchat law enforcement return (memories.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
@@ -25,8 +25,14 @@ _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 
 def _snap_ts(value):
-    # Snapchat return format: "Wed Aug 19 12:00:00 UTC 2021" (the tz field is assumed UTC).
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -34,44 +40,87 @@ def _snap_ts(value):
         return value
 
 
-def _read_multiline_csv(file_path):
-    rows = []
-    start = False
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
     with open(file_path, 'r', newline='', encoding='utf-8') as f:
         for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
-            if start:
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
                 rows.append(row)
-            elif '===========================' in row:
-                start = True
-    return rows
+    return sections
 
 
 @artifact_processor
 def snapMemN(context):
-    ts_idx, media_idx = 7, 2
-    data_headers = (('Timestamp', 'datetime'), 'Id', 'Media_id', 'Encrypted', 'Source_type',
-                    'Latitude', 'Longitude', 'Duration', ('Media', 'media'))
-    non_media = len(data_headers) - 1
+    files_found = [str(f) for f in context.get_files_found()]
 
-    data_list = []
+    # Media files in the return are named by media_id (with or without an extension).
+    media_lookup = {}
+    for path in files_found:
+        name = os.path.basename(path)
+        if name.lower().endswith('.csv'):
+            continue
+        media_lookup.setdefault(name, path)
+        media_lookup.setdefault(os.path.splitext(name)[0], path)
+
+    checked_in = {}
+
+    def _media_refs(media_field):
+        refs = []
+        for token in (t.strip() for t in (media_field or '').split(';')):
+            path = media_lookup.get(token)
+            if not token or not path:
+                continue
+            if path not in checked_in:
+                checked_in[path] = check_in_media(path, os.path.basename(path))
+            if checked_in[path]:
+                refs.append(checked_in[path])
+        return refs
+
+    # Columns are mapped by header name, never by position (the layout changes across
+    # return versions). Known fields are pre-seeded so the Latitude/Longitude columns
+    # the kml output needs stay present even when a return holds no data; any new
+    # fields Snapchat adds are appended as they appear.
+    field_names = ['id', 'media_id', 'encrypted', 'source_type', 'latitude', 'longitude',
+                   'duration']
+    records = []
     source_path = ''
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
+    parsed = set()
+    for file_found in files_found:
         if not os.path.basename(file_found).startswith('memories.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:  # the same file can match more than one search pattern
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        rows = _read_multiline_csv(file_found)
-        for raw in rows[1:]:
-            if len(raw) <= ts_idx:
-                continue
-            entry = list(raw)
-            entry.insert(0, _snap_ts(entry[ts_idx]))
-            del entry[ts_idx + 1]
-            media_raw = entry[media_idx] if len(entry) > media_idx else ''
-            refs = [r for r in (check_in_media(m.strip(), m.strip())
-                                for m in media_raw.split(';') if m.strip()) if r]
-            entry = (entry + [''] * non_media)[:non_media]
-            entry.append(refs)
-            data_list.append(entry)
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            for name in header:
+                if name != 'timestamp' and name not in field_names:
+                    field_names.append(name)
+            for raw in rows:
+                if not any(cell.strip() for cell in raw):
+                    continue
+                values = dict(zip(header, raw))
+                timestamp = _snap_ts(values.pop('timestamp', ''))
+                records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
+
+    data_headers = tuple([('Timestamp', 'datetime')]
+                         + [name.capitalize() for name in field_names]
+                         + [('Media', 'media')])
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+                 for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapRepconN.py
+++ b/scripts/artifacts/snapRepconN.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Reported conversations parsed from a Snapchat law enforcement return (reported_conversations.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
@@ -25,7 +25,14 @@ _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -33,51 +40,97 @@ def _snap_ts(value):
         return value
 
 
-def _read_multiline_csv(file_path):
-    rows = []
-    start = False
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
     with open(file_path, 'r', newline='', encoding='utf-8') as f:
         for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
-            if start:
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
                 rows.append(row)
-            elif '===========================' in row:
-                start = True
-    return rows
+    return sections
+
+
+def _column(name):
+    if name == 'message_timestamp':
+        return ('Message_timestamp', 'datetime')
+    return name.capitalize()
 
 
 @artifact_processor
 def snapRepconN(context):
-    ts_idx, msg_ts_idx, media_idx = 15, 8, 13
-    data_headers = (('Timestamp', 'datetime'), 'Reporter_user_id', 'Reason', 'Context',
-                    'Reported_user_id', 'Reported_profile_type', 'Conversation_id',
-                    'Reported_message_id', ('Message_timestamp', 'datetime'), 'Message_id',
-                    'Sender_user_id', 'Sender_username', 'Text', 'Media_id', 'Reply_to_message_id',
-                    'Message_type', ('Media', 'media'))
-    non_media = len(data_headers) - 1
+    files_found = [str(f) for f in context.get_files_found()]
 
-    data_list = []
+    # Media files in the return are named by media_id (with or without an extension).
+    media_lookup = {}
+    for path in files_found:
+        name = os.path.basename(path)
+        if name.lower().endswith('.csv'):
+            continue
+        media_lookup.setdefault(name, path)
+        media_lookup.setdefault(os.path.splitext(name)[0], path)
+
+    checked_in = {}
+
+    def _media_refs(media_field):
+        refs = []
+        for token in (t.strip() for t in (media_field or '').split(';')):
+            token = token.split(':')[-1].strip()  # values may come as "media_type:media_id"
+            path = media_lookup.get(token)
+            if not token or not path:
+                continue
+            if path not in checked_in:
+                checked_in[path] = check_in_media(path, os.path.basename(path))
+            if checked_in[path]:
+                refs.append(checked_in[path])
+        return refs
+
+    # Columns are mapped by header name, never by position (the layout changes across
+    # return versions). Known fields are pre-seeded to keep a stable column order;
+    # any new fields Snapchat adds are appended as they appear.
+    field_names = ['reporter_user_id', 'reason', 'context', 'reported_user_id',
+                   'reported_profile_type', 'conversation_id', 'reported_message_id',
+                   'message_timestamp', 'message_id', 'sender_user_id', 'sender_username',
+                   'text', 'media_id', 'reply_to_message_id', 'message_type']
+    records = []
     source_path = ''
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
+    parsed = set()
+    for file_found in files_found:
         if not os.path.basename(file_found).startswith('reported_conversations.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:  # the same file can match more than one search pattern
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        rows = _read_multiline_csv(file_found)
-        for raw in rows[1:]:
-            if len(raw) <= ts_idx:
-                continue
-            entry = list(raw)
-            entry.insert(0, _snap_ts(entry[ts_idx]))
-            del entry[ts_idx + 1]
-            if len(entry) > msg_ts_idx:
-                entry[msg_ts_idx] = _snap_ts(entry[msg_ts_idx])
-            media_raw = entry[media_idx] if len(entry) > media_idx else ''
-            media_parts = media_raw.split(':')
-            media_val = media_parts[1] if len(media_parts) > 1 else media_raw
-            refs = [r for r in (check_in_media(m.strip(), m.strip())
-                                for m in media_val.split(';') if m.strip()) if r]
-            entry = (entry + [''] * non_media)[:non_media]
-            entry.append(refs)
-            data_list.append(entry)
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            for name in header:
+                if name != 'timestamp' and name not in field_names:
+                    field_names.append(name)
+            for raw in rows:
+                if not any(cell.strip() for cell in raw):
+                    continue
+                values = dict(zip(header, raw))
+                timestamp = _snap_ts(values.pop('timestamp', ''))
+                if values.get('message_timestamp'):
+                    values['message_timestamp'] = _snap_ts(values['message_timestamp'])
+                records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
+
+    data_headers = tuple([('Timestamp', 'datetime')]
+                         + [_column(name) for name in field_names]
+                         + [('Media', 'media')])
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+                 for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapStoryN.py
+++ b/scripts/artifacts/snapStoryN.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Story entries parsed from a Snapchat law enforcement return (story.csv).",
         "author": "@AlexisBrignoni",
         "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27",
+        "last_update_date": "2026-07-09",
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
@@ -25,7 +25,14 @@ _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -33,44 +40,86 @@ def _snap_ts(value):
         return value
 
 
-def _read_multiline_csv(file_path):
-    rows = []
-    start = False
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
     with open(file_path, 'r', newline='', encoding='utf-8') as f:
         for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
-            if start:
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
                 rows.append(row)
-            elif '===========================' in row:
-                start = True
-    return rows
+    return sections
 
 
 @artifact_processor
 def snapStoryN(context):
-    ts_idx, media_idx = 6, 2
-    data_headers = (('Timestamp', 'datetime'), 'ID', 'Media_id', 'Username', 'Media_type', 'Time',
-                    'Filter_id', 'Upload_ip', 'Source_port_number', ('Media', 'media'))
-    non_media = len(data_headers) - 1
+    files_found = [str(f) for f in context.get_files_found()]
 
-    data_list = []
+    # Media files in the return are named by media_id (with or without an extension).
+    media_lookup = {}
+    for path in files_found:
+        name = os.path.basename(path)
+        if name.lower().endswith('.csv'):
+            continue
+        media_lookup.setdefault(name, path)
+        media_lookup.setdefault(os.path.splitext(name)[0], path)
+
+    checked_in = {}
+
+    def _media_refs(media_field):
+        refs = []
+        for token in (t.strip() for t in (media_field or '').split(';')):
+            path = media_lookup.get(token)
+            if not token or not path:
+                continue
+            if path not in checked_in:
+                checked_in[path] = check_in_media(path, os.path.basename(path))
+            if checked_in[path]:
+                refs.append(checked_in[path])
+        return refs
+
+    # Columns are mapped by header name, never by position (the layout changes across
+    # return versions). Known fields are pre-seeded to keep a stable column order;
+    # any new fields Snapchat adds are appended as they appear.
+    field_names = ['id', 'media_id', 'username', 'media_type', 'time', 'filter_id',
+                   'upload_ip', 'source_port_number']
+    records = []
     source_path = ''
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
+    parsed = set()
+    for file_found in files_found:
         if not os.path.basename(file_found).startswith('story.csv'):
             continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:  # the same file can match more than one search pattern
+            continue
+        parsed.add(real_path)
         source_path = file_found
-        rows = _read_multiline_csv(file_found)
-        for raw in rows[1:]:
-            if len(raw) <= ts_idx:
-                continue
-            entry = list(raw)
-            entry.insert(0, _snap_ts(entry[ts_idx]))
-            del entry[ts_idx + 1]
-            media_raw = entry[media_idx] if len(entry) > media_idx else ''
-            refs = [r for r in (check_in_media(m.strip(), m.strip())
-                                for m in media_raw.split(';') if m.strip()) if r]
-            entry = (entry + [''] * non_media)[:non_media]
-            entry.append(refs)
-            data_list.append(entry)
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            for name in header:
+                if name != 'timestamp' and name not in field_names:
+                    field_names.append(name)
+            for raw in rows:
+                if not any(cell.strip() for cell in raw):
+                    continue
+                values = dict(zip(header, raw))
+                timestamp = _snap_ts(values.pop('timestamp', ''))
+                records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
+
+    data_headers = tuple([('Timestamp', 'datetime')]
+                         + [name.capitalize() for name in field_names]
+                         + [('Media', 'media')])
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+                 for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapSubinfo.py
+++ b/scripts/artifacts/snapSubinfo.py
@@ -3,23 +3,24 @@ __artifacts_v2__ = {
         "name": "Snapchat - Account Information",
         "description": "Account information from a Snapchat law enforcement return (subscriber_info.csv).",
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27", "requirements": "none",
+        "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
         "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "user",
     },
     "snapSubHistory": {
         "name": "Snapchat - Account Change History",
-        "description": "Account change history from a Snapchat law enforcement return (subscriber_info.csv).",
+        "description": "Account change history from a Snapchat law enforcement return (subscriber_info.csv or subscriber_account_change_history.csv).",
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27", "requirements": "none",
+        "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
-        "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "clock",
+        "paths": ('*/subscriber_info.csv', '*/subscriber_account_change_history.csv'),
+        "output_types": "standard", "artifact_icon": "clock",
     },
     "snapSubValueChanges": {
         "name": "Snapchat - Value Changes",
         "description": "Value changes from a Snapchat law enforcement return (subscriber_info.csv).",
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27", "requirements": "none",
+        "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
         "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "edit",
     },
@@ -27,7 +28,7 @@ __artifacts_v2__ = {
         "name": "Snapchat - Account Details",
         "description": "Account details from a Snapchat law enforcement return (subscriber_info.csv).",
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27", "requirements": "none",
+        "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
         "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "info",
     },
@@ -35,7 +36,7 @@ __artifacts_v2__ = {
         "name": "Snapchat - Privacy Settings",
         "description": "Privacy settings from a Snapchat law enforcement return (subscriber_info.csv).",
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27", "requirements": "none",
+        "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
         "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "lock",
     },
@@ -43,12 +44,13 @@ __artifacts_v2__ = {
         "name": "Snapchat - Bitmoji",
         "description": "Bitmoji info from a Snapchat law enforcement return (subscriber_info.csv).",
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
-        "last_update_date": "2026-06-27", "requirements": "none",
+        "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
         "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "smile",
     }
 }
 
+import csv
 import os
 from datetime import datetime, timezone
 
@@ -59,7 +61,14 @@ _MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 
 def _snap_ts(value):
-    parts = (value or '').split(' ')
+    # Older returns: "Wed Aug 19 12:00:00 UTC 2021"; newer returns: "2026-04-11 04:02:00 UTC".
+    value = (value or '').strip()
+    if value.endswith(' UTC'):
+        try:
+            return datetime.strptime(value[:-4], '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    parts = value.split(' ')
     try:
         return datetime(int(parts[5]), _MONTHS[parts[1]], int(parts[2]),
                         *(int(x) for x in parts[3].split(':')), tzinfo=timezone.utc)
@@ -67,106 +76,142 @@ def _snap_ts(value):
         return value
 
 
-def _clean_and_group(input_data):
-    sections, current, exclude = [], [], False
-    for line in input_data.split('\n'):
-        if line.startswith('---') or line.startswith('==='):
-            exclude = not exclude
-            if not exclude and current:
-                sections.append(current)
-                current = []
-            continue
-        if not exclude and line.strip():
-            current.append(line.strip())
-    if current:
-        sections.append(current)
+def _read_sections(file_path):
+    # The file holds one or more sections, each made of a quoted multi-line
+    # legend, a row of '=' characters, a header row, then data rows. Legend
+    # rows parse as a single cell, so rows with fewer than two cells are not data.
+    sections = []
+    rows = None
+    pending_header = False
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        for row in csv.reader(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL):
+            if any(cell and set(cell) == {'='} for cell in row):
+                pending_header = True
+                rows = None
+            elif pending_header:
+                rows = []
+                sections.append((row, rows))
+                pending_header = False
+            elif rows is not None and len(row) >= 2:
+                rows.append(row)
     return sections
 
 
-def _section(context, header_prefix):
-    """Return (source_path, [split data rows]) for the subscriber_info section with the given header."""
+def _section_data(context, filename_prefixes, required_fields, ordered):
+    """Build (data_headers, data_list, source_path) from every section whose header
+    holds required_fields. Columns are mapped by header name, never by position (the
+    layout changes across return versions, e.g. former_phone_number was added and the
+    change history moved to its own file). `ordered` is a list of (field_name, header)
+    pairs; a header tuple typed 'datetime' also converts the value with _snap_ts.
+    Fields Snapchat adds later are appended as they appear."""
+    known = [field for field, _ in ordered]
+    extras = []
+    records = []
+    source_path = ''
+    parsed = set()
     for file_found in context.get_files_found():
         file_found = str(file_found)
-        if not os.path.basename(file_found).startswith('subscriber_info.csv'):
+        base = os.path.basename(file_found)
+        if not any(base.startswith(prefix) for prefix in filename_prefixes):
             continue
-        with open(file_found, encoding='utf-8') as f:
-            for section in _clean_and_group(f.read()):
-                if section[0].startswith(header_prefix):
-                    return file_found, [line.strip().split(',') for line in section[1:]]
-        return file_found, []
-    return '', []
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
+        source_path = file_found
+        for header, rows in _read_sections(file_found):
+            header = [h.strip().lower() for h in header]
+            if not set(required_fields).issubset(header):
+                continue
+            for name in header:
+                if name not in known and name not in extras:
+                    extras.append(name)
+            for raw in rows:
+                if any(cell.strip() for cell in raw):
+                    records.append(dict(zip(header, raw)))
+
+    data_headers = tuple(h for _, h in ordered) + tuple(n.capitalize() for n in extras)
+    data_list = []
+    for values in records:
+        entry = []
+        for field, spec in ordered:
+            value = values.get(field, '')
+            if isinstance(spec, tuple) and spec[1] == 'datetime' and value:
+                value = _snap_ts(value)
+            entry.append(value)
+        entry.extend(values.get(name, '') for name in extras)
+        data_list.append(entry)
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
 @artifact_processor
 def snapSubAccountInfo(context):
-    source_path, rows = _section(context, 'username,user_id,verified_email_address')
-    data_list = []
-    for item in rows:
-        if len(item) < 12:
-            continue
-        ts = _snap_ts(item[5]) if item[5] else ''
-        item[0], item[5] = ts, item[0]   # original swaps username (col 0) with the timestamp (col 5)
-        data_list.append(tuple(item[:12]))
-    data_headers = (('Timestamp', 'datetime'), 'User ID', 'Verified Email Address', 'Email status',
-                    'Pending Email Address', 'Username', 'Creation IP',
-                    ('Verified Phone Number', 'phonenumber'), 'Phone Status',
-                    ('Pending Phone Number', 'phonenumber'), 'Display Name', 'Status')
-    return data_headers, data_list, context.get_relative_path(source_path)
+    return _section_data(
+        context, ('subscriber_info.csv',), ('username', 'user_id', 'created'),
+        [('created', ('Timestamp', 'datetime')),
+         ('user_id', 'User ID'),
+         ('email_address', 'Verified Email Address'),
+         ('email_status', 'Email status'),
+         ('pending_email_address', 'Pending Email Address'),
+         ('username', 'Username'),
+         ('creation_ip', 'Creation IP'),
+         ('phone_number', ('Verified Phone Number', 'phonenumber')),
+         ('phone_status', 'Phone Status'),
+         ('pending_phone_number', ('Pending Phone Number', 'phonenumber')),
+         ('former_phone_number', ('Former Phone Number', 'phonenumber')),
+         ('display_name', 'Display Name'),
+         ('status', 'Status')])
 
 
 @artifact_processor
 def snapSubHistory(context):
-    source_path, rows = _section(context, 'date,action,old_value,new_value,reason')
-    data_list = []
-    for item in rows:
-        if len(item) < 5:
-            continue
-        item[0] = _snap_ts(item[0])
-        data_list.append(tuple(item[:5]))
-    data_headers = (('Timestamp', 'datetime'), 'Action', 'Old Value', 'New Value', 'Reason')
-    return data_headers, data_list, context.get_relative_path(source_path)
+    # Newer returns ship the change history as subscriber_account_change_history.csv;
+    # older ones embed it as a section of subscriber_info.csv.
+    return _section_data(
+        context, ('subscriber_info.csv', 'subscriber_account_change_history.csv'),
+        ('date', 'action', 'old_value', 'new_value', 'reason'),
+        [('date', ('Timestamp', 'datetime')),
+         ('action', 'Action'),
+         ('old_value', 'Old Value'),
+         ('new_value', 'New Value'),
+         ('reason', 'Reason')])
 
 
 @artifact_processor
 def snapSubValueChanges(context):
-    source_path, rows = _section(context, 'old_value,new_value,timestamp')
-    data_list = []
-    for item in rows:
-        if len(item) < 3:
-            continue
-        data_list.append((_snap_ts(item[2]), item[0], item[1]))
-    data_headers = (('Timestamp', 'datetime'), 'Old Value', 'New Value')
-    return data_headers, data_list, context.get_relative_path(source_path)
+    return _section_data(
+        context, ('subscriber_info.csv',), ('old_value', 'new_value', 'timestamp'),
+        [('timestamp', ('Timestamp', 'datetime')),
+         ('old_value', 'Old Value'),
+         ('new_value', 'New Value')])
 
 
 @artifact_processor
 def snapSubDetails(context):
-    source_path, rows = _section(
-        context, 'email_verified_timestamp,phone_verified_timestamp,birthdate,last_active,'
-                 'follower_count,app_version,2FA_status')
-    data_list = []
-    for item in rows:
-        if len(item) < 7:
-            continue
-        data_list.append((_snap_ts(item[0]), _snap_ts(item[1]), item[2], _snap_ts(item[3]),
-                          item[4], item[5], item[6]))
-    data_headers = (('Email Verified Timestamp', 'datetime'), ('Phone Verified Timestamp', 'datetime'),
-                    'Birthdate', ('Last Active', 'datetime'), 'Follower Count', 'App Version',
-                    '2FA Status')
-    return data_headers, data_list, context.get_relative_path(source_path)
+    # last_active is reported by Snapchat in PDT/PST (per the file legend), so it is
+    # kept verbatim as plain text instead of being typed/coerced as a UTC datetime.
+    return _section_data(
+        context, ('subscriber_info.csv',), ('birthdate', 'last_active'),
+        [('email_verified_timestamp', ('Email Verified Timestamp', 'datetime')),
+         ('phone_verified_timestamp', ('Phone Verified Timestamp', 'datetime')),
+         ('birthdate', 'Birthdate'),
+         ('last_active', 'Last Active'),
+         ('follower_count', 'Follower Count'),
+         ('app_version', 'App Version'),
+         ('2fa_status', '2FA Status')])
 
 
 @artifact_processor
 def snapSubPrivacy(context):
-    source_path, rows = _section(context, 'snap_privacy,story_privacy')
-    data_list = [(item[0], item[1]) for item in rows if len(item) >= 2]
-    data_headers = ('Snap Privacy', 'Story Privacy')
-    return data_headers, data_list, context.get_relative_path(source_path)
+    return _section_data(
+        context, ('subscriber_info.csv',), ('snap_privacy', 'story_privacy'),
+        [('snap_privacy', 'Snap Privacy'),
+         ('story_privacy', 'Story Privacy')])
 
 
 @artifact_processor
 def snapSubBitmoji(context):
-    source_path, rows = _section(context, 'is_bitmoji_user,bitmoji_gender')
-    data_list = [(item[0], item[1]) for item in rows if len(item) >= 2]
-    data_headers = ('Is Bitmoji User', 'Bitmoji Gender')
-    return data_headers, data_list, context.get_relative_path(source_path)
+    return _section_data(
+        context, ('subscriber_info.csv',), ('is_bitmoji_user', 'bitmoji_gender'),
+        [('is_bitmoji_user', 'Is Bitmoji User'),
+         ('bitmoji_gender', 'Bitmoji Gender')])


### PR DESCRIPTION
Extends the header-name-mapped, section-aware parsing pattern from #352 (Snapchat - Conversations) to the remaining Snapchat return CSV artifacts, so future column additions or reorderings by Snapchat cannot silently misalign the output.

> Stacked on #352 (`snapchat-return-updates`). When that merges, this PR retargets to `main` automatically.

## Converted to header-name mapping
- `snapMemN` (memories.csv), `snapRepconN` (reported_conversations.csv), `snapStoryN` (story.csv), `snapIPd` (ip_data.csv), `snapGeo` (geo_locations.csv), `snapLocprivsets` (loc_priv_sets.csv), `snapSubinfo` (subscriber_info.csv, 6 artifacts), `snapIncCom` (snap_inc_communications.csv)
- All accept both timestamp formats: legacy `Wed Aug 19 12:00:00 UTC 2021` and new `2026-04-11 04:02:00 UTC`
- All now parse with a real CSV reader, so quoted fields containing commas (e.g. user agents) can no longer shift columns
- Known fields keep a stable column order; new fields Snapchat adds are appended as they appear
- `snapchatAccounthist` parses JSON by key and needed no change

## Mid-2026 format changes handled
- **ip_data.csv is now one consolidated 20+ column table** instead of per-source sections — the old parser matched nothing and returned **0 records** on new returns. Now: 1,999 records on the validation return.
- **Account Change History moved to its own file**: `snapSubHistory` now reads `subscriber_account_change_history.csv` in addition to the legacy subscriber_info.csv section.
- **subscriber_info.csv gained `former_phone_number`**, which misaligned the fixed 12-column account parser; now reported and typed `phonenumber`.
- **`last_active` is PDT/PST local time per the file legend** — now kept verbatim as plain text instead of being mislabeled a UTC datetime (forensic accuracy: local timestamps must not be typed/coerced as UTC).

## New artifacts (3)
- **Snapchat - Geolocation City** — new `country,region,city,timestamp` section of geo_locations.csv
- **Snapchat - Inc Comms SMS** — SMS Events section of snap_inc_communications.csv
- **Snapchat - In App Appeals** — In App Appeals section of snap_inc_communications.csv

## Validation (real mid-2026 return)
| Artifact | Records |
|---|---|
| IP Data | 1,999 (was 0 with old parser) |
| Geolocation / Additional / City | 2,723 / 1 / 1 (KML generated) |
| Account Info / Details / Privacy / Bitmoji | 1 each — all columns aligned, incl. former_phone_number |
| Account Change History (new standalone file) | 2 |
| Location Privacy Settings | 1 |
| Inc Comms (email) | 5 — comma-laden user agent intact |
| Memories / Story / Reported Conversations / SMS / Appeals | empty in this return — correctly "No data found" |

Loader at 316 plugins, `pylint --disable=C,R` at 10.00, LAVA db builds with correct column typing (verified `last_active` is plain text, verified timestamps are `datetime`).

Note: subscriber_info.csv also has a new single-column community `email_address` section that is not yet parsed (no data in the validation corpus to build against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)