### PR TITLE
fix: quote SQL identifiers in LAVA writer; path-safe report names

### DIFF
--- a/admin/test/scripts/test_lava_sql_identifiers.py
+++ b/admin/test/scripts/test_lava_sql_identifiers.py
@@ -1,0 +1,212 @@
+"""Guard the LAVA writer against artifact names that are hostile to SQL or to the filesystem.
+
+The LAVA writer turns each artifact's data_headers into SQLite column names. Those
+identifiers used to be interpolated into CREATE TABLE and INSERT statements unquoted, so
+any header that sanitizes down to a reserved word ('From', 'To', 'Order', ...) killed the
+artifact at report time with `near "from": syntax error`. The parser itself ran fine, so
+the only symptom was a LAVA table that silently never appeared, and
+admin/test/scripts/test_module.py mocks the LAVA database connection, so module-level
+testing passes either way. Module authors hit this three times in one day and worked
+around it by renaming columns.
+
+The same class of trap exists for a '/' in an artifact name or category: those become
+HTML/TSV/KML filenames and _HTML folder names, and os.path.join() reads the '/' as a path
+separator, so the artifact either fails to write its report or lands somewhere unintended.
+"""
+import datetime
+import pathlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import lavafuncs  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+from scripts.ilapfuncs import sanitize_report_name  # pylint: disable=wrong-import-position
+
+# Reserved words an artifact could plausibly want as a column heading. 'From' and 'To' are
+# the ones that actually bit (mastodon notifications, Apple Mail); the rest are the same
+# hazard waiting for the next module.
+RESERVED_HEADERS = [
+    'From', 'To', 'Order', 'Group', 'Index', 'Select', 'Where', 'Table',
+    'Values', 'Default', 'Check', 'References', 'Limit', 'Join', 'Set', 'Action',
+]
+
+
+class TestLavaReservedWordIdentifiers(unittest.TestCase):
+    """The LAVA SQLite writer must quote identifiers so reserved words are usable."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        lavafuncs.initialize_lava(self.tmpdir, self.tmpdir, 'fs')
+
+    def tearDown(self):
+        if lavafuncs.lava_db is not None:
+            lavafuncs.lava_db.close()
+            lavafuncs.lava_db = None
+        lavafuncs.lava_data = None
+        Context.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _fetch_rows(self, table_name):
+        cursor = lavafuncs.lava_db.cursor()
+        return cursor.execute(f'SELECT * FROM "{table_name}"').fetchall()
+
+    def test_reserved_words_are_hostile_unquoted(self):
+        """Documents why RESERVED_HEADERS is the corpus: unquoted, these really do fail."""
+        db = sqlite3.connect(':memory:')
+        offenders = []
+        for header in RESERVED_HEADERS:
+            column = lavafuncs.sanitize_sql_name(header)
+            try:
+                db.execute(f'CREATE TABLE t_{column} ({column} TEXT)')
+            except sqlite3.OperationalError:
+                offenders.append(header)
+        db.close()
+        self.assertIn('From', offenders)
+        self.assertIn('Order', offenders)
+        self.assertGreaterEqual(
+            len(offenders), 5,
+            'Test corpus no longer exercises the bug; add headers SQLite rejects unquoted.')
+
+    def test_create_table_accepts_reserved_word_headers(self):
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'reserved_word_artifact', RESERVED_HEADERS)
+
+        self.assertEqual(table_name, 'reserved_word_artifact')
+        self.assertEqual(object_columns, {})
+        self.assertEqual(
+            [column_map[lavafuncs.sanitize_sql_name(h)] for h in RESERVED_HEADERS],
+            RESERVED_HEADERS)
+
+        cursor = lavafuncs.lava_db.cursor()
+        columns = [row[1] for row in cursor.execute(f'PRAGMA table_info("{table_name}")')]
+        self.assertEqual(columns, [lavafuncs.sanitize_sql_name(h) for h in RESERVED_HEADERS])
+
+    def test_insert_populates_reserved_word_columns(self):
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'reserved_word_artifact', RESERVED_HEADERS)
+        rows = [
+            tuple(f'{header}-row1' for header in RESERVED_HEADERS),
+            tuple(f'{header}-row2' for header in RESERVED_HEADERS),
+        ]
+
+        lavafuncs.lava_insert_sqlite_data(
+            table_name, rows, object_columns, RESERVED_HEADERS, column_map)
+
+        self.assertEqual(self._fetch_rows(table_name), rows)
+
+        # Values must land in the column they were written for, not just somewhere.
+        cursor = lavafuncs.lava_db.cursor()
+        self.assertEqual(
+            cursor.execute(f'SELECT "from", "order" FROM "{table_name}"').fetchall(),
+            [('From-row1', 'Order-row1'), ('From-row2', 'Order-row2')])
+
+    def test_reserved_word_table_name(self):
+        """A module function named e.g. order() makes the table name reserved too."""
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'Order', ['From', 'Timestamp'])
+
+        self.assertEqual(table_name, 'order')
+        lavafuncs.lava_insert_sqlite_data(
+            table_name, [('sender', 'ts')], object_columns, ['From', 'Timestamp'], column_map)
+        self.assertEqual(self._fetch_rows(table_name), [('sender', 'ts')])
+
+    def test_typed_headers_with_reserved_words(self):
+        """Tuple headers take the typed CREATE TABLE branch, which needs quoting too."""
+        headers = [('From', 'datetime'), ('Order', 'datetime'), 'Group']
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'typed_reserved_artifact', headers)
+
+        self.assertEqual(object_columns, {'from': 'datetime', 'order': 'datetime'})
+
+        timestamp = datetime.datetime(2026, 7, 25, 12, 0, tzinfo=datetime.timezone.utc)
+        lavafuncs.lava_insert_sqlite_data(
+            table_name, [(timestamp, timestamp, 'a group')], object_columns, headers, column_map)
+
+        self.assertEqual(
+            self._fetch_rows(table_name),
+            [(int(timestamp.timestamp()), int(timestamp.timestamp()), 'a group')])
+
+    def test_process_artifact_end_to_end(self):
+        """The path artifact_processor actually takes, headers and all."""
+        Context.set_artifact_info({'name': 'Reserved Words', 'description': 'test artifact'})
+        # Only the basename is read, so this path never has to exist. Keeping it synthetic
+        # lets the same test file be shared across the LEAPP tools unchanged.
+        Context.set_module_file_path(str(REPO_ROOT / 'scripts' / 'artifacts' / 'reserved_words.py'))
+
+        table_name, object_columns, column_map = lavafuncs.lava_process_artifact(
+            'Testing', 'reserved_words_module', 'Reserved Words', RESERVED_HEADERS,
+            record_count=1, func_name='reserved_words')
+        lavafuncs.lava_insert_sqlite_data(
+            table_name,
+            [tuple(f'{header}-value' for header in RESERVED_HEADERS)],
+            object_columns, RESERVED_HEADERS, column_map)
+
+        self.assertEqual(table_name, 'reserved_words')
+        self.assertEqual(len(self._fetch_rows(table_name)), 1)
+        artifact = lavafuncs.lava_data['artifacts']['Testing'][0]
+        self.assertEqual(artifact['tablename'], 'reserved_words')
+        self.assertEqual(artifact['record_count'], 1)
+
+
+class TestQuoteSqlName(unittest.TestCase):
+    """quote_sql_name() must not be escapable by whatever ends up in a header."""
+
+    def test_wraps_in_double_quotes(self):
+        self.assertEqual(lavafuncs.quote_sql_name('from'), '"from"')
+
+    def test_doubles_embedded_quotes(self):
+        self.assertEqual(lavafuncs.quote_sql_name('a"b'), '"a""b"')
+
+    def test_embedded_quote_is_a_usable_identifier(self):
+        # sanitize_sql_name() strips quotes today, so this only guards quote_sql_name()
+        # itself against a future caller that skips sanitizing.
+        db = sqlite3.connect(':memory:')
+        column = lavafuncs.quote_sql_name('odd"name')
+        db.execute(f'CREATE TABLE t ({column} TEXT)')
+        db.execute(f'INSERT INTO t ({column}) VALUES (?)', ('value',))
+        self.assertEqual(db.execute('SELECT * FROM t').fetchall(), [('value',)])
+        db.close()
+
+
+class TestSanitizeReportName(unittest.TestCase):
+    """Artifact names and categories become file and folder names."""
+
+    def test_leaves_ordinary_names_alone(self):
+        # Existing artifact names must keep producing byte-identical output paths.
+        for name in ['SMS & iMessage', "Apple Maps", 'Twitter X - Direct Messages']:
+            self.assertEqual(sanitize_report_name(name), name)
+
+    def test_replaces_path_separators(self):
+        self.assertEqual(sanitize_report_name('Twitter/X'), 'Twitter_X')
+        self.assertEqual(sanitize_report_name('Foo\\Bar'), 'Foo_Bar')
+
+    def test_result_is_a_single_path_component(self):
+        import os
+        safe_name = sanitize_report_name('Twitter/X - Cached Posts')
+        self.assertEqual(os.path.basename(safe_name), safe_name)
+        self.assertEqual(os.path.dirname(safe_name), '')
+
+    def test_no_shipped_artifact_needs_sanitizing(self):
+        """Nothing in scripts/artifacts should rely on the fallback."""
+        import re
+        offenders = []
+        pattern = re.compile(r"^\s*'(name|category)':\s*(['\"])(.*?)\2", re.MULTILINE)
+        for py_file in sorted((REPO_ROOT / 'scripts' / 'artifacts').glob('*.py')):
+            source = py_file.read_text(encoding='utf-8', errors='replace')
+            for _, _, value in pattern.findall(source):
+                if '/' in value or '\\' in value:
+                    offenders.append(f'{py_file.name}: {value}')
+        self.assertEqual(
+            offenders, [],
+            'Artifact name/category contains a path separator; the report file name will '
+            'not match the displayed name:\n' + '\n'.join(offenders))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rleapp.py
+++ b/rleapp.py
@@ -436,7 +436,8 @@ def crunch_artifacts(
         if files_found:
             if not lava_only and 'lava_only' in output_types:
                 lava_only = True
-            category_folder = os.path.join(out_params.output_folder_base, '_HTML', plugin.category)
+            category_folder = os.path.join(out_params.output_folder_base, '_HTML',
+                                           sanitize_report_name(plugin.category, 'category'))
             if not os.path.exists(category_folder):
                 try:
                     os.makedirs(category_folder)

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -432,6 +432,34 @@ def get_data_list_with_media(media_header_info, data_list):
 
     return html_data_list, txt_data_list
 
+_reported_unsafe_report_names = set()
+
+def sanitize_report_name(name, kind='name'):
+    """
+    Replaces path separators in an artifact name or category so it is usable as a file
+    or folder name.
+
+    Artifact names become HTML/TSV/KML filenames and categories become _HTML subfolder
+    names. A name such as 'Twitter/X' makes os.path.join() read the '/' as a path
+    separator, so the artifact either fails to write its report or lands in an
+    unintended folder, even though the parser ran fine. The original name is kept for
+    display and for LAVA; only the on-disk name is rewritten.
+
+    Args:
+        name (str): The artifact name or category to make path safe.
+        kind (str): What is being sanitized, used in the warning ('name' or 'category').
+    Returns:
+        str: The name with '/' and '\\' replaced by '_'.
+    """
+
+    safe_name = name.replace('/', '_').replace('\\', '_')
+    if safe_name != name and name not in _reported_unsafe_report_names:
+        _reported_unsafe_report_names.add(name)
+        logfunc(f"Warning: artifact {kind} '{name}' contains a path separator. "
+                f"Report files use '{safe_name}' instead; rename it to avoid the mismatch.")
+    return safe_name
+
+
 def artifact_processor(func):
     @wraps(func)
     def wrapper(files_found, report_folder, seeker, wrap_text):
@@ -479,7 +507,12 @@ def artifact_processor(func):
             else:
                 html_data_list = data_list
             logfunc(f"Found {len(data_list):,} {'records' if len(data_list)>1 else 'record'} for {artifact_name}")
-            icons.setdefault(category, {artifact_name: icon}).update({artifact_name: icon})
+            # Path separators would break (or misplace) the report files, so the HTML, TSV
+            # and KML outputs are written under a path safe name. The sidebar keys off the
+            # on-disk names, so the icon lookup has to use the same safe names.
+            safe_artifact_name = sanitize_report_name(artifact_name)
+            safe_category = sanitize_report_name(category, 'category')
+            icons.setdefault(safe_category, {safe_artifact_name: icon}).update({safe_artifact_name: icon})
 
             # Strip tuples from headers for HTML, TSV, and timeline
             stripped_headers = strip_tuple_from_headers(data_headers)
@@ -492,13 +525,13 @@ def artifact_processor(func):
 
             if check_output_types('html', output_types):
                 report = artifact_report.ArtifactHtmlReport(artifact_name)
-                report.start_artifact_report(report_folder, artifact_name, description)
+                report.start_artifact_report(report_folder, safe_artifact_name, description)
                 report.add_script()
                 report.write_artifact_data_table(stripped_headers, html_data_list, source_path, html_no_escape=html_columns)
                 report.end_artifact_report()
 
             if check_output_types('tsv', output_types):
-                tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, artifact_name)
+                tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, safe_artifact_name)
 
             if check_output_types('timeline', output_types):
                 timeline(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
@@ -518,7 +551,7 @@ def artifact_processor(func):
                 lava_insert_sqlite_data(table_name, data_list, object_columns, data_headers, column_map)
 
             if check_output_types('kml', output_types):
-                kmlgen(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
+                kmlgen(report_folder, safe_artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
 
         else:
             if output_types != 'none':

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -11,6 +11,7 @@ Global Variables:
 
 Functions:
     sanitize_sql_name: Sanitizes strings for use as SQL identifiers.
+    quote_sql_name: Quotes an identifier so reserved words are safe in SQL.
     get_sql_type: Maps Python types to SQL types.
     initialize_lava: Initializes the LAVA data structure and database.
     lava_process_artifact: Processes and stores artifact data.
@@ -64,6 +65,24 @@ def sanitize_sql_name(name):
     if sanitized and not sanitized[0].isalpha() and sanitized[0] != '_':
         sanitized = '_' + sanitized
     return sanitized.lower()
+
+
+def quote_sql_name(name):
+    """
+    Wraps an identifier in double quotes so it is safe to interpolate into SQL.
+
+    sanitize_sql_name() removes the characters SQLite cannot parse, but it cannot stop a
+    header from sanitizing down to a reserved word. A 'From', 'To' or 'Order' column used
+    to emit `CREATE TABLE ... (from TEXT, ...)`, a syntax error that killed the artifact at
+    report time even though the parser itself ran fine. Quoting makes reserved words legal.
+    Any embedded double quote is doubled, per the SQL standard, so the quoting holds.
+    Args:
+        name (str): The identifier to quote.
+    Returns:
+        str: The identifier wrapped in double quotes.
+    """
+
+    return '"' + str(name).replace('"', '""') + '"'
 
 
 def get_sql_type(python_type):
@@ -344,17 +363,17 @@ def lava_create_sqlite_table(table_name, data):
             original_name, data_type = item[:2]  # Only take the first two elements as media item can have more
             sanitized_name = sanitize_sql_name(original_name)
             sql_type = get_sql_type(data_type)
-            columns.append(f"{sanitized_name} {sql_type}")
+            columns.append(f"{quote_sql_name(sanitized_name)} {sql_type}")
             object_columns[sanitized_name] = data_type
         else:
             original_name = item
             sanitized_name = sanitize_sql_name(original_name)
-            columns.append(f"{sanitized_name} TEXT")
+            columns.append(f"{quote_sql_name(sanitized_name)} TEXT")
 
         column_map[sanitized_name] = original_name
 
     columns_sql = ', '.join(columns)
-    cursor.execute(f"CREATE TABLE IF NOT EXISTS {sanitized_table_name} ({columns_sql})")
+    cursor.execute(f"CREATE TABLE IF NOT EXISTS {quote_sql_name(sanitized_table_name)} ({columns_sql})")
     lava_db.commit()
 
     return sanitized_table_name, column_map, object_columns
@@ -390,7 +409,8 @@ def lava_insert_sqlite_data(table_name, data, object_columns, headers, column_ma
 
     # Prepare the SQL query
     placeholders = ', '.join(['?' for _ in sanitized_columns])
-    query = f"INSERT INTO {table_name} ({', '.join(sanitized_columns)}) VALUES ({placeholders})"
+    quoted_columns = ', '.join(quote_sql_name(column) for column in sanitized_columns)
+    query = f"INSERT INTO {quote_sql_name(table_name)} ({quoted_columns}) VALUES ({placeholders})"
 
     # Prepare the data for insertion
     rows_to_insert = []


### PR DESCRIPTION
## Problem

Artifact `data_headers` that sanitize to a SQL reserved word (`From`, `To`, `Order`, `Group`, `Index`, `Select`, ...) failed at report time with `near "from": syntax error`. The parser ran fine, so the only symptom was a LAVA table that silently never appeared. The module test harness mocks the LAVA database connection, so unit-level testing passed either way.

The same class of trap existed for a `/` in an artifact `name` or `category`: those become HTML/TSV/KML filenames and `_HTML` folder names, and `os.path.join()` reads the `/` as a path separator, so the artifact failed to write its report.

## Changes

- **`scripts/lavafuncs.py`** — new `quote_sql_name()`, applied to the table name and every column in `lava_create_sqlite_table()` (both CREATE TABLE branches) and `lava_insert_sqlite_data()`.
- **`scripts/ilapfuncs.py` / main script** — new `sanitize_report_name()` replaces `/` and `\` in artifact names and categories used as file and folder names, logging a one-time warning. Display names, timeline entries and the LAVA JSON keep the original name; only the on-disk name changes. The `icons` keys use the same safe names so the sidebar icon lookup still matches. No shipping artifact contains a separator, so no existing output path changes.
- **`admin/test/scripts/test_lava_sql_identifiers.py`** — 13 regression tests against a real SQLite file, no mocks.

## Verification

13/13 tests pass in this repo. Ported verbatim from iLEAPP, where the identical fix was verified with two full `-t fs` runs over a 300k-file image (691 artifacts, zero SQL errors) and a probe artifact whose every column is a reserved word. Anchors were checked to appear exactly once per file before any edit, the tool still imports, and pylint warning counts per file are unchanged.

## Companion change

LAVA reads these tables and had the same unquoted-identifier bug on its side — see abrignoni/LAVA#157. This change makes reserved-word columns reach LAVA for the first time, so **that one should ship first or together**. Sibling PRs: abrignoni/iLEAPP#1759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)