### PR TITLE
RLEAPP: migrate feather icon names to native Tabler names (94 across 72 files)

### DIFF
--- a/scripts/artifacts/chaseReturnsRTL.py
+++ b/scripts/artifacts/chaseReturnsRTL.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
                  "the rows map (KML).",
         "paths": ('*.pdf',),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
-        "artifact_icon": "log-in",
+        "artifact_icon": "login-2",
     },
     "chaseAccountInfo": {
         "name": "Chase - Account Information",

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -62,7 +62,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Chrome/Device Information.json",
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     },
     "chrome_extensions": {
         "name": "Chrome - Extensions",
@@ -88,7 +88,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Chrome/BrowserHistory.json",
         "output_types": "standard",
-        "artifact_icon": "chrome",
+        "artifact_icon": "brand-chrome",
     },
     "chrome_os_settings": {
         "name": "Chrome - OS Settings",
@@ -127,7 +127,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Chrome/Autofill.json",
         "output_types": "standard",
-        "artifact_icon": "edit-3",
+        "artifact_icon": "pencil-minus",
     },
 }
 

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Chrome/Autofill.json'),
         "output_types": "standard",
-        "artifact_icon": "edit-3",
+        "artifact_icon": "pencil-minus",
     }
 }
 

--- a/scripts/artifacts/chromeDeviceInfo.py
+++ b/scripts/artifacts/chromeDeviceInfo.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Chrome/Device Information.json'),
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     }
 }
 

--- a/scripts/artifacts/chromeHistory.py
+++ b/scripts/artifacts/chromeHistory.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Chrome/BrowserHistory.json'),
         "output_types": "standard",
-        "artifact_icon": "chrome",
+        "artifact_icon": "brand-chrome",
     }
 }
 

--- a/scripts/artifacts/discordReturnsserver.py
+++ b/scripts/artifacts/discordReturnsserver.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/attachments/*.*', '*/messages/servers/*.csv'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/dmlPinger.py
+++ b/scripts/artifacts/dmlPinger.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*DML.xlsx',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/facebookE2EMessages.py
+++ b/scripts/artifacts/facebookE2EMessages.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*.json','*/media/*',),
         "output_types": "standard",
-        'artifact_icon': 'message-square',
+        'artifact_icon': 'message',
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Thread',

--- a/scripts/artifacts/fbigAccountInfo.py
+++ b/scripts/artifacts/fbigAccountInfo.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "Flat Key/Value table; date/phone values stay as raw text (the Value column is heterogeneous and can't be column-typed).",
         "paths": ('*/records.html', '*/preservation*.html', '*/linked_media/profile_picture_*.jpg'),
         "output_types": "standard",
-        "artifact_icon": "info",
+        "artifact_icon": "info-circle",
     }
 }
 

--- a/scripts/artifacts/fbigArchiveStories.py
+++ b/scripts/artifacts/fbigArchiveStories.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/index.html', '*/preservation*.html', '*/linked_media/archived_stories_*'),
         "output_types": "standard",
-        "artifact_icon": "book-open",
+        "artifact_icon": "book",
     }
 }
 

--- a/scripts/artifacts/fbigDevices.py
+++ b/scripts/artifacts/fbigDevices.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/index.html', '*/preservation*.html'),
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     }
 }
 

--- a/scripts/artifacts/fbigLikes.py
+++ b/scripts/artifacts/fbigLikes.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/records.html', '*/preservation*.html'),
         "output_types": "standard",
-        "artifact_icon": "thumbs-up",
+        "artifact_icon": "thumb-up",
     }
 }
 

--- a/scripts/artifacts/fbigPhotos.py
+++ b/scripts/artifacts/fbigPhotos.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/records.html', '*/preservation*.html', '*/linked_media/*.*'),
         "output_types": "standard",
         "html_columns": ["Caption", "Comments", "Location"],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/fbigUnifiedmessaging.py
+++ b/scripts/artifacts/fbigUnifiedmessaging.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/records.html', '*/preservation*.html', '*/linked_media/*.*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "fbigThreadParticipants": {
         "name": "Facebook Instagram Returns - Thread Participants",

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/Google Chat/Groups/*/**',),
         "output_types": "standard",
         "html_columns": ["Group Members"],
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/googleMyactisearch.py
+++ b/scripts/artifacts/googleMyactisearch.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
         "paths": ('*/*MyActivity.MyActivity_*/My Activity/Image Search/MyActivity.html',),
         "output_types": "standard",
         "html_columns": ["Image Search Activity"],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/googlePayTransactions.py
