### PR TITLE
MeWe: LAVA @artifact_processor conversion (10 artifacts)

### DIFF
--- a/scripts/artifacts/meweReturns.py
+++ b/scripts/artifacts/meweReturns.py
@@ -3,595 +3,444 @@ __artifacts_v2__ = {
         "name": "MeWe Contacts",
         "description": "This parses the Contacts list from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-13",
-        "requirements": "",
+        "creation_date": "2024-05-13",
+        "last_update_date": "2024-05-13",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/contacts.txt'),
-        "function": "get_meweContacts"
+        "notes": "",
+        "paths": ('**/mewe-content/contacts.txt',),
+        "output_types": "standard",
+        "artifact_icon": "users",
     },
     "meweDevices": {
         "name": "MeWe Devices",
         "description": "This parses the Device list from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-13",
-        "requirements": "",
+        "creation_date": "2024-05-13",
+        "last_update_date": "2024-05-13",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/devices.txt'),
-        "function": "get_meweDevices"
+        "notes": "",
+        "paths": ('**/mewe-content/devices.txt',),
+        "output_types": "standard",
+        "artifact_icon": "devices",
     },
     "meweEmails": {
         "name": "MeWe Email Accounts",
         "description": "This parses the Email account list from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-13",
-        "requirements": "",
+        "creation_date": "2024-05-13",
+        "last_update_date": "2024-05-13",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/emails.txt'),
-        "function": "get_meweEmails"
+        "notes": "",
+        "paths": ('**/mewe-content/emails.txt',),
+        "output_types": "standard",
+        "artifact_icon": "mail",
     },
     "meweGroupmemberships": {
         "name": "MeWe Group Memberships",
         "description": "This parses the Group Membership list from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-13",
-        "requirements": "",
+        "creation_date": "2024-05-13",
+        "last_update_date": "2024-05-13",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/group-memberships.txt'),
-        "function": "get_meweGroupmemberships"
+        "notes": "",
+        "paths": ('**/mewe-content/group-memberships.txt',),
+        "output_types": "standard",
+        "artifact_icon": "users-group",
     },
     "meweProfile": {
         "name": "MeWe Profile",
         "description": "This parses the User Profile from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.1.0",
-        "date": "2024-05-15",
-        "requirements": "",
+        "creation_date": "2024-05-15",
+        "last_update_date": "2024-05-15",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/profile.txt','**/mewe-content/photos/*.jpg'),
-        "function": "get_meweProfile"
+        "notes": "",
+        "paths": ('**/mewe-content/profile.txt', '**/mewe-content/photos/*.jpg'),
+        "output_types": "standard",
+        "artifact_icon": "user",
     },
     "meweGroupChat": {
         "name": "MeWe Group Chat",
         "description": "This parses the Group Chat Posts from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-15",
-        "requirements": "",
+        "creation_date": "2024-05-15",
+        "last_update_date": "2024-05-15",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/groupChat.txt','**/mewe-content/photos/*.jpg'),
-        "function": "get_meweGroupChat"
+        "notes": "",
+        "paths": ('**/mewe-content/groupChat.txt', '**/mewe-content/photos/*.jpg'),
+        "output_types": "standard",
+        "artifact_icon": "message",
     },
     "mewePosts": {
         "name": "MeWe Posts",
         "description": "This parses the Posts from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-15",
-        "requirements": "",
+        "creation_date": "2024-05-15",
+        "last_update_date": "2024-05-15",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/posts.txt','**/mewe-content/photos/*.jpg'),
-        "function": "get_mewePosts"
+        "notes": "",
+        "paths": ('**/mewe-content/posts.txt', '**/mewe-content/photos/*.jpg'),
+        "output_types": "standard",
+        "artifact_icon": "note",
     },
     "meweUserChat": {
         "name": "MeWe Chat Posts",
         "description": "This parses the User Chat Posts from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.2.0",
-        "date": "2024-05-16",
-        "requirements": "",
+        "creation_date": "2024-05-16",
+        "last_update_date": "2024-05-16",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/userChat.txt','**/mewe-content/photos/*.jpg','**mewe-content/documents/**'),
-        "function": "get_meweUserChat"
+        "notes": "",
+        "paths": ('**/mewe-content/userChat.txt', '**/mewe-content/photos/*.jpg', '**/mewe-content/documents/**'),
+        "output_types": "standard",
+        "artifact_icon": "message-2",
     },
     "meweLoginStats": {
         "name": "MeWe Login Stats",
         "description": "This parses the User Login Stats from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-16",
-        "requirements": "",
+        "creation_date": "2024-05-16",
+        "last_update_date": "2024-05-16",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/logins/stats.txt'),
-        "function": "get_meweLoginStats"
+        "notes": "",
+        "paths": ('**/mewe-content/logins/stats.txt',),
+        "output_types": "standard",
+        "artifact_icon": "login",
     },
     "meweLoginLogs": {
         "name": "MeWe Login Logs",
         "description": "This parses the User Login Logs from a MeWe warrant return.",
         "author": "Troy Schnack (@TheBaldJedi)",
-        "version": "1.0.1",
-        "date": "2024-05-16",
-        "requirements": "",
+        "creation_date": "2024-05-16",
+        "last_update_date": "2024-05-16",
+        "requirements": "none",
         "category": "MeWe",
-        "paths": (
-            '**/mewe-content/logins/logs.txt'),
-        "function": "get_meweLoginLogs"
-    }
+        "notes": "",
+        "paths": ('**/mewe-content/logins/logs.txt',),
+        "output_types": "standard",
+        "artifact_icon": "login",
+    },
 }
 
