### PR TITLE
Security: escape evidence in html_columns report cells (RLEAPP pilot)

### DIFF
--- a/scripts/artifacts/accPinger.py
+++ b/scripts/artifacts/accPinger.py
@@ -20,6 +20,7 @@ import os
 import mammoth
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -34,7 +35,7 @@ def accPinger(context):
         source_path = file_found
         with open(file_found, 'rb') as docx_file:
             result = mammoth.convert_to_html(docx_file)
-        data_list.append((result.value,))
+        data_list.append((safe_source(result.value),))
 
     data_headers = ('User Data',)
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/discordReturnsser.py
+++ b/scripts/artifacts/discordReturnsser.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 import json
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_join
 
 
 @artifact_processor
@@ -33,7 +34,7 @@ def discordReturnsser(context):
             data = json.load(f)
 
         channels = data.get('channels', '')
-        channels_agg = ('<br>'.join(f'{k}: {v}' for k, v in channels.items())
+        channels_agg = (safe_join(f'{k}: {v}' for k, v in channels.items())
                         if isinstance(channels, dict) else '')
         data_list.append((data.get('name', ''), data.get('description', ''), channels_agg,
                           data.get('banner', ''), data.get('icon', ''), data.get('id', ''),

--- a/scripts/artifacts/fbigDirecShares.py
+++ b/scripts/artifacts/fbigDirecShares.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import safe_join
 
 
 def _fbig_ts(value):
@@ -72,7 +73,7 @@ def fbigDirecShares(context):
                     thumb = check_in_media(media_name, media_name)
                 elif label == 'Id':
                     if started:
-                        data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+                        data_list.append((_fbig_ts(timestamp), thumb, safe_join(agg_parts), media_name))
                         timestamp = thumb = media_name = ''
                         agg_parts = []
                     started = True
@@ -80,7 +81,7 @@ def fbigDirecShares(context):
                 else:
                     agg_parts.append(f'{label}: {value}')
             if started:
-                data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+                data_list.append((_fbig_ts(timestamp), thumb, safe_join(agg_parts), media_name))
 
     data_headers = (('Timestamp', 'datetime'), ('Thumb', 'media'), 'Data', 'Filename')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigDirectStories.py
+++ b/scripts/artifacts/fbigDirectStories.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import safe_join
 
 
 def _fbig_ts(value):
@@ -72,7 +73,7 @@ def fbigDirectStories(context):
                     thumb = check_in_media(media_name, media_name)
                 elif label == 'Media Id':
                     if started:
-                        data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+                        data_list.append((_fbig_ts(timestamp), thumb, safe_join(agg_parts), media_name))
                         timestamp = thumb = media_name = ''
                         agg_parts = []
                     started = True
@@ -80,7 +81,7 @@ def fbigDirectStories(context):
                 else:
                     agg_parts.append(f'{label}: {value}')
             if started:
-                data_list.append((_fbig_ts(timestamp), thumb, '<br>'.join(agg_parts), media_name))
+                data_list.append((_fbig_ts(timestamp), thumb, safe_join(agg_parts), media_name))
 
     data_headers = (('Timestamp', 'datetime'), ('Thumb', 'media'), 'Data', 'Filename')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/fbigNcmec.py
+++ b/scripts/artifacts/fbigNcmec.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import safe_join
 
 _SKIP_LABELS = ('Ncmec Reports Definition', 'NCMEC Cybertips', 'Media uploaded in this cybertip')
 
@@ -71,7 +72,7 @@ def fbigNcmec(context):
                 if label == 'CyberTip ID':
                     if started:
                         data_list.append((_fbig_ts(time_val), cybertip_id, resid,
-                                          '<br>'.join(agg_parts), media_refs))
+                                          safe_join(agg_parts), media_refs))
                         cybertip_id = time_val = resid = ''
                         agg_parts = []
                         media_refs = []
@@ -91,7 +92,7 @@ def fbigNcmec(context):
                     agg_parts.append(f'{label} {value}')
             if started:
                 data_list.append((_fbig_ts(time_val), cybertip_id, resid,
-                                  '<br>'.join(agg_parts), media_refs))
+                                  safe_join(agg_parts), media_refs))
 
     data_headers = (('Time', 'datetime'), 'CyberTip ID', 'Responsible ID', 'Data',
                     ('Media', 'media'))

