### PR TITLE
Restore module checkbox indicators on Windows

### DIFF
--- a/rleappGUI.py
+++ b/rleappGUI.py
@@ -114,15 +114,32 @@ def filter_modules(*args):
 
     for artifact_name, module_infos in mlist.items():
         if module_matches_filter(module_infos, filter_term):
-            cb = ttk.Checkbutton(
-                mlist_text,
-                name=f'mcb_{artifact_name}',
-                text=f'{module_infos[0]} [{module_infos[1]} | {module_infos[2]}.py]',
-                variable=module_infos[-1],
-                onvalue=True,
-                offvalue=False,
-                command=get_selected_modules,
-                style='Module.TCheckbutton')
+            if is_platform_macos():
+                cb = ttk.Checkbutton(
+                    mlist_text,
+                    name=f'mcb_{artifact_name}',
+                    text=f'{module_infos[0]} [{module_infos[1]} | {module_infos[2]}.py]',
+                    variable=module_infos[-1],
+                    onvalue=True,
+                    offvalue=False,
+                    command=get_selected_modules,
+                    style='Module.TCheckbutton')
+            else:
+                cb = tk.Checkbutton(
+                    mlist_text,
+                    name=f'mcb_{artifact_name}',
+                    text=f'{module_infos[0]} [{module_infos[1]} | {module_infos[2]}.py]',
+                    variable=module_infos[-1],
+                    onvalue=True,
+                    offvalue=False,
+                    command=get_selected_modules)
+                cb.config(
+                    background=theme_bgcolor,
+                    fg=theme_fgcolor,
+                    selectcolor=theme_inputcolor,
+                    highlightthickness=0,
+                    activebackground=theme_bgcolor,
+                    activeforeground=theme_fgcolor)
             mlist_text.window_create('insert', window=cb)
             mlist_text.insert('end', '\n')
     mlist_text.config(state='disabled')


### PR DESCRIPTION
## Summary
- keep themed ttk module checkboxes on macOS
- restore native Tk module checkboxes on Windows and Linux so selected items show a visible checkmark
- preserve scrolling, filtering, and select/deselect behavior

## Verification
- exercised both platform widget paths
- verified native non-macOS checkbox toggling
- passed py_compile, differential Pylint, and git diff --check

Implemented by Alexis Brignoni with assistance from OpenAI Codex.