### PR TITLE
ChatGPT: LAVA @artifact_processor conversion

### DIFF
--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -1,246 +1,238 @@
 __artifacts_v2__ = {
-    "chatgpt": {
-        "name": "ChatGPT",
-        "description": "Parses user's ChatGPT data export. Parser includes conversations, user info, and others. This parser is based on a research project. Latest validation date: 9 July 2024",
+    "chatgptConversationsMetadata": {
+        "name": "ChatGPT - Conversations Metadata",
+        "description": "Metadata from ChatGPT conversations parsed from a ChatGPT data export (conversations.json). This parser is based on a research project.",
         "author": "Evangelos Dragonas (@theAtropos4n6)",
-        "version": "1.0.2",
-        "date": "2024-07-09",
-        "requirements": "",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "none",
         "category": "ChatGPT",
-        "paths": (
-            '**/conversations.json', 
-            '**/chat.html',
-            '**/message_feedback.json',
-            '**/model_comparisons.json',
-            '**/shared_conversations.json',
-            '**/user.json',
-        ),
-        "function": "get_chatgpt"
-    }
+        "notes": "Latest validation date: 9 July 2024.",
+        "paths": ('**/conversations.json',),
+        "output_types": "standard",
+        "artifact_icon": "message-2",
+    },
+    "chatgptConversations": {
+        "name": "ChatGPT - Conversations",
+        "description": "User conversations with ChatGPT parsed from a ChatGPT data export (conversations.json). This parser is based on a research project.",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "none",
+        "category": "ChatGPT",
+        "notes": "Latest validation date: 9 July 2024.",
+        "paths": ('**/conversations.json',),
+        "output_types": "standard",
+        "artifact_icon": "messages",
+    },
+    "chatgptSharedConversations": {
+        "name": "ChatGPT - Shared Conversations",
+        "description": "Metadata from ChatGPT shared conversations parsed from a ChatGPT data export (shared_conversations.json).",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "none",
+        "category": "ChatGPT",
+        "notes": "Latest validation date: 9 July 2024.",
+        "paths": ('**/shared_conversations.json',),
+        "output_types": "standard",
+        "artifact_icon": "share",
+    },
+    "chatgptMessageFeedback": {
+        "name": "ChatGPT - Message Feedback",
+        "description": "ChatGPT message feedback parsed from a ChatGPT data export (message_feedback.json).",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "none",
+        "category": "ChatGPT",
+        "notes": "Latest validation date: 9 July 2024.",
+        "paths": ('**/message_feedback.json',),
+        "output_types": "standard",
+        "artifact_icon": "message-report",
+    },
 }
-
-
 
 import json
 import os
-from pathlib import Path
 from datetime import datetime, timezone
-import pytz
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
 
