### PR TITLE
Snapchat returns: move the Media column near the front

### DIFF
--- a/scripts/artifacts/snapAiConvN.py
+++ b/scripts/artifacts/snapAiConvN.py
@@ -120,13 +120,13 @@ def snapAiConvN(context):
                 timestamps = [_snap_ts(values.pop(name, '')) for name in _DATETIME_COLUMNS]
                 records.append((timestamps, values, _media_refs(values.get('media_id', ''))))
 
-    data_headers = tuple([('Timestamp', 'datetime')]
-                         + [name.capitalize() for name in field_names]
-                         + [('Media', 'media')])
+    # Media is placed right after Timestamp for readability.
+    data_headers = tuple([('Timestamp', 'datetime'), ('Media', 'media')]
+                         + [name.capitalize() for name in field_names])
     # A single media reference is emitted as a bare id (what the LAVA viewer
     # resolves); a list is kept only when a record links more than one file.
-    data_list = [timestamps + [values.get(name, '') for name in field_names]
-                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
+    data_list = [timestamps + [(refs[0] if len(refs) == 1 else refs) if refs else '']
+                 + [values.get(name, '') for name in field_names]
                  for timestamps, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapConvN.py
+++ b/scripts/artifacts/snapConvN.py
@@ -121,15 +121,31 @@ def snapConvN(context):
                     continue
                 values = dict(zip(header, raw))
                 timestamp = _snap_ts(values.pop('timestamp', ''))
-                records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
+                refs = _media_refs(values.get('media_id', ''))
+                # A single media reference is emitted as a bare id (what the LAVA
+                # viewer resolves); a list is kept only for multi-media messages.
+                media = (refs[0] if len(refs) == 1 else refs) if refs else ''
+                records.append((timestamp, values, media))
 
-    data_headers = tuple([('Timestamp', 'datetime')]
-                         + [name.capitalize() for name in field_names]
-                         + [('Media', 'media')])
-    # A single media reference is emitted as a bare id (what the LAVA viewer
-    # resolves); a list is kept only when a message links more than one file.
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
-                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
-                 for timestamp, values, refs in records]
+    # Promote Media and the key participant/content columns to just after
+    # message_type for readability; the rest keep their return (file) order.
+    # Falls back to appending them last if message_type is absent in a return.
+    promoted = [c for c in ('sender_username', 'recipient_username', 'text') if c in field_names]
+    ordered = []
+    for name in field_names:
+        if name in promoted:
+            continue
+        ordered.append(name)
+        if name == 'message_type':
+            ordered += ['__media__'] + promoted
+    if '__media__' not in ordered:
+        ordered += ['__media__'] + promoted
+
+    data_headers = tuple([('Timestamp', 'datetime')] + [
+        ('Media', 'media') if name == '__media__' else name.capitalize() for name in ordered])
+    data_list = [
+        [timestamp] + [media if name == '__media__' else values.get(name, '')
+                       for name in ordered]
+        for timestamp, values, media in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapMemN.py
+++ b/scripts/artifacts/snapMemN.py
@@ -123,13 +123,13 @@ def snapMemN(context):
                 timestamp = _snap_ts(values.pop('timestamp', ''))
                 records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
 
-    data_headers = tuple([('Timestamp', 'datetime')]
-                         + [name.capitalize() for name in field_names]
-                         + [('Media', 'media')])
+    # Media is placed right after Timestamp for readability.
+    data_headers = tuple([('Timestamp', 'datetime'), ('Media', 'media')]
+                         + [name.capitalize() for name in field_names])
     # A single media reference is emitted as a bare id (what the LAVA viewer
     # resolves); a list is kept only when a record links more than one file.
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
-                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
+    data_list = [[timestamp, (refs[0] if len(refs) == 1 else refs) if refs else '']
+                 + [values.get(name, '') for name in field_names]
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapRepconN.py
+++ b/scripts/artifacts/snapRepconN.py
@@ -133,13 +133,13 @@ def snapRepconN(context):
                     values['message_timestamp'] = _snap_ts(values['message_timestamp'])
                 records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
 
-    data_headers = tuple([('Timestamp', 'datetime')]
-                         + [_column(name) for name in field_names]
-                         + [('Media', 'media')])
+    # Media is placed right after Timestamp for readability.
+    data_headers = tuple([('Timestamp', 'datetime'), ('Media', 'media')]
+                         + [_column(name) for name in field_names])
     # A single media reference is emitted as a bare id (what the LAVA viewer
     # resolves); a list is kept only when a record links more than one file.
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
-                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
+    data_list = [[timestamp, (refs[0] if len(refs) == 1 else refs) if refs else '']
+                 + [values.get(name, '') for name in field_names]
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/snapStoryN.py
+++ b/scripts/artifacts/snapStoryN.py
@@ -122,13 +122,13 @@ def snapStoryN(context):
                 timestamp = _snap_ts(values.pop('timestamp', ''))
                 records.append((timestamp, values, _media_refs(values.get('media_id', ''))))
 
-    data_headers = tuple([('Timestamp', 'datetime')]
-                         + [name.capitalize() for name in field_names]
-                         + [('Media', 'media')])
+    # Media is placed right after Timestamp for readability.
+    data_headers = tuple([('Timestamp', 'datetime'), ('Media', 'media')]
+                         + [name.capitalize() for name in field_names])
     # A single media reference is emitted as a bare id (what the LAVA viewer
     # resolves); a list is kept only when a record links more than one file.
-    data_list = [[timestamp] + [values.get(name, '') for name in field_names]
-                 + [(refs[0] if len(refs) == 1 else refs) if refs else '']
+    data_list = [[timestamp, (refs[0] if len(refs) == 1 else refs) if refs else '']
+                 + [values.get(name, '') for name in field_names]
                  for timestamp, values, refs in records]
 
     return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
The Media (thumbnail) column was appended last, so it sat far right in the HTML report and — because of the very wide `media_id` column — around column 28 in LAVA, requiring lots of scrolling/column-hiding to see. This moves it forward.

- **snapConvN** — `Media, Sender_username, Recipient_username, Text` placed right after `Message_type` (requested layout).
- **snapMemN / snapStoryN / snapRepconN / snapAiConvN** — `Media` placed right after `Timestamp` (these returns don't have the conversation-style sender/recipient/text columns, so Media just leads).

Applies to **every output** (HTML, LAVA, TSV) since the order comes from `data_headers` — consistent everywhere, and Media is now easy to find in the LAVA table too.

**Validation:** pylint 10.00 on all 5; real return run — `snapconvn` Media at column 4, `snapaiconvn` Media at column 2, media still links (9/9), 0 errors.
