### PR TITLE
ci: add a diff-aware pylint check

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,0 +1,49 @@
+name: Python Lint Check
+
+on:
+  pull_request:
+    paths:
+      - '**.py' # only trigger on python files
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Required to fetch the base branch for comparison
+          fetch-depth: 0
+
+      - name: Get changed Python files
+        id: changed-files-py
+        uses: tj-actions/changed-files@v46 # This action finds changed files
+        with:
+          files: |
+            **.py
+
+      - name: Set up Python
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Pylint
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python -m pip install pylint
+
+      - name: Install dependencies
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python -m pip install -r requirements.txt
+
+      # Fails only on warnings this pull request introduces. rleapp.py and
+      # rleappGUI.py carry pre-existing warnings that are structural rather than
+      # fixable -- wildcard imports are how those modules are put together -- so
+      # failing on the absolute count would make every pull request that touches
+      # them red for reasons unrelated to the change. See the script's docstring.
+      - name: Run on changed files
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: |
+          BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          echo "Comparing against merge base $BASE"
+          python admin/scripts/lint_changed.py --base-ref "$BASE" \
+            ${{ steps.changed-files-py.outputs.all_changed_files }}

--- a/admin/scripts/lint_changed.py
+++ b/admin/scripts/lint_changed.py
@@ -1,0 +1,119 @@
+"""Fail CI only on pylint warnings a change actually introduces.
+
+The lint job runs pylint over the files a pull request touches. Several long-lived
+modules carry pre-existing warnings that are deliberate rather than fixable --
+`ileapp.py` uses wildcard imports as its module architecture, `scripts/ilapfuncs.py`
+re-exports names it does not itself use so that older artifact modules keep importing
+them. Any pull request that touches one of those files therefore went red for reasons
+that had nothing to do with the change, which pushes contributors toward either
+unrelated refactors or blanket file-level `# pylint: disable` comments. Both are worse
+than the debt.
+
+This script lints the same file set twice, once at the merge base and once at the
+change, and fails only when a (file, warning) pair appears more often than it did
+before. New code is held to the full standard; existing debt neither blocks a pull
+request nor gets silently widened.
+
+Two details matter for a stable comparison, both learned the hard way:
+
+* pylint's results depend on which files are analysed together, because it infers
+  across the set. Both runs therefore lint the same list of paths.
+* pylint caches results between runs and will otherwise report stale data, so both
+  runs pass --persistent=no.
+
+Usage:
+    python admin/scripts/lint_changed.py --base-ref <sha> <file> [<file> ...]
+"""
+
+import argparse
+import collections
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+PYLINT_ARGS = ['--disable=C,R', '--persistent=no', '--output-format=json']
+
+
+def run_pylint(repo_dir, paths):
+    """Return Counter keyed by (path, symbol) for paths that exist in repo_dir."""
+    present = [p for p in paths if os.path.exists(os.path.join(repo_dir, p))]
+    if not present:
+        return collections.Counter()
+
+    env = dict(os.environ, PYTHONPATH='.')
+    result = subprocess.run(
+        [sys.executable, '-m', 'pylint', *present, *PYLINT_ARGS],
+        cwd=repo_dir, env=env, capture_output=True, text=True, check=False)
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        # No JSON at all means pylint failed to start rather than finding nothing.
+        if result.returncode not in (0,):
+            print(f'pylint produced no output (exit {result.returncode}):\n{result.stderr}',
+                  file=sys.stderr)
+            sys.exit(2)
+        return collections.Counter()
+
+    try:
+        messages = json.loads(stdout)
+    except json.JSONDecodeError:
+        print(f'could not parse pylint output:\n{stdout[:2000]}', file=sys.stderr)
+        sys.exit(2)
+
+    return collections.Counter((m['path'], m['symbol']) for m in messages)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--base-ref', required=True,
+                        help='commit to compare against, normally the merge base')
+    parser.add_argument('paths', nargs='*', help='changed Python files')
+    args = parser.parse_args()
+
+    paths = [p for p in args.paths if p.endswith('.py')]
+    if not paths:
+        print('No Python files changed.')
+        return 0
+
+    print('Linting:\n' + '\n'.join(f'  {p}' for p in paths) + '\n')
+    after = run_pylint('.', paths)
+
+    # A detached worktree gives the base revision with full repo context, so pylint
+    # resolves imports there the same way it does for the change.
+    with tempfile.TemporaryDirectory() as tmp:
+        base_dir = os.path.join(tmp, 'base')
+        subprocess.run(['git', 'worktree', 'add', '--detach', '--quiet', base_dir,
+                        args.base_ref], check=True, capture_output=True)
+        try:
+            before = run_pylint(base_dir, paths)
+        finally:
+            subprocess.run(['git', 'worktree', 'remove', '--force', base_dir],
+                           check=False, capture_output=True)
+
+    introduced = {key: count - before.get(key, 0)
+                  for key, count in after.items() if count > before.get(key, 0)}
+
+    total_before, total_after = sum(before.values()), sum(after.values())
+    print(f'pre-existing warnings in these files: {total_before}')
+    print(f'warnings now:                         {total_after}')
+
+    if not introduced:
+        removed = total_before - total_after
+        if removed > 0:
+            print(f'\nNo new warnings introduced ({removed} fewer than before). PASS')
+        else:
+            print('\nNo new warnings introduced. PASS')
+        return 0
+
+    print('\nThis change introduces new pylint warnings:\n')
+    for (path, symbol), count in sorted(introduced.items()):
+        print(f'  {path}: {symbol} (+{count})')
+    print('\nRe-run locally with:')
+    print(f'  PYTHONPATH=. python -m pylint {" ".join(paths)} {" ".join(PYLINT_ARGS[:2])}')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
RLEAPP has no lint workflow, so nothing verifies a pull request beyond whatever the author ran locally. The two PRs merged on 2026-07-25 went in showing **"no checks reported"**.