-#Copied-pasted the timestamp conversion + timezone conversion functions from ilapfuncs.py to enable this capability for this parser till holistic implementation from the core team
-def convert_ts_int_to_utc(ts):
-    timestamp = datetime.fromtimestamp(ts, tz=timezone.utc)
-    return timestamp
-
-def convert_utc_human_to_timezone(utc_time, time_offset): 
-    #fetch the timezone information
-    timezone = pytz.timezone(time_offset)
-    
-    #convert utc to timezone
-    timezone_time = utc_time.astimezone(timezone)
-    
-    #return the converted value
-    return timezone_time
-
-def convert_ts_int_to_timezone(time, time_offset):
-    #convert ts_int_to_utc_human
-    utc_time = convert_ts_int_to_utc(time)
-
-    #fetch the timezone information
-    timezone = pytz.timezone(time_offset)
-    
-    #convert utc to timezone
-    timezone_time = utc_time.astimezone(timezone)
-    
-    #return the converted value
-    return timezone_time
-
-def convert_ts_human_to_utc(ts): #This is for timestamp in human form
-    if '.' in ts:
-        ts = ts.split('.')[0]
-        
-    dt = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S') #Make it a datetime object
-    timestamp = dt.replace(tzinfo=timezone.utc) #Make it UTC
-    return timestamp
+def _flat(value):
+    '''Serialize dict/list values so they store cleanly as text.'''
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return value
 
 
+def _iso_to_utc(value):
+    '''Parse an ISO-8601 timestamp string to an aware UTC datetime; keep raw on failure.'''
+    if not value:
+        return ''
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
-def get_chatgpt(files_found, report_folder, seeker, wrap_text):
-    conversations_metadata = []
-    conversations_messages = []
-    draft_messages = []
-    account_list = []
-    account_list_files_found = []
-    voice_list = []
-    photo_list = []
-    for file_found in files_found:
+
+@artifact_processor
+def chatgptConversationsMetadata(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        #counter += 1 
-        file_name = os.path.basename(file_found)
-        if file_name.endswith('conversations.json') and 'shared_' not in file_name:
-            with open(file_found, 'r', encoding='utf-8') as file:
-                data = json.load(file)
-                conversations_metadata = []
-                conversations_messages = []
-                for conversations in data:
-                    conversation_title = conversations.get("title","")
-                    conversation_id = conversations.get("id","")
-                    create_time = convert_ts_int_to_timezone(int(conversations.get("create_time", 0)),'UTC')
-                    update_time = convert_ts_int_to_timezone(int(conversations.get("update_time", 0)),'UTC')
-                    moderation_results = conversations.get("moderation_results","")
-                    plugin_ids = conversations.get("plugin_ids","")
-                    gizmo_id = conversations.get("gizmo_id","")
-                    is_archived = conversations.get("is_archived","")
-                    conversations_metadata.append((create_time,update_time,conversation_title,conversation_id,moderation_results,plugin_ids,gizmo_id,is_archived))
+        if os.path.basename(file_found) != 'conversations.json':
+            continue
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8') as file:
+            data = json.load(file)
 
-                    if isinstance(conversations.get("mapping"), dict):
-                        for messageId, message_details in conversations.get("mapping", {}).items():
-                            message_id = message_details.get("id")
-                            if message_details.get("message"):
-                                msg_content = message_details.get("message")
-                                author_role = msg_content.get("author", "").get("role", "")
-                                author_name = msg_content.get("author", "").get("name", "")
-                                author_metadata = msg_content.get("author", "").get("metadata", "")
-                                msg_create_time = convert_ts_int_to_timezone(int(msg_content.get("create_time", 0)),'UTC') if msg_content.get("create_time") is not None else ""
-                                msg_update_time = convert_ts_int_to_timezone(int(msg_content.get("update_time", 0)),'UTC') if msg_content.get("update_time") is not None else ""
-                                content_type = msg_content.get("content", "").get("content_type", "")
-                                content_language = msg_content.get("content", "").get("language", "")
-                                content_text = msg_content.get("content", "").get("text", "")
-                                content_parts = msg_content.get("content", "").get("parts", "")
-                                status = msg_content.get("status", "")
-                                end_turn = msg_content.get("end_turn", "")
-                                weight = msg_content.get("weight", "")
-                                is_visually_hidden_from_conversation = msg_content.get("metadata", False).get("is_visually_hidden_from_conversation", "")
-                                if isinstance(msg_content.get("metadata").get("user_context_message_data", ""), dict):
-                                    about_user_message = msg_content.get("metadata").get("user_context_message_data", "").get("about_user_message", "")
-                                    about_model_message = msg_content.get("metadata").get("user_context_message_data", "").get("about_model_message", "")
-                                else:
-                                    about_user_message = ""
-                                    about_model_message = ""
-                                voice_mode_message = msg_content.get("metadata", False).get("voice_mode_message", "")
-                                rest_metadata = msg_content.get("metadata", False)
-                                recipient = msg_content.get("recipient", "")
-                                conversations_messages.append((msg_create_time,msg_update_time,message_id,conversation_title,conversation_id,author_role,author_name,content_parts,about_user_message,about_model_message,content_type,content_language,content_text,rest_metadata,status,voice_mode_message,author_metadata,is_visually_hidden_from_conversation,end_turn,weight,recipient))
-                                
-                            #parsing collected conversations metadata
-                if len(conversations_metadata) > 0:
-                    description = f'Metadata from ChatGPT conversations'
-                    report = ArtifactHtmlReport(f'ChatGPT - Conversations Metadata')
-                    report.start_artifact_report(report_folder, f'Conversations Metadata', description)
-                    report.add_script()
-                    data_headers = ('Creation Time','Modification Date','Title','Conversation ID','Moderation Results','Plugin IDs','Gizmo ID','Is Archived') 
-                    report.write_artifact_data_table(data_headers, conversations_metadata, file_found, html_escape=False)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'ChatGPT - Conversations Metadata'
-                    tsv(report_folder, data_headers, conversations_metadata, tsvname)
+        for conversation in data:
+            create_time = convert_unix_ts_to_utc(conversation.get("create_time")) if conversation.get("create_time") else ''
+            update_time = convert_unix_ts_to_utc(conversation.get("update_time")) if conversation.get("update_time") else ''
+            data_list.append((
+                create_time,
+                update_time,
+                conversation.get("title", ""),
+                conversation.get("id", ""),
+                _flat(conversation.get("moderation_results", "")),
+                _flat(conversation.get("plugin_ids", "")),
+                conversation.get("gizmo_id", ""),
+                conversation.get("is_archived", ""),
+            ))
 
-                    tlactivity = f'ChatGPT - Conversations Metadata'
-                    timeline(report_folder, tlactivity, conversations_metadata, data_headers)
+    data_headers = (
+        ('Creation Time', 'datetime'),
+        ('Modification Date', 'datetime'),
+        'Title', 'Conversation ID', 'Moderation Results', 'Plugin IDs',
+        'Gizmo ID', 'Is Archived',
+    )
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chatgptConversations(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'conversations.json':
+            continue
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8') as file:
+            data = json.load(file)
+
+        for conversation in data:
+            conversation_title = conversation.get("title", "")
+            conversation_id = conversation.get("id", "")
+            if not isinstance(conversation.get("mapping"), dict):
+                continue
+            for _message_id, message_details in conversation.get("mapping", {}).items():
+                message_id = message_details.get("id")
+                msg_content = message_details.get("message")
+                if not msg_content:
+                    continue
+                author = msg_content.get("author", "") or {}
+                author_role = author.get("role", "") if isinstance(author, dict) else ""
+                author_name = author.get("name", "") if isinstance(author, dict) else ""
+                author_metadata = author.get("metadata", "") if isinstance(author, dict) else ""
+                msg_create_time = convert_unix_ts_to_utc(msg_content.get("create_time")) if msg_content.get("create_time") is not None else ""
+                msg_update_time = convert_unix_ts_to_utc(msg_content.get("update_time")) if msg_content.get("update_time") is not None else ""
+                content = msg_content.get("content", "") or {}
+                content_type = content.get("content_type", "") if isinstance(content, dict) else ""
+                content_language = content.get("language", "") if isinstance(content, dict) else ""
+                content_text = content.get("text", "") if isinstance(content, dict) else ""
+                content_parts = content.get("parts", "") if isinstance(content, dict) else ""
+                status = msg_content.get("status", "")
+                end_turn = msg_content.get("end_turn", "")
+                weight = msg_content.get("weight", "")
+                metadata = msg_content.get("metadata", False) or {}
+                is_visually_hidden = metadata.get("is_visually_hidden_from_conversation", "") if isinstance(metadata, dict) else ""
+                user_context = metadata.get("user_context_message_data", "") if isinstance(metadata, dict) else ""
+                if isinstance(user_context, dict):
+                    about_user_message = user_context.get("about_user_message", "")
+                    about_model_message = user_context.get("about_model_message", "")
                 else:
-                    logfunc(f'No ChatGPT - Conversations Metadata available')
+                    about_user_message = ""
+                    about_model_message = ""
+                voice_mode_message = metadata.get("voice_mode_message", "") if isinstance(metadata, dict) else ""
+                recipient = msg_content.get("recipient", "")
+                data_list.append((
+                    msg_create_time, msg_update_time, message_id, conversation_title,
+                    conversation_id, author_role, author_name, _flat(content_parts),
+                    about_user_message, about_model_message, content_type, content_language,
+                    content_text, _flat(metadata), status, voice_mode_message,
+                    _flat(author_metadata), is_visually_hidden, end_turn, weight, recipient,
+                ))
 
-                #parsing collected conversations metadata
-                if len(conversations_messages) > 0:
-                    description = f'User conversations with ChatGPT'
-                    report = ArtifactHtmlReport(f'ChatGPT - Conversations')
-                    report.start_artifact_report(report_folder, f'Conversations', description)
-                    report.add_script()
-                    data_headers = ('Creation Time','Modification Date','Message ID','Conversation Title','Conversation ID','Author (Role)','Author (Name)','Parts','Custom Instructions (User)','Custom Instructions (Model)','Content Type','Language','Text','Rest Metadata','Status','Voice Chat','Author (Metadata)','Is Visually Hidden From Conversation','End Turn','Weight','Recipient')
-                    report.write_artifact_data_table(data_headers, conversations_messages, file_found, html_escape=False)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'ChatGPT - Conversations'
-                    tsv(report_folder, data_headers, conversations_messages, tsvname)
+    data_headers = (
+        ('Creation Time', 'datetime'),
+        ('Modification Date', 'datetime'),
+        'Message ID', 'Conversation Title', 'Conversation ID', 'Author (Role)',
+        'Author (Name)', 'Parts', 'Custom Instructions (User)', 'Custom Instructions (Model)',
+        'Content Type', 'Language', 'Text', 'Rest Metadata', 'Status', 'Voice Chat',
+        'Author (Metadata)', 'Is Visually Hidden From Conversation', 'End Turn', 'Weight',
+        'Recipient',
+    )
+    return data_headers, data_list, context.get_relative_path(source_path)
 
-                    tlactivity = f'ChatGPT - Conversations'
-                    timeline(report_folder, tlactivity, conversations_messages, data_headers)
-                else:
-                    logfunc(f'No ChatGPT - Conversations available')
-        
-        if file_name.endswith('shared_conversations.json'):
-            with open(file_found, 'r', encoding='utf-8') as file:
-                data = json.load(file)
-                shared_conversations_metadata = []
-                for conversations in data:
-                    conversation_title = conversations.get("title","")
-                    share_id = conversations.get("id","")
-                    conversation_anonymous = conversations.get("is_anonymous",False)
-                    conversation_id = conversations.get("conversation_id","")
-                    shared_conversations_metadata.append((share_id,conversation_id,conversation_title,conversation_anonymous))
 
-                if len(shared_conversations_metadata) > 0:
-                    description = f'Metadata from ChatGPT shared conversations'
-                    report = ArtifactHtmlReport(f'ChatGPT - Shared Conversations')
-                    report.start_artifact_report(report_folder, f'Shared Conversations', description)
-                    report.add_script()
-                    data_headers = ('Share ID','Conversation ID','Title','Is Anonymous') 
-                    report.write_artifact_data_table(data_headers, shared_conversations_metadata, file_found, html_escape=False)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'ChatGPT - Shared Conversations'
+@artifact_processor
+def chatgptSharedConversations(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'shared_conversations.json':
+            continue
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8') as file:
+            data = json.load(file)
 
-                    tsv(report_folder, data_headers, shared_conversations_metadata, tsvname)
-                else:
-                    logfunc(f'No ChatGPT - Shared Conversations available')
+        for conversation in data:
+            data_list.append((
+                conversation.get("id", ""),
+                conversation.get("conversation_id", ""),
+                conversation.get("title", ""),
+                conversation.get("is_anonymous", False),
+            ))
 
-        if file_name.endswith('user.json'):
-            with open(file_found, 'r', encoding='utf-8') as file:
-                data = json.load(file)
-                user = []
-                user_id = data.get("id","")
-                email = data.get("email","")
-                chatgpt_plus_user = data.get("chatgpt_plus_user",False)
-                user.append((user_id,email,chatgpt_plus_user))
+    data_headers = ('Share ID', 'Conversation ID', 'Title', 'Is Anonymous')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
-                if len(user) > 0:
-                    description = f'ChatGPT user info'
-                    report = ArtifactHtmlReport(f'ChatGPT - User')
-                    report.start_artifact_report(report_folder, f'User', description)
-                    report.add_script()
-                    data_headers = ('User ID','Email','Is ChatGPT Plus User') 
-                    report.write_artifact_data_table(data_headers, user, file_found, html_escape=False)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'ChatGPT - User'
-                    tsv(report_folder, data_headers, user, tsvname)
-                else:
-                    logfunc(f'No ChatGPT - User available')
 
-        if file_name.endswith('message_feedback.json'):
-            with open(file_found, 'r', encoding='utf-8') as file:
-                data = json.load(file)
-                message_feedback = []
-                for feedback in data:
-                    msg_id = feedback.get("id","")
-                    conv_id = feedback.get("conversation_id","")
-                    user_id = feedback.get("user_id","")
-                    rating = feedback.get("rating","")
-                    formatted_timestamp = feedback.get("create_time","").split('T')[0] + ' ' + feedback.get("create_time","").split('T')[1].split('.')[0] #converts iso format to ilapp function's desired input
-                    create_time = convert_utc_human_to_timezone(convert_ts_human_to_utc(formatted_timestamp), 'UTC')
-                    workspace_id = feedback.get("workspace_id","")
-                    content = feedback.get("content","")
-                    storage_protocol = feedback.get("storage_protocol","")
-                    message_feedback.append((create_time,user_id,msg_id,conv_id,rating,workspace_id,content,storage_protocol))
+@artifact_processor
+def chatgptMessageFeedback(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'message_feedback.json':
+            continue
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8') as file:
+            data = json.load(file)
 
-                if len(message_feedback) > 0:
-                    description = f'ChatGPT message feedback'
-                    report = ArtifactHtmlReport(f'ChatGPT - Message Feedback')
-                    report.start_artifact_report(report_folder, f'Message Feedback', description)
-                    report.add_script()
-                    data_headers = ('Creation Time','User ID','Message ID','Conversation ID','Rating','Workspace ID','Content','Storage Protocol') 
-                    report.write_artifact_data_table(data_headers, message_feedback, file_found, html_escape=False)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'ChatGPT - Message Feedback'
-                    tsv(report_folder, data_headers, message_feedback, tsvname)
-                else:
-                    logfunc(f'No ChatGPT - Message Feedback available')
+        for feedback in data:
+            data_list.append((
+                _iso_to_utc(feedback.get("create_time", "")),
+                feedback.get("user_id", ""),
+                feedback.get("id", ""),
+                feedback.get("conversation_id", ""),
+                feedback.get("rating", ""),
+                feedback.get("workspace_id", ""),
+                _flat(feedback.get("content", "")),
+                feedback.get("storage_protocol", ""),
+            ))
 
-        if file_name.endswith('chat.html'):
-            pass 
-        if file_name.endswith('model_comparisons.json'):
-            pass 
+    data_headers = (
+        ('Creation Time', 'datetime'),
+        'User ID', 'Message ID', 'Conversation ID', 'Rating', 'Workspace ID',
+        'Content', 'Storage Protocol',
+    )
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts `scripts/artifacts/chatgpt.py` from the legacy `ArtifactHtmlReport` body to the context-form `@artifact_processor` LAVA pipeline.

The single legacy function is split into **4 artifacts** (one LAVA table each):
- ChatGPT - Conversations Metadata
- ChatGPT - Conversations
- ChatGPT - Shared Conversations
- ChatGPT - Message Feedback

**Changes**
- Context form (`def fn(context)`), `context.get_relative_path` on source paths.
- Aware-UTC datetimes via `convert_unix_ts_to_utc` (epoch) and ISO parsing for message feedback, replacing the copied pytz/naive helpers.
- Dict/list fields serialized to JSON text for clean storage.
- **Drops the `user.json` handling**: `user.json` is now owned by `chatGPTaccountInfo.py` (merged PR #357), which also surfaces the phone number. No name collision.
- Preserves original attribution (Evangelos Dragonas, @theAtropos4n6).

**Validation**: pylint `--disable=C,R` = 10.00; reserved-word audit clean; PluginLoader +3 (4 new artifacts replace the 1 legacy stub); `__wrapped__` structural check.