+++ b/scripts/artifacts/googlePayTransactions.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "Transaction Timestamp is preserved as the raw source value (Takeout CSV format is locale-dependent; not normalized to UTC).",
         "paths": ('*/Google Pay/Google transactions/transactions_*.csv'),
         "output_types": "standard",
-        "artifact_icon": "dollar-sign",
+        "artifact_icon": "currency-dollar",
     }
 }
 

--- a/scripts/artifacts/googlePlaystoredevices.py
+++ b/scripts/artifacts/googlePlaystoredevices.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
                  "(TEXT) since the column set varies per return.",
         "paths": ('*/*GooglePlayStore.Devices_*/Google Play Store/Devices.csv',),
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     }
 }
 

--- a/scripts/artifacts/googleYoutubsuninf.py
+++ b/scripts/artifacts/googleYoutubsuninf.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
         "paths": ('*/*YoutubeAndYoutubeMusic.BasicSubscriberInfo_*/YouTube and YouTube Music/'
                   'Data for User */Basic Subscriber Info/Basic Subscriber Info.csv',),
         "output_types": "standard",
-        "artifact_icon": "youtube",
+        "artifact_icon": "brand-youtube",
     }
 }
 

--- a/scripts/artifacts/google_health.py
+++ b/scripts/artifacts/google_health.py
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Stress Score/Stress Score.csv",
         "output_types": "standard",
-        "artifact_icon": "meh",
+        "artifact_icon": "mood-empty",
     },
     "fitbit_profile": {
         "name": "Google Health (Fitbit) - Account Profile",
@@ -62,7 +62,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Paired Devices/Trackers.csv",
         "output_types": "standard",
-        "artifact_icon": "watch",
+        "artifact_icon": "device-watch",
     },
     "fitbit_goals": {
         "name": "Google Health (Fitbit) - Activity Goals",

--- a/scripts/artifacts/google_playstore.py
+++ b/scripts/artifacts/google_playstore.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Google Play Store/Devices.json",
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     },
     "playstore_library": {
         "name": "Google Play Store - Library",
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": "*/Google Play Store/Reviews.json",
         "output_types": "standard",
-        "artifact_icon": "edit-3",
+        "artifact_icon": "pencil-minus",
     },
     "playstore_subscriptions": {
         "name": "Google Play Store - Subscriptions",

--- a/scripts/artifacts/google_tasks.py
+++ b/scripts/artifacts/google_tasks.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Tasks/Tasks.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "check-circle",
+        "artifact_icon": "circle-check",
     }
 }
 