--- a/scripts/artifacts/fbigPhotos.py
+++ b/scripts/artifacts/fbigPhotos.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import esc
 
 
 def _fbig_ts(value):
@@ -43,7 +44,7 @@ def _row(fields):
     return (_fbig_ts(fields.get('taken', '')), fields.get('thumb'), fields.get('lmf', ''),
             fields.get('url', ''), fields.get('source', ''), fields.get('filter', ''),
             fields.get('pub', ''), fields.get('sba', ''), fields.get('carid', ''),
-            fields.get('caption', ''), fields.get('comments', ''), fields.get('location', ''))
+            esc(fields.get('caption', '')), esc(fields.get('comments', '')), esc(fields.get('location', '')))
 
 
 @artifact_processor

--- a/scripts/artifacts/fbigVideos.py
+++ b/scripts/artifacts/fbigVideos.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from bs4 import BeautifulSoup
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import esc
 
 
 def _fbig_ts(value):
@@ -43,7 +44,7 @@ def _row(fields):
     return (_fbig_ts(fields.get('taken', '')), fields.get('thumb'), fields.get('lmf', ''),
             fields.get('url', ''), fields.get('source', ''), fields.get('filter', ''),
             fields.get('pub', ''), fields.get('sba', ''), fields.get('carid', ''),
-            fields.get('caption', ''), fields.get('comments', ''), fields.get('location', ''))
+            esc(fields.get('caption', '')), esc(fields.get('comments', '')), esc(fields.get('location', '')))
 
 
 @artifact_processor

--- a/scripts/artifacts/googleAccChangeHist.py
+++ b/scripts/artifacts/googleAccChangeHist.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Returns Account Change History",
         "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
-                 "verbatim in the Account Change History column (rendered, not escaped).",
+                 "verbatim in the Account Change History column (shown as escaped source text, not rendered).",
         "paths": ('*/*GoogleAccount.ChangeHistory_*.Preserved/Google Account/*.ChangeHistory.html',
                   '*/*GoogleAccount.ChangeHistory_*/Google Account/*.ChangeHistory.html'),
         "output_types": "standard",
@@ -21,6 +21,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -33,7 +34,7 @@ def googleAccChangeHist(context):
             continue
         source_path = file_found
         with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
