### PR TITLE
Snapchat returns: emit single media reference as a bare id so LAVA renders it

### DIFF
--- a/scripts/artifacts/snapAiConvN.py
+++ b/scripts/artifacts/snapAiConvN.py
@@ -123,7 +123,10 @@ def snapAiConvN(context):
     data_headers = tuple([('Timestamp', 'datetime')]
                          + [name.capitalize() for name in field_names]
                          + [('Media', 'media')])
-    data_list = [timestamps + [values.get(name, '') for name in field_names] + [refs if refs else '']
+    # A single media reference is emitted as a bare id (what the LAVA viewer
+    # resolves); a list is kept only when a record links more than one file.
+    data_list = [timestamps + [values.get(name, '') for name in field_names]
+                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
                  for timestamps, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapConvN.py
+++ b/scripts/artifacts/snapConvN.py
@@ -126,7 +126,10 @@ def snapConvN(context):
     data_headers = tuple([('Timestamp', 'datetime')]
                          + [name.capitalize() for name in field_names]
                          + [('Media', 'media')])
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+    # A single media reference is emitted as a bare id (what the LAVA viewer
+    # resolves); a list is kept only when a message links more than one file.
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
+                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapMemN.py
+++ b/scripts/artifacts/snapMemN.py
@@ -126,7 +126,10 @@ def snapMemN(context):
     data_headers = tuple([('Timestamp', 'datetime')]
                          + [name.capitalize() for name in field_names]
                          + [('Media', 'media')])
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+    # A single media reference is emitted as a bare id (what the LAVA viewer
+    # resolves); a list is kept only when a record links more than one file.
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
+                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapRepconN.py
+++ b/scripts/artifacts/snapRepconN.py
@@ -136,7 +136,10 @@ def snapRepconN(context):
     data_headers = tuple([('Timestamp', 'datetime')]
                          + [_column(name) for name in field_names]
                          + [('Media', 'media')])
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+    # A single media reference is emitted as a bare id (what the LAVA viewer
+    # resolves); a list is kept only when a record links more than one file.
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
+                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapStoryN.py
+++ b/scripts/artifacts/snapStoryN.py
@@ -125,7 +125,10 @@ def snapStoryN(context):
     data_headers = tuple([('Timestamp', 'datetime')]
                          + [name.capitalize() for name in field_names]
                          + [('Media', 'media')])
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names] + [refs if refs else '']
+    # A single media reference is emitted as a bare id (what the LAVA viewer
+    # resolves); a list is kept only when a record links more than one file.
+    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
+                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Follow-up to #369. Media now links correctly and renders in the HTML report, but the LAVA viewer showed the red broken-media icon on every media row.

## Cause
LAVA's `RenderMedia.jsx` resolves a **single** ref-id string via `getMediaDetails(id)`, and `DataRenderer.jsx` passes the media cell value through unchanged. RLEAPP stored a message's media cell as a JSON list even for a single file (`["<id>"]`), so `getMediaDetails(["<id>"])` matches nothing and LAVA falls back to the broken-media glyph. (Tracked upstream as abrignoni/LAVA#143.)

## Fix
Emit a **bare id** when a record links exactly one media file; keep a list only for genuine multi-media:
```python
(refs[0] if len(refs) == 1 else refs) if refs else ''
```
This matches how artifacts that already render in LAVA format their media cell, and the HTML/TSV path is unaffected (`get_data_list_with_media` wraps a bare string automatically). Applied across the Snapchat return family: `snapConvN`, `snapMemN`, `snapStoryN`, `snapRepconN`, `snapAiConvN`.

## Validation
`snapConvN` on a real return: the media cell is now the bare id `db985d…` (was `["db985d…"]`), which matches `_lava_media_references.id` that LAVA looks up; 9/9 media still link; HTML thumbnails still render; pylint 10.00; 0 errors.

## Caveat
This fixes the common **single-media** case. A message that links **2+ files** still emits a list and stays subject to [LAVA #143](https://github.com/abrignoni/LAVA/issues/143), which is the proper array-handling fix on the viewer side.
