### PR TITLE
ci: run the runtime contract on every supported Python

### DIFF
--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        # The versions README.md tells users to run
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The README tells users Python 3.10 or above, but the runtime-contract job stopped short of current releases, leaving new-Python breakage (stdlib removals, tightened APIs like the plistlib aware_datetime change) untested on the versions most users actually have. This levels the matrix to 3.10 through 3.14, matching iLEAPP.

Pre-flight: this repo's full admin test suite was run locally on Python 3.14 (pip install of requirements.txt plus unittest discover over admin/test/scripts) and passes.

Part of a CI leveling pass across the five cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)