### PR TITLE
Takeout - My Activity HTML and Search Contributions (LAVA conversion of #255)

### DIFF
--- a/scripts/artifacts/takeoutMyActivity.py
+++ b/scripts/artifacts/takeoutMyActivity.py
@@ -1,0 +1,55 @@
+__artifacts_v2__ = {
+    "takeoutMyActivity": {
+        "name": "Google Takeout - My Activity",
+        "description": "Parses and displays MyActivity.html files from Google Takeout for various "
+                       "services (e.g., Ads, Chrome, YouTube).",
+        "author": "@Jadoo4QFan",
+        "creation_date": "2025-07-23",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Each service's MyActivity.html file is checked in as a media item so the "
+                 "original HTML can be opened and reviewed manually from the report; the file "
+                 "contents are not parsed into rows. The Service column is taken from the "
+                 "folder name under 'My Activity' in the Takeout path.",
+        "paths": ('*/My Activity/*/MyActivity.html',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    }
+}
+
+import os
+
+from scripts.ilapfuncs import artifact_processor, check_in_media
+
+
+def _service_name(file_found):
+    # Extract service name from path: .../My Activity/Service Name/MyActivity.html
+    path_parts = os.path.normpath(file_found).split(os.sep)
+    try:
+        my_activity_index = path_parts.index('My Activity')
+        return path_parts[my_activity_index + 1]
+    except (ValueError, IndexError):
+        return 'Unknown'
+
+
+@artifact_processor
+def takeoutMyActivity(context):
+    data_list = []
+    source_path = ''
+    seen = set()
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'MyActivity.html':
+            continue
+        real_path = os.path.realpath(file_found)
+        if real_path in seen:
+            continue
+        seen.add(real_path)
+        source_path = file_found
+        service_name = _service_name(file_found)
+        media_ref = check_in_media(file_found, f'My Activity - {service_name}')
+        data_list.append((service_name, media_ref, context.get_relative_path(file_found)))
+
+    data_headers = ('Service', ('HTML File', 'media'), 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/takeoutSearchContributions.py
+++ b/scripts/artifacts/takeoutSearchContributions.py
@@ -1,0 +1,163 @@
+__artifacts_v2__ = {
+    "takeoutSearchContributionsStreaming": {
+        "name": "Google Search Contributions - Streaming Providers",
+        "description": "User-reported information about streaming providers that the user is "
+                       "subscribed to.",
+        "author": "@Jadoo4QFan",
+        "creation_date": "2025-07-23",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Published/Updated values are ISO 8601 UTC ('Z') strings in the Takeout JSON "
+                 "and are converted to timezone-aware UTC; unparseable values are kept "
+                 "verbatim as text.",
+        "paths": ('*/Search Contributions/Streaming video providers.json',),
+        "output_types": "standard",
+        "artifact_icon": "tv",
+    },
+    "takeoutSearchContributionsReviews": {
+        "name": "Google Search Contributions - Reviews",
+        "description": "Reviews for movies, TV shows, music albums, etc.",
+        "author": "@Jadoo4QFan",
+        "creation_date": "2025-07-23",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Published/Updated values are ISO 8601 UTC ('Z') strings in the Takeout JSON "
+                 "and are converted to timezone-aware UTC; unparseable values are kept "
+                 "verbatim as text.",
+        "paths": ('*/Search Contributions/Reviews.json',),
+        "output_types": "standard",
+        "artifact_icon": "star",
+    },
+    "takeoutSearchContributionsWatched": {
+        "name": "Google Search Contributions - Watched",
+        "description": "Movies and TV shows that the user reported as already watched.",
+        "author": "@Jadoo4QFan",
+        "creation_date": "2025-07-23",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Published/Updated values are ISO 8601 UTC ('Z') strings in the Takeout JSON "
+                 "and are converted to timezone-aware UTC; unparseable values are kept "
+                 "verbatim as text.",
+        "paths": ('*/Search Contributions/Watched.json',),
+        "output_types": "standard",
+        "artifact_icon": "eye",
+    },
+    "takeoutSearchContributionsThumbs": {
+        "name": "Google Search Contributions - Thumbs",
+        "description": "Thumb ratings for movies, TV shows, music albums, etc.",
+        "author": "@Jadoo4QFan",
+        "creation_date": "2025-07-23",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "Google Takeout Archive",
+        "notes": "Published/Updated values are ISO 8601 UTC ('Z') strings in the Takeout JSON "
+                 "and are converted to timezone-aware UTC; unparseable values are kept "
+                 "verbatim as text.",
+        "paths": ('*/Search Contributions/Thumbs.json',),
+        "output_types": "standard",
+        "artifact_icon": "thumbs-up",
+    }
+}
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+def _iso_to_utc(value):
+    # Takeout Search Contributions timestamps are ISO 8601 UTC strings
+    # (e.g. "2023-05-01T12:34:56.789Z"). Anything unparseable stays as text.
+    if not value:
+        return value
+    try:
+        return datetime.fromisoformat(value.strip().replace('Z', '+00:00')).astimezone(timezone.utc)
+    except (ValueError, AttributeError):
+        return value
+
+
+def _load_items(context, target_name):
+    items = []
+    source_path = ''
+    seen = set()
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != target_name:
+            continue
+        real_path = os.path.realpath(file_found)
+        if real_path in seen:
+            continue
+        seen.add(real_path)
+        with open(file_found, encoding='utf-8', mode='r') as f:
+            try:
+                data = json.loads(f.read())
+            except json.JSONDecodeError:
+                logfunc(f'Error decoding JSON from file: {os.path.basename(file_found)}')
+                continue
+        source_path = file_found
+        if isinstance(data, list):
+            items.extend(data)
+    return items, source_path
+
+
+@artifact_processor
+def takeoutSearchContributionsStreaming(context):
+    data_list = []
+    items, source_path = _load_items(context, 'Streaming video providers.json')
+    for item in items:
+        provider_name = item.get('Provider Name', '')
+        published = _iso_to_utc(item.get('Published', ''))
+        data_list.append((published, provider_name))
+
+    data_headers = (('Published Timestamp', 'datetime'), 'Provider Name')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def takeoutSearchContributionsReviews(context):
+    data_list = []
+    items, source_path = _load_items(context, 'Reviews.json')
+    for item in items:
+        published = _iso_to_utc(item.get('Published', ''))
+        updated = _iso_to_utc(item.get('Updated', ''))
+        comment = item.get('Review Comment', '')
+        rating = item.get('Review Star Rating', '')
+        query = item.get('Search Query', '')
+        data_list.append((published, updated, query, rating, comment))
+
+    data_headers = (('Published Timestamp', 'datetime'), ('Updated Timestamp', 'datetime'),
+                    'Search Query', 'Star Rating', 'Comment')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def takeoutSearchContributionsWatched(context):
+    data_list = []
+    items, source_path = _load_items(context, 'Watched.json')
+    for item in items:
+        published = _iso_to_utc(item.get('Published', ''))
+        query = item.get('Search Query', '')
+        data_list.append((published, query))
+
+    data_headers = (('Published Timestamp', 'datetime'), 'Search Query')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def takeoutSearchContributionsThumbs(context):
+    data_list = []
+    items, source_path = _load_items(context, 'Thumbs.json')
+    for item in items:
+        published = _iso_to_utc(item.get('Published', ''))
+        updated = _iso_to_utc(item.get('Updated', ''))
+        query = item.get('Search Query', '')
+        rating = item.get('Thumbs Rating', '')
+        data_list.append((published, updated, query, rating))
+
+    data_headers = (('Published Timestamp', 'datetime'), ('Updated Timestamp', 'datetime'),
+                    'Search Query', 'Thumbs Rating')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary

Modernizes the two Google Takeout artifacts contributed by @Jadoo4QFan in PR #255 to the current `@artifact_processor` / LAVA pattern, rebased on current main.

- **`takeoutMyActivity.py`** — `Google Takeout - My Activity`: one row per `My Activity/<Service>/MyActivity.html` with Service, the original HTML file, and the source path. Category `Google Takeout Archive`.
- **`takeoutSearchContributions.py`** — the original single function produced four report tables, so it is split into four artifacts (matching how main handles multi-table takeout files, e.g. `takeoutSavedLinks.py`):
  - `Google Search Contributions - Streaming Providers`
  - `Google Search Contributions - Reviews`
  - `Google Search Contributions - Watched`
  - `Google Search Contributions - Thumbs`

Parsing logic, fields, and column meanings are preserved from the original PR — no invented fields. Attribution preserved (`author: @Jadoo4QFan`, `creation_date: 2025-07-23` = original PR date).

## Conversion notes

- **My Activity HTML**: the original embedded the raw HTML into the report via `html_no_escape` (one report per service). The modern report framework has no raw-HTML-cell equivalent, so each `MyActivity.html` is checked in via `check_in_media` (`('HTML File', 'media')` column) so the original file remains available for manual review, and the per-service report titles became a `Service` column (extracted from the path with the exact same `'My Activity'` path-index logic and `Unknown` fallback as the original). No HTML content parsing — same as the original.
- **Timestamps**: Search Contributions `Published`/`Updated` values are ISO 8601 `Z`-suffixed UTC strings (the original stripped the `T`/`Z` markers as plain text). Now converted to timezone-aware UTC `datetime` columns; empty/unparseable values are kept verbatim as text (noted in each artifact's `notes`). The My Activity artifact emits no timestamp columns, again same as the original.
- Original wildcard path `*/Search Contributions/*.json` split into the four exact filenames the original dispatched on.
- House conventions: basename filter + `os.path.realpath` dedupe, `context.get_relative_path` source paths, `encoding=` on `open()`, local `_iso_to_utc` helper (same pattern as `takeoutAccessLogActivity.py`).

## Validation

- `ast.parse` clean on both files; zero legacy references (`ArtifactHtmlReport`, `media_to_html`, `timezone_offset`, `files_found[0]`, `fromtimestamp`, `tsv(`, `timeline(`).
- Reserved-word audit: all 10 headers through `sanitize_sql_name` + `CREATE TABLE` in `:memory:` sqlite — pass (no `From`/`To`/`Values` collisions).
- `PYTHONPATH=. pylint --disable=C,R` → **10.00/10** on both files.
- PluginLoader: 316 plugins on main → **321** on this branch (+5: 1 My Activity + 4 Search Contributions), all with `__wrapped__` present.
- Functional smoke test on synthetic fixtures (two `MyActivity.html` services; all four Search Contributions JSONs incl. missing/empty-timestamp items): header/row alignment verified, all populated timestamp cells are timezone-aware UTC, empty timestamps stay blank, realpath dedupe and service extraction verified.

Supersedes #255 — original parsers by @Jadoo4QFan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)