### PR TITLE
fix: concurrent runs corrupt history.json, and a corrupt one stops startup

### DIFF
--- a/leapp_functions/app/history.py
+++ b/leapp_functions/app/history.py
@@ -129,7 +129,10 @@ def _atomic_write_json(path, data):
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_suffix(".tmp")
+    # Unique per process: concurrent runs sharing one temp path interleave their
+    # writes into it, which lands a concatenated document in the real file and
+    # makes the second os.replace fail because the first already moved it.
+    temp_path = path.with_suffix(f".tmp.{os.getpid()}")
 
     try:
         with open(temp_path, "w", encoding="utf-8") as f:
@@ -162,6 +165,15 @@ def _read_json(path, default=None):
             return json.load(f)
     except OSError as e:
         logger.error("Failed to read history/settings file at %s: %s", path, e)
+        return default
+    except ValueError as e:
+        # Unreadable JSON here is a damaged convenience file, not a reason to stop
+        # parsing evidence. Keep a copy so the damage can be looked at later.
+        logger.error("History/settings file at %s is not valid JSON (%s); ignoring it", path, e)
+        try:
+            os.replace(path, f"{path}.corrupt.bak")
+        except OSError:
+            pass
         return default
 
 


### PR DESCRIPTION
Two defects in the run-history file, neither platform specific. Levelled across all five cores so they stay in step.

## 1. Concurrent runs corrupt history.json

`_atomic_write_json` writes to a temp file and then `os.replace`s it, which is correct on its own. But **every process uses the same temp path**, `history.tmp`. Run two parses at once and they interleave into that one file, so the document that lands in `history.json` can be two documents concatenated, and whichever process replaces second fails with `No such file or directory: history.tmp`.

The temp path is now unique per process.

## 2. A corrupt history.json stops the tool parsing evidence

`_read_json` catches only `OSError`. A `JSONDecodeError` propagates out of startup and kills the run before any artifact executes:

```
File "leapp_functions/app/history.py", line 252, in _record_path
    history_data = _read_json(get_history_path())
json.decoder.JSONDecodeError: Extra data: line 149 column 2
```

A damaged *convenience* file should never prevent evidence being parsed. It now logs, preserves the file as `.corrupt.bak`, and continues with defaults.

## How this surfaced

Running five parses in parallel against a corpus. The history file was left holding two concatenated JSON documents, and every subsequent run then died at startup with the traceback above until the file was moved aside. A `history.json.corrupt.bak` dated 27 June was already sitting next to it, so this had happened before.

## Verification (live, on real runs)

Six simultaneous runs against a deliberately corrupted `history.json`, three rounds, each killed once past the history write. Everything relevant happens at startup, so there is no need to let parsing finish:

| | original | fixed |
|---|---|---|
| runs | 18 | 18 |
| **reached parsing** | **0** | **18** |
| **startup crashes** | **18** | **0** |
| history left corrupt | 3/3 | 0/3 |
| stray temp files | 0 | 0 |

The damaged file is preserved as `history.json.corrupt.bak` rather than discarded.


## Levelled across the cores

Same fix in all five, byte-identical files so they do not drift: [iLEAPP #1915](https://github.com/abrignoni/iLEAPP/pull/1915), [ALEAPP #1080](https://github.com/abrignoni/ALEAPP/pull/1080), [DLEAPP #60](https://github.com/abrignoni/DLEAPP/pull/60), [VLEAPP #116](https://github.com/abrignoni/VLEAPP/pull/116).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

