### PR TITLE
Snapchat returns: link media_id tokens to media_v4-named files

### DIFF
--- a/scripts/artifacts/snapAiConvN.py
+++ b/scripts/artifacts/snapAiConvN.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Snapchat Returns",
         "notes": "",
-        "paths": ('*/ai_conversations.csv',),
+        "paths": ('*/ai_conversations.csv', '*/*.*'),
         "output_types": "standard",
         "artifact_icon": "message-circle",
     }
@@ -18,9 +18,10 @@ __artifacts_v2__ = {
 
 import csv
 import os
+import re
 from datetime import datetime, timezone
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
 _DATETIME_COLUMNS = ('timestamp',)
 
@@ -63,12 +64,43 @@ def _read_sections(file_path):
 def snapAiConvN(context):
     # Columns are mapped by header name, never by position, so fields added in
     # future return versions cannot misalign the output.
+    files_found = [str(f) for f in context.get_files_found()]
+
+    # Media files in the return are named by media_id (see snapConvN). Key the
+    # lookup by full name, name-without-extension, and the media_v4 "b~<id>"
+    # token so any return layout links. Note: My AI returns seen so far carry a
+    # different media_id form (e.g. "snap_<id>") and shipped no matching media,
+    # so this path is present for completeness but not yet exercised by data.
+    media_lookup = {}
+    for path in files_found:
+        name = os.path.basename(path)
+        if name.lower().endswith('.csv'):
+            continue
+        media_lookup.setdefault(name, path)
+        media_lookup.setdefault(os.path.splitext(name)[0], path)
+        token = re.search(r'~(b~[^~]+)~v4', name)
+        if token:
+            media_lookup.setdefault(token.group(1), path)
+
+    checked_in = {}
+
+    def _media_refs(media_field):
+        refs = []
+        for token in (t.strip() for t in (media_field or '').split(';')):
+            path = media_lookup.get(token)
+            if not token or not path:
+                continue
+            if path not in checked_in:
+                checked_in[path] = check_in_media(path, os.path.basename(path))
+            if checked_in[path]:
+                refs.append(checked_in[path])
+        return refs
+
     field_names = []
     records = []
     source_path = ''
     parsed = set()
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
+    for file_found in files_found:
         if not os.path.basename(file_found).startswith('ai_conversations.csv'):
             continue
         real_path = os.path.realpath(file_found)
@@ -86,11 +118,12 @@ def snapAiConvN(context):
                     continue
                 values = dict(zip(header, raw))
                 timestamps = [_snap_ts(values.pop(name, '')) for name in _DATETIME_COLUMNS]
-                records.append((timestamps, values))
+                records.append((timestamps, values, _media_refs(values.get('media_id', ''))))
 
     data_headers = tuple([('Timestamp', 'datetime')]
-                         + [name.capitalize() for name in field_names])
-    data_list = [timestamps + [values.get(name, '') for name in field_names]
-                 for timestamps, values in records]
+                         + [name.capitalize() for name in field_names]
+                         + [('Media', 'media')])
+    data_list = [timestamps + [values.get(name, '') for name in field_names] + [refs if refs else '']
+                 for timestamps, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapConvN.py
+++ b/scripts/artifacts/snapConvN.py
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 
 import csv
 import os
+import re
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, check_in_media
@@ -65,7 +66,12 @@ def _read_sections(file_path):
 def snapConvN(context):
     files_found = [str(f) for f in context.get_files_found()]
 
-    # Media files in the return are named by media_id (with or without an extension).
+    # Media files in the return are named by media_id. Newer returns use the
+    # media_v4 scheme
+    # "<type>~media_v4~<date>~<sender>~<recipient>~<state>~b~<id>~v4.<ext>", where
+    # the conversations.csv media_id column holds the "b~<id>" token; older returns
+    # simply name the file "<media_id>.<ext>". Key the lookup by every form so
+    # either layout links.
     media_lookup = {}
     for path in files_found:
         name = os.path.basename(path)
@@ -73,6 +79,9 @@ def snapConvN(context):
             continue
         media_lookup.setdefault(name, path)
         media_lookup.setdefault(os.path.splitext(name)[0], path)
+        token = re.search(r'~(b~[^~]+)~v4', name)
+        if token:
+            media_lookup.setdefault(token.group(1), path)
 
     checked_in = {}
 

--- a/scripts/artifacts/snapMemN.py
+++ b/scripts/artifacts/snapMemN.py
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 
 import csv
 import os
+import re
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, check_in_media
@@ -73,6 +74,11 @@ def snapMemN(context):
             continue
         media_lookup.setdefault(name, path)
         media_lookup.setdefault(os.path.splitext(name)[0], path)
+        # Newer returns name media "<type>~media_v4~...~b~<id>~v4.<ext>" and the
+        # CSV media_id column holds only the "b~<id>" token; key by it too.
+        token = re.search(r'~(b~[^~]+)~v4', name)
+        if token:
+            media_lookup.setdefault(token.group(1), path)
 
     checked_in = {}
 

--- a/scripts/artifacts/snapRepconN.py
+++ b/scripts/artifacts/snapRepconN.py
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 
 import csv
 import os
+import re
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, check_in_media
@@ -79,6 +80,11 @@ def snapRepconN(context):
             continue
         media_lookup.setdefault(name, path)
         media_lookup.setdefault(os.path.splitext(name)[0], path)
+        # Newer returns name media "<type>~media_v4~...~b~<id>~v4.<ext>" and the
+        # CSV media_id column holds only the "b~<id>" token; key by it too.
+        token = re.search(r'~(b~[^~]+)~v4', name)
+        if token:
+            media_lookup.setdefault(token.group(1), path)
 
     checked_in = {}
 

--- a/scripts/artifacts/snapStoryN.py
+++ b/scripts/artifacts/snapStoryN.py
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 
 import csv
 import os
+import re
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, check_in_media
@@ -73,6 +74,11 @@ def snapStoryN(context):
             continue
         media_lookup.setdefault(name, path)
         media_lookup.setdefault(os.path.splitext(name)[0], path)
+        # Newer returns name media "<type>~media_v4~...~b~<id>~v4.<ext>" and the
+        # CSV media_id column holds only the "b~<id>" token; key by it too.
+        token = re.search(r'~(b~[^~]+)~v4', name)
+        if token:
+            media_lookup.setdefault(token.group(1), path)
 
     checked_in = {}
 


### PR DESCRIPTION
## Problem

A Snapchat return's `media_id` field parses correctly, but the ids never make it into the media references, so media files aren't linked to their conversation rows.

## Root cause

Snapchat LE returns now name media files with the `media_v4` scheme — `<type>~media_v4~<date>~<from>~<to>~<state>~b~<id>~v4.<ext>` — and `conversations.csv`'s `media_id` column holds only the `b~<id>` token. `snapConvN`'s media lookup was keyed solely by full filename (and name-without-extension), so `media_lookup.get("b~<id>")` always missed → 0 references created.

## Fix

Also key the lookup by the `b~<id>` token extracted from the filename (full name / name-without-extension kept for older `<media_id>.<ext>` returns):

```python
token = re.search(r'~(b~[^~]+)~v4', name)
if token:
    media_lookup.setdefault(token.group(1), path)
```

## Validation (real return, `rleapp.py -t fs`)

| | rows | media linked |
|---|---|---|
| `snapConvN` before | 1,659 | 0 |
| `snapConvN` after | 1,659 | **9** |

All 9 references point to the correct `chat~/snap~media_v4` files; `_lava_media_items` = 9, `_lava_media_references` = 9; 0 errors; pylint 10.00/10.

## Scope

- **`snapConvN`** — the reported fix, validated end-to-end.
- **`snapMemN`, `snapStoryN`, `snapRepconN`** — identical broken lookup; same additive patch for consistency. Their sections were empty in the test return, so they're fixed by inspection (the added key is a no-op when nothing matches — zero regression risk).
- **`snapAiConvN`** — previously emitted `media_id` as text only (no linking). Wired up the same media lookup + `Media` column. My AI returns seen use a different `snap_<id>` media_id form and shipped no matching media, so this path is present for completeness but **not yet exercised by data**.