-            data_list.append((f.read(), context.get_relative_path(file_found)))
+            data_list.append((safe_source(f.read()), context.get_relative_path(file_found)))
 
     data_headers = ('Account Change History', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts.ilapfuncs import artifact_processor, check_in_media
+from scripts.html_safe import safe_join
 
 _MONTHS = {'January': 1, 'February': 2, 'March': 3, 'April': 4, 'May': 5, 'June': 6,
            'July': 7, 'August': 8, 'September': 9, 'October': 10, 'November': 11, 'December': 12}
@@ -76,7 +77,7 @@ def googleChat(context):
                 group_data = json.load(fg)
             for member in group_data.get('members', []):
                 members.append(member.get('name', '') + ' - ' + member.get('email', ''))
-        members_html = '<br>'.join(members)
+        members_html = safe_join(members)
 
         for chat_message in data.get('messages', []):
             created_date = chat_message.get('created_date', '')

--- a/scripts/artifacts/googleDeviceconfig.py
+++ b/scripts/artifacts/googleDeviceconfig.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Returns Android Device Config",
         "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
-                 "verbatim in the Device Configuration column (rendered, not escaped).",
+                 "verbatim in the Device Configuration column (shown as escaped source text, not rendered).",
         "paths": ('*/*AndroidDeviceConfigurationService.DeviceAndUserProfile_*/'
                   'Android Device Configuration Service/Device-*.html',),
         "output_types": "standard",
@@ -21,6 +21,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -33,7 +34,7 @@ def googleDeviceconfig(context):
             continue
         source_path = file_found
         with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
-            data_list.append((f.read(), context.get_relative_path(file_found)))
+            data_list.append((safe_source(f.read()), context.get_relative_path(file_found)))
 
     data_headers = ('Device Configuration', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleMyactisearch.py
+++ b/scripts/artifacts/googleMyactisearch.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Returns My Activity Image Search",
         "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
-                 "verbatim in the Image Search Activity column (rendered, not escaped).",
+                 "verbatim in the Image Search Activity column (shown as escaped source text, not rendered).",
         "paths": ('*/*MyActivity.MyActivity_*/My Activity/Image Search/MyActivity.html',),
         "output_types": "standard",
         "html_columns": ["Image Search Activity"],
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -32,7 +33,7 @@ def googleMyactisearch(context):
             continue
         source_path = file_found
         with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
-            data_list.append((f.read(), context.get_relative_path(file_found)))
+            data_list.append((safe_source(f.read()), context.get_relative_path(file_found)))
 
     data_headers = ('Image Search Activity', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleMyactssearch.py
+++ b/scripts/artifacts/googleMyactssearch.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Returns My Activity Search",
         "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
-                 "verbatim in the Search Activity column (rendered, not escaped).",
+                 "verbatim in the Search Activity column (shown as escaped source text, not rendered).",
         "paths": ('*/*MyActivity.MyActivity_*/My Activity/Search/MyActivity.html',),
         "output_types": "standard",
         "html_columns": ["Search Activity"],
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -32,7 +33,7 @@ def googleMyactssearch(context):
             continue
         source_path = file_found
         with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
-            data_list.append((f.read(), context.get_relative_path(file_found)))
+            data_list.append((safe_source(f.read()), context.get_relative_path(file_found)))
 
     data_headers = ('Search Activity', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googlePlayuseract.py
+++ b/scripts/artifacts/googlePlayuseract.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Returns Play User Act",
         "notes": "The return ships this activity as a pre-rendered HTML page; the full document is "
-                 "embedded verbatim in the User Activity column (rendered, not escaped).",
+                 "embedded verbatim in the User Activity column (shown as escaped source text, not rendered).",
         "paths": ('*/*GooglePlayStore.UserActivity_*/Google Play Store/User Activity.html',),
         "output_types": "standard",
         "html_columns": ["User Activity"],
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -32,7 +33,7 @@ def googlePlayuseract(context):
             continue
         source_path = file_found
         with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
-            data_list.append((f.read(), context.get_relative_path(file_found)))
+            data_list.append((safe_source(f.read()), context.get_relative_path(file_found)))
 
     data_headers = ('User Activity', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleSubinfo.py
+++ b/scripts/artifacts/googleSubinfo.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Returns Subscriber Info",
         "notes": "The return ships this as a pre-rendered HTML page; the full document is embedded "
-                 "verbatim in the Subscriber Info column (rendered, not escaped).",
+                 "verbatim in the Subscriber Info column (shown as escaped source text, not rendered).",
         "paths": ('*/*GoogleAccount.SubscriberInfo_*/Google Account/*.SubscriberInfo.html',),
         "output_types": "standard",
         "html_columns": ["Subscriber Info"],
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -32,7 +33,7 @@ def googleSubinfo(context):
             continue
         source_path = file_found
         with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
-            data_list.append((f.read(), context.get_relative_path(file_found)))
+            data_list.append((safe_source(f.read()), context.get_relative_path(file_found)))
 
     data_headers = ('Subscriber Info', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/iNotes.py
+++ b/scripts/artifacts/iNotes.py
@@ -21,6 +21,7 @@ import json
 import os
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -57,7 +58,7 @@ def iNotes(context):
                 notapath = match
                 if 'content' not in match:
                     with open(match, encoding='utf-8', errors='backslashreplace') as g:
-                        note_text = g.read().replace('\n', '<br>')
+                        note_text = safe_source(g.read())
 
             data_list.append((created, modified, note_text, recordname, refs,
                               '' if deleted is None else deleted,

--- a/scripts/artifacts/icloudReturnsphotolibrary.py
+++ b/scripts/artifacts/icloudReturnsphotolibrary.py
@@ -25,6 +25,7 @@ from pillow_heif import register_heif_opener
 
 from scripts.ilapfuncs import (artifact_processor, check_in_media, check_in_embedded_media,
                                convert_unix_ts_to_utc)
+from scripts.html_safe import esc
 
 _EXIF_TAGS = {271: 'Manufacturer', 272: 'Model', 305: 'Software', 274: 'Orientation',
               306: 'Creation/Changed', 282: 'Resolution X', 283: 'Resolution Y', 316: 'Host device'}
@@ -66,7 +67,7 @@ def _exif_summary(image_path):
     except Exception:  # pylint: disable=broad-except
         return '', '', ''
     lat, lon = _gps_decimal(_geotagging(exif.get_ifd(0x8825)))
-    summary = ''.join(f'{_EXIF_TAGS.get(tag, tag)}: {value}<br>' for tag, value in exif.items())
+    summary = ''.join(f'{esc(_EXIF_TAGS.get(tag, tag))}: {esc(value)}<br>' for tag, value in exif.items())
     return lat, lon, summary
 
 

--- a/scripts/artifacts/instagramMessageReq.py
+++ b/scripts/artifacts/instagramMessageReq.py
@@ -19,6 +19,7 @@ import os
 import json
 
 from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, check_in_media, convert_unix_ts_to_utc
+from scripts.html_safe import esc
 
 @artifact_processor
 def instagramMessageReq(context):
@@ -86,7 +87,7 @@ def instagramMessageReq(context):
                         actor = utf8_in_extended_ascii(actor)[1]
                             
                         counter = counter + 1
-                        agregator_reac = agregator_reac + f'<td>{reaction}<br>{actor}</td>'
+                        agregator_reac = agregator_reac + f'<td>{esc(reaction)}<br>{esc(actor)}</td>'
                         #hacer uno que no tenga html
                         if counter == 2:
                             counter = 0
@@ -100,7 +101,7 @@ def instagramMessageReq(context):
                 content = utf8_in_extended_ascii(content)[1]
                 if share_info:
                     content = (content + '\n' + share_info).strip()
-                type = x.get('type', '')
+                msg_type = x.get('type', '')
                 is_unsent = x.get('is_unsent', '')
                 
                 photos = x.get('photos', '')
@@ -121,7 +122,7 @@ def instagramMessageReq(context):
                             if ref:
                                 media_items.append(ref)
                 
-                data_list.append((timestamp, title, names, sender_name, content, media_items, agregator_reac, is_unsent, type, thread_type, is_still_participant, context.get_relative_path(file_found)))
+                data_list.append((timestamp, title, names, sender_name, content, media_items, agregator_reac, is_unsent, msg_type, thread_type, is_still_participant, context.get_relative_path(file_found)))
     
     data_headers = (('Timestamp', 'datetime'), 'Party Account Name', 'Participants', 'Sender Account Name', 'Content', ('Media','media'), 'Reactions', 'Is Unsent', 'Type', 'Thread Type', 'Is Still Participant','Source File')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramMessages.py
+++ b/scripts/artifacts/instagramMessages.py
@@ -19,6 +19,7 @@ import os
 import json
 
 from scripts.ilapfuncs import artifact_processor, utf8_in_extended_ascii, check_in_media, convert_unix_ts_to_utc
+from scripts.html_safe import esc
 
 @artifact_processor
 def instagramMessages(context):
@@ -78,7 +79,7 @@ def instagramMessages(context):
                         actor = utf8_in_extended_ascii(actor)[1]
                             
                         counter = counter + 1
-                        agregator_reac = agregator_reac + f'<td>{reaction}<br>{actor}</td>'
+                        agregator_reac = agregator_reac + f'<td>{esc(reaction)}<br>{esc(actor)}</td>'
                         #hacer uno que no tenga html
                         if counter == 2:
                             counter = 0
@@ -92,7 +93,7 @@ def instagramMessages(context):
                 content = utf8_in_extended_ascii(content)[1]
                 if share_info:
                     content = (content + '\n' + share_info).strip()
-                type = x.get('type', '')
+                msg_type = x.get('type', '')
                 is_unsent = x.get('is_unsent', '')
                 
                 photos = x.get('photos', '')
@@ -113,7 +114,7 @@ def instagramMessages(context):
                             if ref:
                                 media_items.append(ref)
                         
-                data_list.append((timestamp, names, sender_name, content, media_items, agregator_reac, is_unsent, type, context.get_relative_path(file_found)))
+                data_list.append((timestamp, names, sender_name, content, media_items, agregator_reac, is_unsent, msg_type, context.get_relative_path(file_found)))
     
     data_headers = (('Timestamp','datetime'), 'Participants', 'Sender', 'Content', ('Media','media'), 'Reactions', 'Is unsent', 'Type','Source File')
     return data_headers, data_list, 'See source path(s) below'

--- a/scripts/artifacts/instagramProfchanges.py
+++ b/scripts/artifacts/instagramProfchanges.py
@@ -19,6 +19,7 @@ import os
 import json
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+from scripts.html_safe import esc
 
 
 @artifact_processor
@@ -45,7 +46,7 @@ def instagramProfchanges(context):
                         for c, d in z.items():
                             if d and 'timestamp' in c:
                                 d = convert_unix_ts_to_utc(d)
-                            aggregator += f'{y} - {c} - {d} <br>'
+                            aggregator += f'{esc(y)} - {esc(c)} - {esc(d)} <br>'
                 data_list.append((title, aggregator))
 
     data_headers = ('Title', 'Items')

--- a/scripts/artifacts/kik.py
+++ b/scripts/artifacts/kik.py
@@ -203,6 +203,7 @@ import re
 from datetime import datetime, timedelta, timezone
 
 from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc
+from scripts.html_safe import safe_url
 
 try:
     from pdfminer.high_level import extract_text as pdf_extract_text
@@ -404,7 +405,7 @@ def kik_subscriber_pics(context):
             orig_md5 = pic_orig_md5s[i].upper() if i < len(pic_orig_md5s) else ''
             scaled_md5 = pic_scaled_md5s[i].upper() if i < len(pic_scaled_md5s) else ''
             data_list.append((
-                f'<a href="{url}" style="color:#4dabf7;">{url}</a>',
+                safe_url(url),
                 orig_md5, scaled_md5, rel_source
             ))
 

--- a/scripts/artifacts/kikReturns.py
+++ b/scripts/artifacts/kikReturns.py
@@ -37,6 +37,7 @@ import os
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, check_in_media
+from scripts.html_safe import esc
 
 
 def utf8_in_extended_ascii(input_string, *, raise_on_unexpected=False):
@@ -225,7 +226,7 @@ def kikAbuseReport(context):
                     report_from = parts[2] if len(parts) > 2 else ''
                     timestamp = (parts[4].strip('(') + ' ' + parts[5]) if len(parts) > 5 else ''
                 else:
-                    aggregator = aggregator + line + '<br>'
+                    aggregator = aggregator + esc(line) + '<br>'
             if aggregator != '':
                 data_list.append((_ts(timestamp), report_from, aggregator))
     data_headers = (('Timestamp', 'datetime'), 'Report From', 'Data')

--- a/scripts/artifacts/synchronoss.py
+++ b/scripts/artifacts/synchronoss.py
@@ -147,6 +147,7 @@ import re
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, logfunc, check_in_media, convert_unix_ts_to_utc
+from scripts.html_safe import safe_join
 
 
 def _register_media(file_path, name):
@@ -336,7 +337,7 @@ def synchronoss_messages(context):
         if msg_type not in ('sms', 'mms'):
             continue
         source_path = row.get('source_path', '')
-        recipients_fmt = '<br>'.join(
+        recipients_fmt = safe_join(
             r.strip() for r in row.get('Recipients', '').split(';') if r.strip()
         )
         data_list.append((
@@ -451,7 +452,7 @@ def _synchronoss_mms_media(context, direction):
         date_folder = msg_date[:10] if msg_date else ''   # YYYY-MM-DD
         folder_files = date_media.get(date_folder, {})
 
-        recipients_fmt = '<br>'.join(
+        recipients_fmt = safe_join(
             r.strip() for r in row.get('Recipients', '').split(';') if r.strip()
         )
 

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -20,6 +20,7 @@ import hashlib
 import bencoding
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import esc
 
 
 def _decode(value):
@@ -53,7 +54,7 @@ def torrentData(context):
             path_parts = fileinfo.get(b'path', [])
             dirr = _decode(path_parts[0]) if len(path_parts) > 1 else ''
             filen = _decode(path_parts[-1]) if path_parts else ''
-            rows.append(f'<tr><td>{dirr}</td><td>{filen}</td><td>{length}</td></tr>')
+            rows.append(f'<tr><td>{esc(dirr)}</td><td>{esc(filen)}</td><td>{esc(length)}</td></tr>')
         path_table = ('<table><tr><th>Directory</th><th>File</th><th>Length</th></tr>'
                       + ''.join(rows) + '</table>') if rows else ''
 

--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -1,0 +1,74 @@
+"""Helpers for safely emitting evidence-derived values into ``html_columns`` cells.
+
+Columns listed in an artifact's ``__artifacts_v2__`` ``html_columns`` are written to
+the HTML report **without** the framework's ``html.escape`` (see
+``scripts/artifact_report.py`` ``write_artifact_data_table`` -- the ``html_no_escape``
+branch). Any evidence-derived text placed in such a cell is therefore an
+HTML/JavaScript injection sink: malicious content in a parsed return renders live in
+the examiner's report (stored XSS, CWE-79).
+
+Route every evidence-derived value in an ``html_columns`` cell through these helpers so
+the dynamic parts are escaped while the tool's own structural markup (``<a>``, ``<br>``,
+``<table>``) is preserved.
+"""
+
+import html
+from urllib.parse import urlparse
+
+# Schemes we are willing to turn into a live <a href>. Anything else (notably
+# javascript: and data:) is rendered as escaped text, never as a clickable link.
+ALLOWED_URL_SCHEMES = ('http', 'https', 'mailto', 'tel', 'ftp', 'ftps')
+
+
+def esc(value):
+    """HTML-escape a single evidence value for safe use in text or an attribute.
+
+    ``None`` becomes ``''``. ``quote=True`` escapes ``"`` and ``'`` as well, so the
+    result is safe in both element-text and double-quoted-attribute contexts.
+    """
+    if value is None:
+        return ''
+    return html.escape(str(value), quote=True)
+
+
+def safe_url(url, text=None, target='_blank'):
+    """Build an ``<a href>`` anchor with an escaped, scheme-checked href.
+
+    Returns the escaped visible text with **no** anchor when the URL is empty or its
+    scheme is not allowlisted, so ``javascript:``/``data:`` URLs never become live
+    links. ``text`` (the visible label) defaults to the URL itself.
+    """
+    url = '' if url is None else str(url).strip()
+    label = esc(text if text is not None else url)
+    if not url:
+        return label
+    try:
+        scheme = urlparse(url).scheme.lower()
+    except ValueError:
+        return label
+    if scheme not in ALLOWED_URL_SCHEMES:
+        return label
+    rel = ' rel="noopener noreferrer"' if target == '_blank' else ''
+    return f'<a href="{esc(url)}" target="{esc(target)}"{rel}>{label}</a>'
+
+
+def safe_join(values, sep='<br>'):
+    """Escape each evidence value and join with a tool-controlled separator.
+
+    The separator is emitted verbatim (it is tool-owned markup, default ``<br>``);
+    every joined value is escaped.
+    """
+    return sep.join(esc(v) for v in values)
+
+
+def safe_source(text):
+    """Escape an evidence text/document body for display as source.
+
+    Real newlines become ``<br>`` for readability *after* escaping, so any markup in
+    the evidence (including a literal ``<br>``) is shown inert as text. Use for
+    Tier-1 raw bodies -- message/email bodies, whole return pages, notes -- per the
+    escape-to-source policy.
+    """
+    if text is None:
+        return ''
+    return esc(text).replace('\n', '<br>')


### PR DESCRIPTION
## Summary

Pilot fix for the stored HTML/JS injection surface in `html_columns` report cells (advisory **GHSA-hr8c-x9g4-8ppj**, CWE-79). Columns listed in an artifact's `html_columns` are written to the HTML report **without** `html.escape` (`scripts/artifact_report.py`), so malicious HTML/JS in a parsed return renders live in the examiner's `file://` report. This PR closes that gap for **all of RLEAPP** and establishes the shared pattern for the iLEAPP/ALEAPP follow-ups.

## New shared helper — `scripts/html_safe.py`

| Function | Use |
|---|---|
| `esc(v)` | escape one evidence value (`quote=True`, `None`→`''`) — safe in text and attribute context |
| `safe_url(url, text=None)` | `<a href>` with escaped href + text **and a scheme allowlist** (`http/https/mailto/tel/ftp`), so `javascript:`/`data:` never become live links; `rel="noopener noreferrer"` |
| `safe_join(values, sep='<br>')` | escape each value, join with tool-owned separator |
| `safe_source(text)` | escape a body and turn real newlines into `<br>` — for Tier‑1 raw bodies (escape-to-source) |

## Tier 1 — raw bodies, escape-to-source (11 artifacts)

These previously embedded a whole attacker-controlled document verbatim; they now show it as **escaped source text**. ⚠️ **Report-appearance change:** the six `google*` return pages and the Pinger `.docx` no longer *render* — they display as source. The rendered original is still reachable via each artifact's **Source File** path.

`googleAccChangeHist`, `googleDeviceconfig`, `googleMyactisearch`, `googleMyactssearch`, `googlePlayuseract`, `googleSubinfo` (whole return HTML page) · `accPinger` (mammoth docx→html) · `iNotes` (note body) · `kikReturns.kikAbuseReport` (report body) · `fbigPhotos` / `fbigVideos` (Caption/Comments/Location).

## Tier 2 — interpolated markup, escape the dynamic parts (12 artifacts)

Structural `<a>`/`<br>`/`<table>` markup preserved; every evidence substring escaped:

`discordReturnsser` (Channels) · `fbigDirecShares` / `fbigDirectStories` / `fbigNcmec` (Data) · `googleChat` (Group Members) · `icloudReturnsphotolibrary` (Exif) · `instagramMessageReq` / `instagramMessages` (Reactions) · `instagramProfchanges` (Items) · `kik.kik_subscriber_pics` (Profile Pic URL → `safe_url`) · `synchronoss` messages/mms_received/mms_sent (Recipients) · `torrentData` (Path).

## Not changed

Media-typed columns (`('col','media')`) hold `check_in_media` ref-ids, and `semanticLocbymonth` waypoints are numeric — both already safe.

## Validation

- ✅ `pylint --disable=C,R` = **10.00/10** on all changed files (also fixed a pre-existing `type` shadowing in the two instagram modules).
- ✅ `py_compile` clean; `PluginLoader` loads **379** plugins.
- ✅ **End-to-end payload test** — a `<script>alert(document.cookie)</script>` / `"><img src=x onerror=alert(1)>` in crafted evidence comes out escaped for both a Tier 1 (`googleAccChangeHist`) and a Tier 2 (`discordReturnsser`) artifact; no live markup in the cell. Sample cell:
  ```
  &lt;html&gt;&lt;body&gt;&lt;script&gt;alert(document.cookie)&lt;/script&gt;<br>line2&lt;/b…
  ```
- Helper unit-tested: `javascript:` and scheme-less URLs never render as links.

## Scope

This is the **pilot** — RLEAPP only. iLEAPP and ALEAPP have the same class (tracked in their own advisories) and will follow this exact `html_safe` pattern once the approach is reviewed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