This ports the check iLEAPP and ALEAPP already run.

## Why diff-aware rather than a plain pylint run

The obvious workflow — `pylint <changed files> --disable=C,R` — is unusable here. Measured on this repo:

| File | Pre-existing warnings |
|---|---|
| `rleapp.py` | 14 |
| `rleappGUI.py` | 30 |
| artifact modules (sampled) | 0 |

Most of that is wildcard imports, which are how those modules are put together rather than something to fix. A check that failed on the absolute count would pass every artifact-only pull request and fail every core-file one for reasons unrelated to the change. That is precisely the state iLEAPP was in: PRs #1280, #1661 and #1719 all sat red, the last of them while changing nothing but one file it happened to touch.

`admin/scripts/lint_changed.py` lints the same file set twice — once at the merge base, once at the change — and fails only when a `(file, warning)` pair appears more often than before. New code is held to the full standard; existing debt neither blocks a pull request nor gets silently widened.

Two details in the script matter for a stable comparison, both documented in its docstring: pylint infers across the analysed set, so both runs lint the same path list, and pylint caches between runs, so both pass `--persistent=no`.

## Verified locally, both directions

- `rleapp.py` unchanged against `origin/main` → 14 before, 14 after, **PASS**
- append an f-string with nothing to interpolate → **exit 1**, naming `rleapp.py: f-string-without-interpolation (+1)`

## Difference from the iLEAPP workflow

The blackboxprotobuf guard step is left out — RLEAPP neither vendors nor imports it.

## Unrelated finding

While measuring the baseline, pylint surfaced a real defect this check will *not* catch, because it predates the change:

```
rleapp.py:195:28: E0602: Undefined variable 'pathlib'
```

`rleapp.py` line 195 calls `pathlib.Path(args.custom_artifacts_path)`, but `pathlib` is never imported and is not re-exported by any of the three wildcard imports (verified). Passing `--custom_artifacts_path` should raise `NameError`. Worth a one-line fix in its own pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