-
-import os
 import csv
-import datetime
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, media_to_html
-
-
-def get_meweLoginLogs(files_found, report_folder, seeker, wrap_text):
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
-    for file_found in files_found:
+def _kv(field):
+    '''Return the value from a "key: value" field. Uses a single split so
+    values that themselves contain ": " (timestamps, IPv6, URLs) are kept
+    whole -- the original lstrip()/split(': ') logic truncated those.'''
+    field = str(field)
+    if ': ' in field:
+        return field.split(': ', 1)[1].strip()
+    return field.strip()
+
+
+def _mewe_ts(value):
+    '''Parse a MeWe ISO-8601 timestamp to an aware UTC datetime.
+    Naive values are assumed UTC (warrant-return convention); unparseable
+    values are kept verbatim.'''
+    if not value:
+        return ''
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@artifact_processor
+def meweLoginLogs(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            
-            data_list_dm =[]
-            
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    dateCreated = item[0].lstrip('date: ')
-                    dateCreated = datetime.datetime.fromisoformat(dateCreated)
-                    ipAddress = item[1].lstrip('ip: ')
-                                                
-                    data_list_dm.append((dateCreated,ipAddress))
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Login Logs ')
-                report.start_artifact_report(report_folder, f'MeWe - Logins Logs - {csvname}')
-                report.add_script()
-                data_headers = ('Login Date','IP Address')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Logins Logs - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if len(item) < 2:
+                    continue
+                data_list.append((_mewe_ts(_kv(item[0])), _kv(item[1])))
 
-                tlactivity = f'MeWe - Logins Logs'
-                timeline(report_folder, tlactivity, data_list_dm, data_headers)
-
-                
-            else:
-                logfunc(f'No MeWe - Logins Logs - {csvname}')
+    data_headers = (('Login Date', 'datetime'), 'IP Address')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_meweLoginStats(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweLoginStats(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            
-            data_list_dm =[]
-            
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    ipAddress = item[0].lstrip('ip: ')
-                    totalCount = item[1].lstrip('totalCount: ')
-                                                
-                    data_list_dm.append((ipAddress,totalCount))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Login Stats ')
-                report.start_artifact_report(report_folder, f'MeWe - Logins Stats - {csvname}')
-                report.add_script()
-                data_headers = ('IP Adress','Total Logins From IP')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Logins Stats - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-               
-            else:
-                logfunc(f'No MeWe - Logins Stats - {csvname}')
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if len(item) < 2:
+                    continue
+                data_list.append((_kv(item[0]), _kv(item[1])))
+
+    data_headers = ('IP Address', 'Total Logins From IP')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_meweUserChat(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweUserChat(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        folderPath = os.path.dirname(file_found)
-        
-        ''' Define subfolder paths for photos and other file types.'''
-        ''' Example: mp4's are stored in the documents folder.'''
-        photoPath = folderPath + '/photos'
-        attachPath = folderPath + '/documents'
-        
-        
-        if file_found.endswith('.txt'):
-            
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                data = f.readlines()
-                
-                data_list_dm =[]
-                dateCreated = chatText = senderID = threadID = chatType = recipientID = documentID = imageID = thumb = ''
-    
-                for line in data:
-                    
-                    if 'date_created:' in line:
-                        dateCreated = line.split(': ')[1].strip()
-                        dateCreated = datetime.datetime.fromisoformat(dateCreated)
-                    elif 'text:' in line:
-                        chatText = line.split(': ')[1].strip()
-                    elif 'sender_id:' in line:
-                        senderID = line.split(': ')[1].strip()
-                    elif 'threadId:' in line:
-                        threadID = line.split(': ')[1].strip()
-                    elif 'chatThreadType:' in line:
-                        chatType = line.split(': ')[1].strip()
-                    elif 'recipientUsersId' in line:
-                        recipientID = line.split(': ')[1].strip()
-                    elif 'document_id:' in line:
-                        documentID = line.split(': ')[1].strip()
-                        thumb = media_to_html(documentID,files_found,report_folder)
-                    elif 'image_id:' in line:
-                        imageID = line.split(': ')[1].strip()
-                        thumb = media_to_html(imageID,files_found,report_folder)
-                    elif '---------------' in line:
-                        data_list_dm.append((dateCreated,chatText,senderID,threadID,chatType,recipientID,documentID,imageID,thumb))
-                        dateCreated = chatText = senderID = threadID = chatType = recipientID = documentID = imageID = thumb = ''
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - User Chat ')
-                report.start_artifact_report(report_folder, f'MeWe - User Chat - {csvname}')
-                report.add_script()
-                data_headers = ('Created Date','Text','Sender ID','Thread ID','Chat Type','Recipient ID','Attached Filename','Photo Filename','Media')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - User Chat - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        date_created = chat_text = sender_id = thread_id = chat_type = recipient_id = document_id = image_id = ''
+        media_refs = []
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for line in f:
+                if 'date_created:' in line:
+                    date_created = _mewe_ts(_kv(line))
+                elif 'text:' in line:
+                    chat_text = _kv(line)
+                elif 'sender_id:' in line:
+                    sender_id = _kv(line)
+                elif 'threadId:' in line:
+                    thread_id = _kv(line)
+                elif 'chatThreadType:' in line:
+                    chat_type = _kv(line)
+                elif 'recipientUsersId' in line:
+                    recipient_id = _kv(line)
+                elif 'document_id:' in line:
+                    document_id = _kv(line)
+                    ref = check_in_media(document_id, document_id)
+                    if ref:
+                        media_refs.append(ref)
+                elif 'image_id:' in line:
+                    image_id = _kv(line)
+                    ref = check_in_media(image_id, image_id)
+                    if ref:
+                        media_refs.append(ref)
+                elif '---------------' in line:
+                    data_list.append((date_created, chat_text, sender_id, thread_id, chat_type,
+                                      recipient_id, document_id, image_id, media_refs))
+                    date_created = chat_text = sender_id = thread_id = chat_type = recipient_id = document_id = image_id = ''
+                    media_refs = []
 
-                tlactivity = f'MeWe - User Chat'
-                timeline(report_folder, tlactivity, data_list_dm, data_headers)
-                
-            else:
-                logfunc(f'No MeWe - User Chat - {csvname}')
+    data_headers = (('Created Date', 'datetime'), 'Text', 'Sender ID', 'Thread ID', 'Chat Type',
+                    'Recipient ID', 'Attached Filename', 'Photo Filename', ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_mewePosts(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def mewePosts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                data = f.readlines()
-                
-                data_list_dm =[]
-                dateCreated = chatText = imageID = thumb = ''
-    
-                for line in data:
-                    
-                    if 'date_created:' in line:
-                        dateCreated = line.split(': ')[1].strip()
-                        dateCreated = datetime.datetime.fromisoformat(dateCreated)
-                    elif 'text:' in line:
-                        chatText = line.split(': ')[1].strip()
-                    elif 'image_id:' in line:
-                        imageID = line.split(': ')[1].strip()
-                        thumb = media_to_html(imageID,files_found,report_folder)
-                    elif '---------------' in line:
-                        data_list_dm.append((dateCreated,chatText,imageID,thumb))
-                        dateCreated = chatText = imageID = thumb = ''
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Posts ')
-                report.start_artifact_report(report_folder, f'MeWe - Posts - {csvname}')
-                report.add_script()
-                data_headers = ('Created Date','Text','Image ID','Media')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Posts - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        date_created = chat_text = image_id = ''
+        media_ref = ''
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for line in f:
+                if 'date_created:' in line:
+                    date_created = _mewe_ts(_kv(line))
+                elif 'text:' in line:
+                    chat_text = _kv(line)
+                elif 'image_id:' in line:
+                    image_id = _kv(line)
+                    media_ref = check_in_media(image_id, image_id)
+                elif '---------------' in line:
+                    data_list.append((date_created, chat_text, image_id, media_ref))
+                    date_created = chat_text = image_id = ''
+                    media_ref = ''
 
-                tlactivity = f'MeWe - Posts'
-                timeline(report_folder, tlactivity, data_list_dm, data_headers)
-                
-            else:
-                logfunc(f'No MeWe - Posts - {csvname}')
+    data_headers = (('Created Date', 'datetime'), 'Text', 'Image ID', ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_meweGroupChat(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweGroupChat(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                data = f.readlines()
-                
-                data_list_dm =[]
-                dateCreated = chatID = chatText = senderID = threadID = chatType = imageID = thumb = ''
-    
-                for line in data:
-                    
-                    if 'date_created' in line:
-                        dateCreated = line.split(': ')[1].strip()
-                        dateCreated = datetime.datetime.fromisoformat(dateCreated)
-                    elif 'text:' in line:
-                        chatText = line.split(': ')[1].strip()
-                    elif 'sender_id:' in line:
-                        senderID = line.split(': ')[1].strip()
-                    elif 'threadId' in line:
-                        threadID = line.split(': ')[1].strip()
-                    elif 'chatThreadType' in line:
-                        chatType = line.split(': ')[1].strip()
-                    elif 'image_id:' in line:
-                        imageID = line.split(': ')[1].strip()
-                        thumb = media_to_html(imageID,files_found,report_folder)
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        date_created = chat_text = sender_id = thread_id = chat_type = image_id = ''
+        media_ref = ''
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for line in f:
+                if 'date_created' in line:
+                    date_created = _mewe_ts(_kv(line))
+                elif 'text:' in line:
+                    chat_text = _kv(line)
+                elif 'sender_id:' in line:
+                    sender_id = _kv(line)
+                elif 'threadId' in line:
+                    thread_id = _kv(line)
+                elif 'chatThreadType' in line:
+                    chat_type = _kv(line)
+                elif 'image_id:' in line:
+                    image_id = _kv(line)
+                    media_ref = check_in_media(image_id, image_id)
+                elif '---------------' in line:
+                    data_list.append((date_created, chat_text, sender_id, thread_id, chat_type, image_id, media_ref))
+                    date_created = chat_text = sender_id = thread_id = chat_type = image_id = ''
+                    media_ref = ''
 
-                    elif '---------------' in line:
-                        data_list_dm.append((dateCreated,chatText,senderID,threadID,chatType,imageID,thumb))
-                        dateCreated = chatID = chatText = senderID = threadID = chatType = imageID = thumb = ''
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Group Chat ')
-                report.start_artifact_report(report_folder, f'MeWe - Group Chat - {csvname}')
-                report.add_script()
-                data_headers = ('Created Date','Text','Sender ID','Thread ID','Chat Type','Image ID','Media')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Group Chat - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-
-                tlactivity = f'MeWe - Group Chat'
-                timeline(report_folder, tlactivity, data_list_dm, data_headers)
-                
-            else:
-                logfunc(f'No MeWe - Group Chat - {csvname}')
+    data_headers = (('Created Date', 'datetime'), 'Text', 'Sender ID', 'Thread ID', 'Chat Type',
+                    'Image ID', ('Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_meweProfile(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweProfile(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                data = f.readlines()
-                
-                data_list_dm =[]
-                userid = dateRegistered = firstName = lastName = email = lastSeen = timeZone = profileText = isBanned = urlPage = coverImage = profileImage = profileThumb = coverThumb =''
-    
-                for line in data:
-                    
-                    if 'user_id:' in line:
-                        userid = line.split(': ')[1].strip()
-                    elif 'date_registered:' in line:
-                        dateRegistered = line.split(': ')[1].strip()
-                        dateRegistered = datetime.datetime.fromisoformat(dateRegistered)
-                    elif 'first_name' in line:
-                        firstName = line.split(': ')[1].strip()
-                    elif 'last_name' in line:
-                        lastName = line.split(': ')[1].strip()
-                    elif 'email' in line:
-                        email = line.split(': ')[1].strip()
-                    elif 'last_seen_login' in line:
-                        lastSeen = line.split(': ')[1].strip()
-                        lastSeen = datetime.datetime.fromisoformat(lastSeen)
-                    elif 'registration_time_zone' in line:
-                        timeZone = line.split(': ')[1].strip()
-                    elif 'profile_text' in line:
-                        profileText = line.split(': ')[1].strip()
-                    elif 'is_banned' in line:
-                        isBanned = line.split(': ')[1].strip()
-                    elif 'url' in line:
-                        urlPage = line.split(': ')[1].strip()
-                    elif 'cover_image' in line:
-                        coverImage = line.split(': ')[1].strip()
-                        coverThumb = media_to_html(coverImage,files_found,report_folder)
-                    elif 'profile_image' in line:
-                        profileImage = line.split(': ')[1].strip()
-                        profileThumb = media_to_html(profileImage,files_found,report_folder)
-                    elif '---------------' in line:
-                        data_list_dm.append((userid,dateRegistered,firstName,lastName,email,lastSeen,timeZone,profileText,isBanned,urlPage,coverImage,coverThumb,profileImage,profileThumb))
-                        userid = dateRegistered = firstName = lastName = email = lastSeen = timeZone = profileText = isBanned = urlPage = coverImage = profileImage = profileThumb = coverThumb =''
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Profile ')
-                report.start_artifact_report(report_folder, f'MeWe - Profile - {csvname}')
-                report.add_script()
-                data_headers = ('User ID','Date Registered','First Name','Last Name','Email','Last Seen','Registration TimeZone','Profile Text','Is Banned','MeWe URL','Cover Filename','Cover Media','Profile Filename','Profile Media')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Cover Media','Profile Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Profile - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-            else:
-                logfunc(f'No MeWe - Profile - {csvname}')
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        userid = first_name = last_name = email = time_zone = profile_text = is_banned = url_page = cover_image = profile_image = ''
+        date_registered = last_seen = ''
+        cover_ref = profile_ref = ''
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for line in f:
+                if 'user_id:' in line:
+                    userid = _kv(line)
+                elif 'date_registered:' in line:
+                    date_registered = _mewe_ts(_kv(line))
+                elif 'first_name' in line:
+                    first_name = _kv(line)
+                elif 'last_name' in line:
+                    last_name = _kv(line)
+                elif 'email' in line:
+                    email = _kv(line)
+                elif 'last_seen_login' in line:
+                    last_seen = _mewe_ts(_kv(line))
+                elif 'registration_time_zone' in line:
+                    time_zone = _kv(line)
+                elif 'profile_text' in line:
+                    profile_text = _kv(line)
+                elif 'is_banned' in line:
+                    is_banned = _kv(line)
+                elif 'url' in line:
+                    url_page = _kv(line)
+                elif 'cover_image' in line:
+                    cover_image = _kv(line)
+                    cover_ref = check_in_media(cover_image, cover_image)
+                elif 'profile_image' in line:
+                    profile_image = _kv(line)
+                    profile_ref = check_in_media(profile_image, profile_image)
+                elif '---------------' in line:
+                    data_list.append((userid, date_registered, first_name, last_name, email, last_seen,
+                                      time_zone, profile_text, is_banned, url_page, cover_image, cover_ref,
+                                      profile_image, profile_ref))
+                    userid = first_name = last_name = email = time_zone = profile_text = is_banned = url_page = cover_image = profile_image = ''
+                    date_registered = last_seen = ''
+                    cover_ref = profile_ref = ''
+
+    data_headers = ('User ID', ('Date Registered', 'datetime'), 'First Name', 'Last Name', 'Email',
+                    ('Last Seen', 'datetime'), 'Registration TimeZone', 'Profile Text', 'Is Banned',
+                    'MeWe URL', 'Cover Filename', ('Cover Media', 'media'), 'Profile Filename',
+                    ('Profile Media', 'media'))
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_meweGroupmemberships(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweGroupmemberships(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            data_list_dm =[]
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    groupid = item[0].lstrip('id: ')
-                    groupname = item[1].lstrip('name: ')
-                                                
-                    data_list_dm.append((groupid,groupname))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Group Membership ')
-                report.start_artifact_report(report_folder, f'MeWe - Group Membership - {csvname}')
-                report.add_script()
-                data_headers = ('Group ID','Group Name')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Group Membership - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-            else:
-                logfunc(f'No MeWe - Group Membership - {csvname}')
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if len(item) < 2:
+                    continue
+                data_list.append((_kv(item[0]), _kv(item[1])))
+
+    data_headers = ('Group ID', 'Group Name')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-
-def get_meweEmails(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweEmails(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            data_list_dm =[]
-            with open(file_found, mode = 'r', errors='backslashreplace') as f:
-                delimited = csv.reader(f)
-                for item in delimited:
-                    email = item[0].lstrip('email: ')
-                    timestamp = item[1].lstrip('createdAt: ')
-                    timestamp = datetime.datetime.fromisoformat(timestamp)
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for item in csv.reader(f):
+                if len(item) < 2:
+                    continue
+                data_list.append((_mewe_ts(_kv(item[1])), _kv(item[0])))
 
-                    data_list_dm.append((timestamp,email))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Emails ')
-                report.start_artifact_report(report_folder, f'MeWe - Emails - {csvname}')
-                report.add_script()
-                data_headers = ('Created Date','Email Account')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Emails - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-
-            else:
-                logfunc(f'No MeWe - Emails - {csvname}')
-                
+    data_headers = (('Created Date', 'datetime'), 'Email Account')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-def get_meweDevices(files_found, report_folder, seeker, wrap_text):
-
-
-    for file_found in files_found:
+@artifact_processor
+def meweDevices(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            data_list_dm =[]
-            with open(file_found, mode = 'r', errors='backslashreplace') as f:
-                delimited = csv.reader(f)
-                for item in delimited:
-                    deviceid = item[0].lstrip('deviceId: ')
-                    vendordeviceid = item[1].lstrip('vendorDeviceID: ')
-                    devicetype = item[2].split(': ')[1].strip()
-                    timestamp = item[3].split(': ')[1].strip()
-                    timestamp = datetime.datetime.fromisoformat(timestamp)
-                
-                    data_list_dm.append((devicetype,timestamp,deviceid,vendordeviceid))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Devices ')
-                report.start_artifact_report(report_folder, f'MeWe - Devices - {csvname}')
-                report.add_script()
-                data_headers = ('Device Type','Created Timestamp','Device ID','Vendor Device ID')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Devices - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for item in csv.reader(f):
+                if len(item) < 4:
+                    continue
+                device_id = _kv(item[0])
+                vendor_device_id = _kv(item[1])
+                device_type = _kv(item[2])
+                timestamp = _mewe_ts(_kv(item[3]))
+                data_list.append((device_type, timestamp, device_id, vendor_device_id))
 
-            else:
-                logfunc(f'No MeWe - Devices - {csvname}')
-                
-
-def get_meweContacts(files_found, report_folder, seeker, wrap_text):
+    data_headers = ('Device Type', ('Created Timestamp', 'datetime'), 'Device ID', 'Vendor Device ID')
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
-    for file_found in files_found:
+@artifact_processor
+def meweContacts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-    
-        filename = os.path.basename(file_found)
-        csvname = filename
-        
-        if file_found.endswith('.txt'):
-            data_list_dm =[]
-            with open(file_found, encoding = 'utf-8', mode = 'r', errors='backslashreplace') as f:
-                delimited = csv.reader(f, delimiter=',')
-                for item in delimited:
-                    userid = item[0].lstrip('_id: ')
-                    username = item[1].lstrip('contactUserName: ')
-                
-                    data_list_dm.append((userid,username))
-                        
-        
-            if data_list_dm:
-                report = ArtifactHtmlReport(f'MeWe - Contacts ')
-                report.start_artifact_report(report_folder, f'MeWe - Contacts - {csvname}')
-                report.add_script()
-                data_headers = ('User ID','Username')
-                report.write_artifact_data_table(data_headers, data_list_dm, file_found, html_no_escape=['Media'])
-                report.end_artifact_report()
-                
-                tsvname = f'MeWe - Contacts - {csvname}'
-                tsv(report_folder, data_headers, data_list_dm, tsvname)
-                
-            else:
-                logfunc(f'No MeWe - Contacts - {csvname}')
-                
+        if not file_found.endswith('.txt'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8', mode='r', errors='backslashreplace') as f:
+            for item in csv.reader(f, delimiter=','):
+                if len(item) < 2:
+                    continue
+                data_list.append((_kv(item[0]), _kv(item[1])))
+
+    data_headers = ('User ID', 'Username')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts all 10 MeWe warrant-return artifacts in `scripts/artifacts/meweReturns.py` from legacy `ArtifactHtmlReport` bodies to the context-form `@artifact_processor` LAVA pipeline (Contacts, Devices, Email Accounts, Group Memberships, Profile, Group Chat, Posts, Chat Posts, Login Stats, Login Logs).

**Changes**
- Context form; `context.get_relative_path` on source paths.
- Aware-UTC datetimes via ISO parsing; naive values assumed UTC (warrant-return convention), unparseable values kept verbatim.
- Media via `check_in_media` into typed `('Media','media')` columns (replacing `media_to_html`); multi-attachment chat cells carry a list of refs.
- Robust `key: value` field splitting so values containing `': '` (IPv6 addresses, timestamps, URLs, text) are no longer truncated by the original `lstrip()`/`split(': ')` logic.
- Fixes the userChat documents glob typo (`**mewe-content` -> `**/mewe-content`) and the Login Stats `IP Adress` header typo.
- Preserves original attribution (Troy Schnack, @TheBaldJedi).

**Validation**: pylint `--disable=C,R` = 10.00; reserved-word audit clean; PluginLoader loads all 10; synthetic `__wrapped__` smoke test confirmed aware-UTC datetimes and the `: `-in-value fix.