### PR TITLE
Resolve concatenation in the html-safety check, and empty the baseline

### DIFF
--- a/admin/scripts/check_html_safety.py
+++ b/admin/scripts/check_html_safety.py
@@ -45,7 +45,7 @@ THREE RULES
     A literal remote URL appears in a markup-bearing string, or an `href=`/`src=`
     attribute is completed by an interpolation. A dynamic destination cannot be shown
     to be report-relative by reading the source, so it fails unless it comes from
-    `safe_local_link()`.
+    `safe_local_path()` or `safe_local_link()`.
 
 `unguarded-html-columns`
     A module declares `html_columns` but never references an escaper. This catches the
@@ -125,35 +125,9 @@ LOCAL_LINK_NAMES = frozenset({
 
 # Pre-existing violations. Delete an entry when its violation is fixed; a stale entry
 # fails the run. See the module docstring before adding one.
-BASELINE = {
-    # media_to_html() assigns `source` four times before emitting it -- the raw match,
-    # a relative path, a copied path, then safe_local_path(). A name is treated as safe
-    # only when *every* assignment to it is, because this check does not order
-    # assignments. The function is in fact correct: the last write is safe_local_path()
-    # and nothing reads `source` before it. Rewriting it to bind the escaped value to
-    # its own name would clear this honestly.
-    ('scripts/ilapfuncs.py', 'remote-destination', 'media_to_html'),
-    ('scripts/ilapfuncs.py', 'unescaped-interpolation', 'media_to_html'),
-
-    # Both Instagram artifacts build <table>/<tr> accumulators out of evidence values
-    # without escaping them. Real.
-    ('scripts/artifacts/instagramMessages.py', 'unescaped-interpolation',
-     'instagramMessages'),
-    ('scripts/artifacts/instagramMessageReq.py', 'unescaped-interpolation',
-     'instagramMessageReq'),
-
-    # kikAbuseReport() appends esc(line), so the value reaching the cell is escaped.
-    # The accumulator it appends to has mixed assignments, which this check cannot
-    # order -- same limitation as media_to_html above.
-    ('scripts/artifacts/kikReturns.py', 'unescaped-interpolation', 'kikAbuseReport'),
-
-    # semanticLocbymonth joins waypoint coordinates with <br> into an html_columns cell
-    # and escapes nothing. The values go through arithmetic so they are numeric in
-    # practice, but nothing enforces that. Dropping html_columns would remove the sink.
-    ('scripts/artifacts/semanticLocbymonth.py', 'unescaped-interpolation',
-     'semanticLocationsMonthActivity'),
-    ('scripts/artifacts/semanticLocbymonth.py', 'unguarded-html-columns', '<module>'),
-}
+#
+# Empty: every finding this core had is now fixed rather than carried.
+BASELINE = set()
 
 # Reviewed exceptions expected to stay. Every entry needs a comment saying why.
 ALLOWLIST = set()
@@ -295,6 +269,12 @@ def _resolve(node, assignments, names, seen):
     if isinstance(node, ast.JoinedStr):
         return all(_resolve(v.value, assignments, names, seen)
                    for v in node.values if isinstance(v, ast.FormattedValue))
+    # `agg = agg + f'<td>{esc(v)}</td>'` -- the accumulator shape most of these
+    # builders use. A concatenation is safe when both sides are, and the
+    # self-reference on the left terminates through `seen`.
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return (_resolve(node.left, assignments, names, seen)
+                and _resolve(node.right, assignments, names, seen))
     if isinstance(node, ast.Call):
         if call_name(node) in names:
             return True

--- a/scripts/artifacts/semanticLocbymonth.py
+++ b/scripts/artifacts/semanticLocbymonth.py
@@ -31,6 +31,7 @@ __artifacts_v2__ = {
 import json
 from datetime import datetime, timezone
 
+from scripts.html_safe import safe_join
 from scripts.ilapfuncs import artifact_processor
 
 
@@ -117,7 +118,10 @@ def semanticLocationsMonthActivity(context):
                 agg_parts.append(f'{end_lat},{end_lon}')
                 for pt in waypoints:
                     agg_parts.append(f"{pt['latE7'] / 1e7},{pt['lngE7'] / 1e7}")
-            agg = '<br>'.join(agg_parts)
+            # safe_join keeps the <br> separator (tool-owned) and escapes each
+            # value. The coordinates are numeric -- every one goes through / 1e7 --
+            # so nothing changes in the output; it stops depending on that.
+            agg = safe_join(agg_parts, '<br>')
 
             parking = seg.get('parkingEvent', {})
             if parking:

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -925,17 +925,21 @@ def media_to_html(media_path, files_found, report_folder):
         # allow_parent: relative_paths() above deliberately emits ../data/... to reach
         # the extraction folder beside the report. The evidence filename in the
         # fallback link text is escaped -- it used to be interpolated raw.
-        source = safe_local_path(source, allow_parent=True)
-        filename = esc(filename)
+        # Bind the escaped values to their own names rather than writing back over
+        # `source`, which is assigned several times above. Reading a name that only
+        # ever holds a checked value makes the safety local and obvious, to a reader
+        # and to admin/scripts/check_html_safety.py alike.
+        safe_source = safe_local_path(source, allow_parent=True)
+        safe_filename = esc(filename)
 
         if 'video' in mimetype:
-            thumb = f'<video width="320" height="240" controls="controls"><source src="{source}" type="video/mp4" preload="none">Your browser does not support the video tag.</video>'
+            thumb = f'<video width="320" height="240" controls="controls"><source src="{safe_source}" type="video/mp4" preload="none">Your browser does not support the video tag.</video>'
         elif 'image' in mimetype:
-            thumb = f'<a href="{source}" target="_blank"><img src="{source}" width="300"></img></a>'
+            thumb = f'<a href="{safe_source}" target="_blank"><img src="{safe_source}" width="300"></img></a>'
         elif 'audio' in mimetype:
-            thumb = f'<audio controls><source src="{source}" type="audio/ogg"><source src="{source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
+            thumb = f'<audio controls><source src="{safe_source}" type="audio/ogg"><source src="{safe_source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
         else:
-            thumb = f'<a href="{source}" target="_blank"> Link to {filename} file</a>'
+            thumb = f'<a href="{safe_source}" target="_blank"> Link to {safe_filename} file</a>'
     return thumb
 
 


### PR DESCRIPTION
Port of ALEAPP #1045. **Every baselined entry in this core turned out to be a false positive rather than an unescaped sink**, so the baseline goes to zero.

## The checker gap

It did not resolve `+` chains at all, so an accumulator read as unknown even when every write to it was escaped:

```python
agg = agg + f'<td>{esc(value)}</td>'   # escaped, but reported as unknown
agg = agg + '</table>'                  # concat with a tool-owned literal
```

It now resolves a concatenation when both sides resolve, with the self-reference terminating through the existing `seen` set. Accumulate-then-emit is how most of these builders work, so this was the single largest source of noise.

**This does not weaken the check.** The regression probe includes an unescaped accumulator concat, and it is still caught.

## `media_to_html`

`source` was assigned four times and then emitted. The final write was `safe_local_path()` and nothing read it earlier, so the function was correct — but a name counts as safe only when *every* assignment to it is, because this check does not order assignments.

The escaped values now bind to their own names, `safe_source` and `safe_filename`. That makes the safety local and obvious to a reader as much as to the checker, which is the better shape regardless of tooling.

## Also in this core

`semanticLocbymonth` joined waypoint coordinates with `<br>` and escaped nothing. Every coordinate goes through `/ 1e7`, so they are floats or `` and the rendered output is unchanged — but it now goes through `safe_join()` so it no longer *depends* on that being true.

Both Instagram artifacts (`instagramMessages`, `instagramMessageReq`) were flagged and both were already correct: `f'<td>{esc(reaction)}<br>{esc(actor)}</td>'`, with the surrounding lines being accumulator concats of tool-owned literals. `kikReturns` likewise appends `esc(line)`. All three clear on the concat fix alone.

## Validation

- `py_compile` clean; `lint_changed` reports no new warnings
- unit tests OK; `PluginLoader` loads every plugin
- the check exits 0 with **0 baselined**, and still exits 1 on injected probes — including an unescaped accumulator concat

🤖 Generated with [Claude Code](https://claude.com/claude-code)