### PR TITLE
ChatGPT User Information (data export user.json) - LAVA conversion of PR #172

### DIFF
--- a/scripts/artifacts/chatGPTaccountInfo.py
+++ b/scripts/artifacts/chatGPTaccountInfo.py
@@ -1,0 +1,59 @@
+__artifacts_v2__ = {
+    "chatGPTaccountInfo": {
+        "name": "ChatGPT User Information",
+        "description": "Account information for the ChatGPT user (user ID, email "
+                       "address, ChatGPT Plus status and phone number), parsed from "
+                       "the user.json file of a ChatGPT data export.",
+        "author": "@upintheairsheep2",
+        "creation_date": "2023-08-02",
+        "last_update_date": "2026-07-09",
+        "requirements": "none",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('*/user.json',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
+}
+
+import json
+import os
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def chatGPTaccountInfo(context):
+    data_list = []
+    source_path = ''
+    parsed = set()
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'user.json':
+            continue
+        real_path = os.path.realpath(file_found)
+        if real_path in parsed:
+            continue
+        parsed.add(real_path)
+        source_path = file_found
+
+        with open(file_found, encoding='utf-8', mode='r') as f:
+            data = json.load(f)
+
+        # user.json holds a single JSON object; accept a list of them too.
+        accounts = data if isinstance(data, list) else [data]
+        for account in accounts:
+            data_list.append((
+                account.get('id', ''),
+                account.get('email', ''),
+                account.get('chatgpt_plus_user', ''),
+                account.get('phone_number', ''),
+            ))
+
+    data_headers = (
+        'User ID',
+        'User Email Address',
+        'Does this user use ChatGPT Plus?',
+        ('User Phone Number', 'phonenumber'),
+    )
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
## Summary
Adds `scripts/artifacts/chatGPTaccountInfo.py`, parsing account information (user ID, email address, ChatGPT Plus status, phone number) from the `user.json` file of a ChatGPT data export. This is the parser contributed by @upintheairsheep2 in #172, converted to the modern `@artifact_processor` / LAVA pattern on current main.

## Conversion notes
- `__artifacts_v2__` block mirroring the current house metadata set; original author attribution (`@upintheairsheep2`) and original PR creation date (2023-08-02) preserved; category `ChatGPT` to group with the existing ChatGPT artifact.
- Single `context` argument, `context.get_files_found()` loop with `user.json` basename filter (keeps the original's skip of `-journal` and other files) and `os.path.realpath` dedupe; returns `(data_headers, data_list, context.get_relative_path(source_path))` with `output_types: standard`.
- All four original fields preserved exactly (`id`, `email`, `chatgpt_plus_user`, `phone_number`); `User Phone Number` tagged with the LAVA `phonenumber` column type.
- Overlap note: the existing `chatgpt.py` also globs `**/user.json` and reports ID/email/Plus status, but not the phone number; shared path globs are fine in the framework and this artifact keeps the contributor's standalone table (superset of fields).

## Defect fixes vs the original (the PR itself noted it was untested)
- `user.json` holds a single JSON object; the original's `for site in data:` iterated the object's key strings, so `site['id']` raised `TypeError: string indices must be integers` on any real export. Now parses the object directly (and still accepts a list of objects, preserving the original iteration intent).
- Direct key indexing replaced with `.get(..., '')` so an export missing a field (e.g. no phone number on file) does not crash the artifact.
- Header typo fixed: `User Email Adress` -> `User Email Address`.
- Original had an empty `timeline()` candidacy with no timestamp column; `user.json` contains no timestamps, so the artifact is a plain table (no invented datetime fields).

## Validation
- `ast.parse` clean; zero legacy refs (ArtifactHtmlReport, media_to_html, timezone_offset, `files_found[0]`, fromtimestamp, `tsv(`, `timeline(`).
- Reserved-word audit: all four headers pass `sanitize_sql_name` + `CREATE TABLE` in `:memory:` sqlite.
- `PYTHONPATH=. python3 -m pylint --disable=C,R` -> **10.00/10**.
- PluginLoader: 317 plugins (main baseline 316, +1), `chatGPTaccountInfo` present, `hasattr(method, '__wrapped__')` True.
- Functional smoke test on a synthetic `user.json` (with a duplicate path and a `user.json-journal` decoy passed in): headers/rows align, single correct row produced.

Supersedes #172 — original parser by @upintheairsheep2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)