### PR TITLE
Remove every remote destination from the HTML report

### DIFF
--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -8,16 +8,26 @@ HTML/JavaScript injection sink: malicious content in a parsed return renders liv
 the examiner's report (stored XSS, CWE-79).
 
 Route every evidence-derived value in an ``html_columns`` cell through these helpers so
-the dynamic parts are escaped while the tool's own structural markup (``<a>``, ``<br>``,
+the dynamic parts are escaped while the tool's own structural markup (``<br>``,
 ``<table>``) is preserved.
+
+**A report links to nothing outside its own folder.** A remote destination in a
+report is a disclosure channel: an ``<img src="https://...">`` is fetched the moment
+the report is opened, with no click, which tells whoever controls that host that the
+account is under examination, when, and from which IP address. An ``<a href>`` needs a
+click but reaches the same place. Reports are read on analyst workstations and mailed
+to counsel, so no ``href`` or ``src`` may leave the report folder -- not ``http``,
+``https``, ``ftp``, and not ``mailto``/``tel``, which hand the subject's own address or
+number to a mail client or dialer.
+
+Evidence URLs are still *evidence*, so nothing is dropped: they are rendered as escaped
+text the examiner can read and copy. Only the anchor goes away. Report-relative
+destinations -- ``media/<file>`` thumbnails, files an artifact writes beside the report
+-- stay clickable through ``safe_local_link()``; they resolve offline and reach nothing.
 """
 
 import html
 from urllib.parse import urlparse
-
-# Schemes we are willing to turn into a live <a href>. Anything else (notably
-# javascript: and data:) is rendered as escaped text, never as a clickable link.
-ALLOWED_URL_SCHEMES = ('http', 'https', 'mailto', 'tel', 'ftp', 'ftps')
 
 
 def esc(value):
@@ -31,25 +41,42 @@ def esc(value):
     return html.escape(str(value), quote=True)
 
 
-def safe_url(url, text=None, target='_blank'):
-    """Build an ``<a href>`` anchor with an escaped, scheme-checked href.
+def safe_url(url, text=None, target=None):      # pylint: disable=unused-argument
+    """Render an evidence URL as escaped text. **Never returns a link.**
 
-    Returns the escaped visible text with **no** anchor when the URL is empty or its
-    scheme is not allowlisted, so ``javascript:``/``data:`` URLs never become live
-    links. ``text`` (the visible label) defaults to the URL itself.
+    A URL read out of an extraction names a host chosen by whoever wrote the data, so
+    it is exactly the destination a report must not reach; see the module docstring.
+    The URL itself is evidence and is preserved verbatim as escaped text, so an
+    examiner can read it, copy it, and open it deliberately elsewhere.
+
+    ``text`` overrides the visible string when the caller has a better label than the
+    raw URL. ``target`` is accepted and ignored: it exists so the call sites that
+    passed it before this became text-only keep working.
     """
     url = '' if url is None else str(url).strip()
-    label = esc(text if text is not None else url)
-    if not url:
+    return esc(text if text is not None else url)
+
+
+def safe_local_link(path, text=None):
+    """Build an ``<a href>`` to a file inside the report folder.
+
+    This is the only helper that still emits an anchor. The destination must be
+    report-relative -- no scheme, no protocol-relative ``//host``, no absolute path,
+    and no ``..`` escaping the folder -- so following it can never leave the report.
+    Anything else is returned as escaped text with no anchor.
+    """
+    path = '' if path is None else str(path).strip()
+    label = esc(text if text is not None else path)
+    if not path:
+        return label
+    if path.startswith(('/', '\\', '//')) or '..' in path.replace('\\', '/').split('/'):
         return label
     try:
-        scheme = urlparse(url).scheme.lower()
+        if urlparse(path).scheme:
+            return label
     except ValueError:
         return label
-    if scheme not in ALLOWED_URL_SCHEMES:
-        return label
-    rel = ' rel="noopener noreferrer"' if target == '_blank' else ''
-    return f'<a href="{esc(url)}" target="{esc(target)}"{rel}>{label}</a>'
+    return f'<a href="{esc(path)}" target="_blank">{label}</a>'
 
 
 def safe_join(values, sep='<br>'):


### PR DESCRIPTION
## Why

Port of iLEAPP #1887, keeping `html_safe.py` byte-identical across the cores that carry it.

A remote `href` or `src` in a report is a disclosure channel: following one — or in the `<img>` case merely opening the report — tells whoever controls that host that the account is under examination, when, and from which IP address. Reports are read on analyst workstations and mailed to counsel, so a report should reach nothing outside its own folder.

## What changed

- `safe_url()` no longer builds an anchor. It returns the URL as escaped text, so the evidence stays readable and copyable while the destination goes. The scheme allowlist it used to gate anchors on goes with them.
- `safe_local_link()` is added for the destinations that stay: report-relative paths. It refuses a scheme, a protocol-relative `//host`, an absolute path, and any `..` segment.

No artifact in this core builds an anchor by hand, so the helper is the whole change.

This matters more than a zero-diff port looks: an artifact calling `safe_url()` was still emitting a live remote anchor here, because this core carried the old anchor-building version of the helper.

## Validation

- `py_compile` clean
- `safe_url` returns no anchor for a remote URL; `safe_local_link` anchors a report-relative path and refuses a remote one
- `PluginLoader` loads every plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)