### PR TITLE
fix: import pathlib in rleapp.py so --custom_artifacts_path works

### DIFF
--- a/rleapp.py
+++ b/rleapp.py
@@ -2,6 +2,7 @@ import json
 import argparse
 import io
 import os.path
+import pathlib
 import typing
 import scripts.report as report
 import traceback


### PR DESCRIPTION
`main()` calls `pathlib.Path(args.custom_artifacts_path)` at line 195, but `pathlib` is never imported, and it is not re-exported by any of the three wildcard imports at the top of the file (checked each one). Passing the flag aborts before anything happens.

## Reproduced against `main`

```
$ python3 rleapp.py --custom_artifacts_path /tmp/somedir -p
Traceback (most recent call last):
  File "rleapp.py", line 498, in <module>
    main()
  File "rleapp.py", line 195, in main
    loader_paths.append(pathlib.Path(args.custom_artifacts_path))
                        ^^^^^^^
NameError: name 'pathlib' is not defined. Did you mean: 'hashlib'?
```

The flag has presumably never worked. Line 195 sits immediately after `parse_args()` with no early exit before it, so the crash is unconditional whenever the option is supplied.

## After

Same command completes normally, loading the extra path:

```
*[Dd][Vv] [Aa]ccess [Ll]ogs*.csv
*contacts_*.txt

Artifact path list generation completed
```

## Why it went unnoticed

pylint has been reporting it on every run:

```
rleapp.py:195:28: E0602: Undefined variable 'pathlib'
```

but the repo had no lint workflow until #380, so nothing surfaced it. Worth noting that the diff-aware check added there would **not** catch this either — it fails only on warnings a change introduces, and this one predates any change. It showed up because I was measuring the pre-existing baseline while writing that workflow.

`rleapp.py` goes from 14 pre-existing warnings to 13; the new lint gate reports `No new warnings introduced (1 fewer than before). PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