--- a/scripts/artifacts/icloudMsgsInCloud.py
+++ b/scripts/artifacts/icloudMsgsInCloud.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Messagesinicloud/*MessagesInICloud*', '*/Messages/MessagesInICloud*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/icloudReturnsAcc.py
+++ b/scripts/artifacts/icloudReturnsAcc.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/Account/*_AccountDetails.xlsx',),
         "output_types": "standard",
-        "artifact_icon": "sliders",
+        "artifact_icon": "adjustments-alt",
     }
 }
 

--- a/scripts/artifacts/icloudReturnsphotolibrary.py
+++ b/scripts/artifacts/icloudReturnsphotolibrary.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/*/cloudphotolibrary/*',),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
         "html_columns": ["Exif"],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/instagramAccinfo.py
+++ b/scripts/artifacts/instagramAccinfo.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/account_information/account_information.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramAdsclicked.py
+++ b/scripts/artifacts/instagramAdsclicked.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/ads_clicked.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramAdsviewed.py
+++ b/scripts/artifacts/instagramAdsviewed.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/ads_viewed.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramBlocked.py
+++ b/scripts/artifacts/instagramBlocked.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/followers_and_following/blocked_accounts.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramDevices.py
+++ b/scripts/artifacts/instagramDevices.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/device_information/devices.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramDevicescam.py
+++ b/scripts/artifacts/instagramDevicescam.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/device_information/camera_information.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramFollowers.py
+++ b/scripts/artifacts/instagramFollowers.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/followers_and_following/followers.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramFollowing.py
+++ b/scripts/artifacts/instagramFollowing.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/followers_and_following/following.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramInfotoadv.py
+++ b/scripts/artifacts/instagramInfotoadv.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ("*/ads_and_businesses/information_you've_submitted_to_advertisers.json"),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramInterests.py
+++ b/scripts/artifacts/instagramInterests.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/information_about_you/ads_interests.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramLikedcomm.py
+++ b/scripts/artifacts/instagramLikedcomm.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/likes/liked_comments.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramLogin.py
+++ b/scripts/artifacts/instagramLogin.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/login_and_account_creation/login_activity.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramLogout.py
+++ b/scripts/artifacts/instagramLogout.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/login_and_*_creation/logout_activity.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramMessageReq.py
+++ b/scripts/artifacts/instagramMessageReq.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/messages/message_requests/*'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
         "html_columns": ['Media','Reactions'],
     }
 }

--- a/scripts/artifacts/instagramMessages.py
+++ b/scripts/artifacts/instagramMessages.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/messages/inbox/*'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
         "html_columns": ['Media','Reactions'],
     }
 }

--- a/scripts/artifacts/instagramMusicheard.py
+++ b/scripts/artifacts/instagramMusicheard.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/music_heard_in_stories.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramNointerest.py
+++ b/scripts/artifacts/instagramNointerest.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/*re_not_interested_in.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPasswordchange.py
+++ b/scripts/artifacts/instagramPasswordchange.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/login_and_account_creation/password_change_activity.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPending.py
+++ b/scripts/artifacts/instagramPending.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/followers_and_following/pending_follow_requests.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPersinfo.py
+++ b/scripts/artifacts/instagramPersinfo.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*_information/personal_information.json', '*/media/other/*.jpg'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPolls.py
+++ b/scripts/artifacts/instagramPolls.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/story_sticker_interactions/polls.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPostcom.py
+++ b/scripts/artifacts/instagramPostcom.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/comments/post_comments.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPosts.py
+++ b/scripts/artifacts/instagramPosts.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/content/posts_1.json', '*/media/*'),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPostsviewed.py
+++ b/scripts/artifacts/instagramPostsviewed.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/posts_viewed.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramPrivacychange.py
+++ b/scripts/artifacts/instagramPrivacychange.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/login_and_account_creation/account_privacy_changes.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramProfchanges.py
+++ b/scripts/artifacts/instagramProfchanges.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/account_information/profile_changes.json'),
         "output_types": "standard",
         "html_columns": ["Items"],
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramRecentreq.py
+++ b/scripts/artifacts/instagramRecentreq.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/followers_and_following/recent_follow_requests.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramRemovedsug.py
+++ b/scripts/artifacts/instagramRemovedsug.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/followers_and_following/removed_suggestions.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramSavedposts.py
+++ b/scripts/artifacts/instagramSavedposts.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/saved/saved_posts.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramSearches.py
+++ b/scripts/artifacts/instagramSearches.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/recent_searches/account_searches.json'),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramStories.py
+++ b/scripts/artifacts/instagramStories.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/content/stories.json', '*/media/stories/*'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramSuggestedviewed.py
+++ b/scripts/artifacts/instagramSuggestedviewed.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/suggested_accounts_viewed.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/instagramVideoswatched.py
+++ b/scripts/artifacts/instagramVideoswatched.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/ads_and_content/videos_watched.json'),
         "output_types": "standard",
-        "artifact_icon": "instagram",
+        "artifact_icon": "brand-instagram",
     }
 }
 

--- a/scripts/artifacts/kik.py
+++ b/scripts/artifacts/kik.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "paths": ('*/package/subscriber-data-*.pdf',),
         "output_types": "standard",
         "html_columns": ['Profile Pic URL'],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
     "kik_subscriber_events": {
         "name": "Kik - Subscriber Events",
@@ -63,7 +63,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/content/data-text.csv",
         "paths": ('*/package/content/data-text.csv',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "kik_chat_media": {
         "name": "Kik - Chat Messages (Media)",
@@ -76,7 +76,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/content/data-media.csv. Filenames in medias/ folder are Base64-encoded.",
         "paths": ('*/package/content/data-media.csv', '*/package/content/medias/*'),
         "output_types": "standard",
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
     "kik_chat_sent": {
         "name": "Kik - Sent Chats (Log)",
@@ -89,7 +89,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/logs/chat_sent.csv",
         "paths": ('*/package/logs/chat_sent.csv',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "kik_chat_sent_received": {
         "name": "Kik - Sent and Received Chats (Log)",
@@ -102,7 +102,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/logs/chat_sent_received.csv",
         "paths": ('*/package/logs/chat_sent_received.csv',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "kik_chat_platform_sent": {
         "name": "Kik - Platform Chat Sent (Log)",
@@ -115,7 +115,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/logs/chat_platform_sent.csv",
         "paths": ('*/package/logs/chat_platform_sent.csv',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "kik_chat_platform_sent_received": {
         "name": "Kik - Platform Chat Sent and Received (Log)",
@@ -128,7 +128,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/logs/chat_platform_sent_received.csv",
         "paths": ('*/package/logs/chat_platform_sent_received.csv',),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "kik_group_receive": {
         "name": "Kik - Group Messages Received (Log)",
@@ -193,7 +193,7 @@ __artifacts_v2__ = {
         "notes": "Located at package/logs/binds.csv",
         "paths": ('*/package/logs/binds.csv',),
         "output_types": "standard",
-        "artifact_icon": "smartphone"
+        "artifact_icon": "device-mobile"
     },
 }
 

--- a/scripts/artifacts/snapAccountinfo.py
+++ b/scripts/artifacts/snapAccountinfo.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
         "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
         "last_update_date": "2026-06-28", "requirements": "none",
         "category": "Snapchat Archive", "notes": "",
-        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "smartphone",
+        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "device-mobile",
     },
     "snapArchiveDeviceHistory": {
         "name": "Snapchat - Device History",
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
         "author": "@AlexisBrignoni", "creation_date": "2023-12-11",
         "last_update_date": "2026-06-28", "requirements": "none",
         "category": "Snapchat Archive", "notes": "",
-        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "log-in",
+        "paths": ('*/account.json',), "output_types": "standard", "artifact_icon": "login-2",
     }
 }
 

--- a/scripts/artifacts/snapChathistory.py
+++ b/scripts/artifacts/snapChathistory.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/chat_history.json',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Other Party",

--- a/scripts/artifacts/snapConvN.py
+++ b/scripts/artifacts/snapConvN.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/conversations.csv', '*/*.*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/snapIncCom.py
+++ b/scripts/artifacts/snapIncCom.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/snap_inc_communications.csv',),
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     },
     "snapIncComAppeals": {
         "name": "Snapchat - In App Appeals",

--- a/scripts/artifacts/snapMemN.py
+++ b/scripts/artifacts/snapMemN.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/memories.csv', '*/*.*'),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/snapStoryN.py
+++ b/scripts/artifacts/snapStoryN.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/story.csv', '*/*.*'),
         "output_types": "standard",
-        "artifact_icon": "book-open",
+        "artifact_icon": "book",
     }
 }
 

--- a/scripts/artifacts/snapSubinfo.py
+++ b/scripts/artifacts/snapSubinfo.py
@@ -30,7 +30,7 @@ __artifacts_v2__ = {
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
         "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
-        "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "info",
+        "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "info-circle",
     },
     "snapSubPrivacy": {
         "name": "Snapchat - Privacy Settings",
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
         "author": "@AlexisBrignoni", "creation_date": "2024-06-13",
         "last_update_date": "2026-07-09", "requirements": "none",
         "category": "Snapchat Returns", "notes": "",
-        "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "smile",
+        "paths": ('*/subscriber_info.csv',), "output_types": "standard", "artifact_icon": "mood-smile",
     }
 }
 

--- a/scripts/artifacts/synchronoss.py
+++ b/scripts/artifacts/synchronoss.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/messages/2*.csv',),
         "output_types": "standard",
         "html_columns": ['Recipients'],
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "synchronoss_calls": {
         "name": "Synchronoss - Calls",
@@ -41,7 +41,7 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "html_columns": ['Recipients'],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "synchronoss_mms_sent": {
         "name": "Synchronoss - MMS Media Sent",
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "html_columns": ['Recipients'],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "synchronoss_mms_unlinked": {
         "name": "Synchronoss - MMS Folder Media (Unlinked)",
@@ -122,7 +122,7 @@ __artifacts_v2__ = {
                  "Sync rows show device activity without a specific file upload.",
         "paths": ('*[Dd][Vv] [Aa]ccess [Ll]ogs*.csv',),
         "output_types": "standard",
-        "artifact_icon": "refresh-cw",
+        "artifact_icon": "refresh",
     },
     "synchronoss_vzmobile": {
         "name": "Synchronoss - VZMOBILE Device Backup",
@@ -136,7 +136,7 @@ __artifacts_v2__ = {
                  "Files are PNG device backups. Date folder = upload date per Synchronoss FAQ.",
         "paths": ('*/VZMOBILE/*/*/**',),
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     },
 }
 

--- a/scripts/artifacts/takeoutAccessLogActivity.py
+++ b/scripts/artifacts/takeoutAccessLogActivity.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "Old-format exports store last country/activity-time inside a free-text field; that legacy string slicing is preserved as-is.",
         "paths": ('*/Access Log Activity/Devices*.csv',),
         "output_types": "standard",
-        "artifact_icon": "smartphone",
+        "artifact_icon": "device-mobile",
     }
 }
 

--- a/scripts/artifacts/takeoutSearchContributions.py
+++ b/scripts/artifacts/takeoutSearchContributions.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
                  "verbatim as text.",
         "paths": ('*/Search Contributions/Streaming video providers.json',),
         "output_types": "standard",
-        "artifact_icon": "tv",
+        "artifact_icon": "device-tv",
     },
     "takeoutSearchContributionsReviews": {
         "name": "Google Search Contributions - Reviews",
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
                  "verbatim as text.",
         "paths": ('*/Search Contributions/Thumbs.json',),
         "output_types": "standard",
-        "artifact_icon": "thumbs-up",
+        "artifact_icon": "thumb-up",
     }
 }
 

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "paths": ('*/*.torrent',),
         "output_types": "standard",
         "html_columns": ["Path"],
-        "artifact_icon": "download-cloud",
+        "artifact_icon": "cloud-download",
     }
 }
 

--- a/scripts/artifacts/twitterReturns.py
+++ b/scripts/artifacts/twitterReturns.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*_tweets_media/*.*','*/*-tweets*.txt',),
         "output_types": "standard",
-        "artifact_icon": "twitter",
+        "artifact_icon": "brand-twitter",
     },
     "deltweets": {
         "name": "Deleted Tweets",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*_deleted_tweets_media/*.*','*/*deleted-tweets*.txt',),
         "output_types": "standard",
-        "artifact_icon": "twitter",
+        "artifact_icon": "brand-twitter",
     },
     "dmtwitter": {
         "name": "Twitter DMs",
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*_direct_messages_media/*.*','*/*direct-messages*.txt',),
         "output_types": "standard",
-        "artifact_icon": "twitter",
+        "artifact_icon": "brand-twitter",
     },
     "deleteddmtwitter": {
         "name": "Deleted Twitter DMs",
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*_deleted_direct_messages_media/*.*','*/*-deleted-direct-messages*.txt',),
         "output_types": "standard",
-        "artifact_icon": "twitter",
+        "artifact_icon": "brand-twitter",
     },
     "blocktwitter": {
         "name": "Blocked Twitter",
@@ -62,7 +62,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*-block*.txt',),
         "output_types": "standard",
-        "artifact_icon": "twitter",
+        "artifact_icon": "brand-twitter",
     }
 }
 

--- a/scripts/artifacts/youtubeSubscriptions.py
+++ b/scripts/artifacts/youtubeSubscriptions.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/YouTube and YouTube Music/subscriptions/subscriptions.csv'),
         "output_types": "standard",
-        "artifact_icon": "youtube",
+        "artifact_icon": "brand-youtube",
     }
 }
 


### PR DESCRIPTION
## What
Migrates all **94** feather-named artifact icons (across 72 files) to their **native Tabler** names, so RLEAPP no longer relies on the `feather_to_tabler_icon_names.json` compatibility map for any shipped artifact.

Examples: `instagram`→`brand-instagram` (×33), `message-square`→`message` (×14), `smartphone`→`device-mobile` (×10), `image`→`photo` (×8), `twitter`→`brand-twitter` (×5), `edit-3`→`pencil-minus`, `chrome`→`brand-chrome`, `youtube`→`brand-youtube`, `dollar-sign`→`currency-dollar`, …

## Safety
- **Metadata-only** — only `artifact_icon` string values changed (94 insertions / 94 deletions, no code).
- Every target verified present in `scripts/_elements/tabler-icons.css` (0 would fall back to `alert-triangle`).
- **Audit after:** 246/246 artifacts on native Tabler names, 0 feather-mapped, 0 missing, 0 invalid.
- 379 plugins load.

## Note
`twitterReturns.py` shows pylint warnings, but they're **pre-existing** (unused imports + legacy 4-arg signature; it was 7.74/10 before this change) and unrelated to the icon edit. Left for a separate context-form cleanup.
