### PR TITLE
Google Chrome User Dictionary (Google Takeout) - LAVA conversion of PR #174

### DIFF
--- a/scripts/artifacts/chromeDictionary.py
+++ b/scripts/artifacts/chromeDictionary.py
@@ -1,0 +1,46 @@
+__artifacts_v2__ = {
+    "chromeDictionary": {
+        "name": "Google Chrome User Dictionary",
+        "description": "Words added by the user to the Google Chrome custom spelling "
+                       "dictionary, parsed from a Google Takeout archive "
+                       "(Chrome/Dictionary.csv). The Entry Order column preserves the "
+                       "order in which the words appear in the file.",
+        "author": "@upintheairsheep2",
+        "creation_date": "2023-08-02",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "",
+        "paths": ('*/Chrome/Dictionary.csv',),
+        "output_types": "standard",
+        "artifact_icon": "book",
+    }
+}
+
+import os
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def chromeDictionary(context):
+    data_list = []
+    source_path = ''
+    parsed = set()
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'Dictionary.csv':
+            continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
+        source_path = file_found
+        counter = 1
+        with open(file_found, 'r', encoding='utf-8-sig') as csvfile:
+            for row in csvfile:
+                data_list.append((counter, row.rstrip('\r\n')))
+                counter += 1
+
+    data_headers = ('Entry Order', 'Word')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary
Adds `scripts/artifacts/chromeDictionary.py`, parsing the custom spelling dictionary words from a Google Takeout archive (`*/Chrome/Dictionary.csv`) into an Entry Order / Word table. This is the parser contributed by @upintheairsheep2 in #174, converted to the modern `@artifact_processor` / LAVA pattern on current main.

## Conversion notes
- `__artifacts_v2__` block mirroring the current house metadata set; original author attribution (`@upintheairsheep2`) and original creation date (2023-08-02) preserved; category `Google Takeout Archive` (same as the other Takeout Chrome artifacts).
- Single `context` argument, `context.get_files_found()` loop with `Dictionary.csv` basename filter and `os.path.realpath` dedupe, returns `(data_headers, data_list, context.get_relative_path(source_path))` with `output_types: standard`.
- Parsing logic preserved exactly: reads the file as `utf-8-sig` text lines (handles the BOM Takeout writes) and numbers each word sequentially.

## Defect fixes vs the original
- `files_found[0]` (only the first match, could be the wrong file) replaced with the filtered loop above.
- Each word was stored with its trailing newline; now stripped (CR/LF only, word content untouched).
- `Order` header renamed to `Entry Order`: ORDER is a SQL reserved word and breaks LAVA's `CREATE TABLE` (confirmed with a `sanitize_sql_name` + in-memory sqlite audit). Column meaning unchanged.

## Validation
- `ast.parse` clean; zero legacy refs (ArtifactHtmlReport, media_to_html, timezone_offset, `files_found[0]`, fromtimestamp, `tsv(`, `timeline(`).
- Reserved-word audit: `Entry Order` / `Word` both pass `sanitize_sql_name` + `CREATE TABLE` in `:memory:` sqlite.
- `PYTHONPATH=. python3 -m pylint --disable=C,R` -> **10.00/10**.
- PluginLoader: 317 plugins (main baseline 316, +1), `chromeDictionary` present, `hasattr(method, '__wrapped__')` True.
- Functional smoke test on a synthetic BOM-prefixed `Dictionary.csv` (3 words, duplicate path passed to verify dedupe): headers/rows align, rows `(1..3, word)` correct.

Supersedes #174 — original parser by @upintheairsheep2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)