### PR TITLE
fix: collect the packages artifacts import into frozen builds

### DIFF
--- a/scripts/pyinstaller/rleapp.spec
+++ b/scripts/pyinstaller/rleapp.spec
@@ -2,12 +2,27 @@
 
 block_cipher = None
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
    ['..\\..\\rleapp.py'],
    pathex=['..\\scripts\\artifacts'],
    binaries=[],
    datas=[('..\\', '.\\scripts')],
    hiddenimports=[
+      # Artifacts are bundled as data files and imported from disk at runtime,
+      # so PyInstaller's import-graph analysis never sees what they import.
+      # hook-plugin_loader.py was meant to cover this but targets a bare
+      # 'plugin_loader' module that no longer exists (it moved to
+      # scripts.plugin_loader), so it never fires. Collect the packages
+      # artifacts import wholesale; a missing submodule here is a startup
+      # crash in the frozen build only. pdfminer is imported lazily by the
+      # Kik artifact with a graceful fallback, so without it the frozen
+      # build silently loses a capability dev runs have.
+      *collect_submodules('leapp_functions'),
+      *collect_submodules('PIL'),
+      *collect_submodules('pdfminer'),
+      'bs4',
       'bencoding',
       'fitz',
       'ijson',

--- a/scripts/pyinstaller/rleappGUI.spec
+++ b/scripts/pyinstaller/rleappGUI.spec
@@ -2,12 +2,27 @@
 
 block_cipher = None
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
    ['..\\..\\rleappGUI.py'],
    pathex=['..\\scripts\\artifacts'],
    binaries=[],
    datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets')],
    hiddenimports=[
+      # Artifacts are bundled as data files and imported from disk at runtime,
+      # so PyInstaller's import-graph analysis never sees what they import.
+      # hook-plugin_loader.py was meant to cover this but targets a bare
+      # 'plugin_loader' module that no longer exists (it moved to
+      # scripts.plugin_loader), so it never fires. Collect the packages
+      # artifacts import wholesale; a missing submodule here is a startup
+      # crash in the frozen build only. pdfminer is imported lazily by the
+      # Kik artifact with a graceful fallback, so without it the frozen
+      # build silently loses a capability dev runs have.
+      *collect_submodules('leapp_functions'),
+      *collect_submodules('PIL'),
+      *collect_submodules('pdfminer'),
+      'bs4',
       'bencoding',
       'fitz',
       'ijson',

--- a/scripts/pyinstaller/rleappGUI_Linux.spec
+++ b/scripts/pyinstaller/rleappGUI_Linux.spec
@@ -1,5 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../rleappGUI.py'],
     pathex=['../scripts/artifacts'],
@@ -10,6 +12,19 @@ a = Analysis(
         ('../../leapp_functions', 'leapp_functions')
         ],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only. pdfminer is imported lazily by the
+        # Kik artifact with a graceful fallback, so without it the frozen
+        # build silently loses a capability dev runs have.
+        *collect_submodules('leapp_functions'),
+        *collect_submodules('PIL'),
+        *collect_submodules('pdfminer'),
+        'bs4',
         'bencoding',
         'fitz',
         'ijson',
@@ -20,6 +35,7 @@ a = Analysis(
         'pillow_heif',
         'pypdf',
         'requests',
+        'simplekml',
         'xlrd',
     ],
     hookspath=[],

--- a/scripts/pyinstaller/rleappGUI_macOS.spec
+++ b/scripts/pyinstaller/rleappGUI_macOS.spec
@@ -1,11 +1,26 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../rleappGUI.py'],
     pathex=['scripts/artifacts'],
     binaries=[],
     datas=[('../', 'scripts'), ('../../assets', 'assets')],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only. pdfminer is imported lazily by the
+        # Kik artifact with a graceful fallback, so without it the frozen
+        # build silently loses a capability dev runs have.
+        *collect_submodules('leapp_functions'),
+        *collect_submodules('PIL'),
+        *collect_submodules('pdfminer'),
+        'bs4',
         'bencoding',
         'fitz',
         'ijson',
@@ -15,6 +30,7 @@ a = Analysis(
         'pillow_heif',
         'pypdf',
         'requests',
+        'simplekml',
         'xlrd',
     ],
     hookspath=[],

--- a/scripts/pyinstaller/rleapp_Linux.spec
+++ b/scripts/pyinstaller/rleapp_Linux.spec
@@ -1,11 +1,26 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../rleapp.py'],
     pathex=['../scripts/artifacts'],
     binaries=[],
     datas=[('../', 'scripts')],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only. pdfminer is imported lazily by the
+        # Kik artifact with a graceful fallback, so without it the frozen
+        # build silently loses a capability dev runs have.
+        *collect_submodules('leapp_functions'),
+        *collect_submodules('PIL'),
+        *collect_submodules('pdfminer'),
+        'bs4',
         'bencoding',
         'fitz',
         'ijson',
@@ -15,6 +30,7 @@ a = Analysis(
         'pillow_heif',
         'pypdf',
         'requests',
+        'simplekml',
         'xlrd',
     ],
     hookspath=[],

--- a/scripts/pyinstaller/rleapp_macOS.spec
+++ b/scripts/pyinstaller/rleapp_macOS.spec
@@ -1,11 +1,26 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../rleapp.py'],
     pathex=['../scripts/artifacts'],
     binaries=[],
     datas=[('../', 'scripts')],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only. pdfminer is imported lazily by the
+        # Kik artifact with a graceful fallback, so without it the frozen
+        # build silently loses a capability dev runs have.
+        *collect_submodules('leapp_functions'),
+        *collect_submodules('PIL'),
+        *collect_submodules('pdfminer'),
+        'bs4',
         'bencoding',
         'fitz',
         'ijson',
@@ -15,6 +30,7 @@ a = Analysis(
         'pillow_heif',
         'pypdf',
         'requests',
+        'simplekml',
         'xlrd',
     ],
     hookspath=[],


### PR DESCRIPTION
Pre-flight for the test_builds workflow port, fixing the same frozen-build defect class ALEAPP #1097 fixed: artifacts are bundled as data files and imported from disk at runtime, so PyInstaller's import-graph analysis never sees what they import, and the existing hook-plugin_loader.py never fires (it targets a bare plugin_loader module; the loader moved to scripts.plugin_loader).

What was missing, found by enumerating every third-party import across scripts/ against the spec lists:

- bs4 (chromeReadingList, fbigPhotos and others import it; nothing else pulls it into the graph)
- every leapp_functions.data_sources module artifacts import
- simplekml in the four non-Windows specs only (the Windows specs had it)
- pdfminer: the Kik artifact imports it lazily with a graceful fallback, so a frozen build without it silently loses PDF parsing that dev runs have

All six specs now collect leapp_functions, PIL and pdfminer wholesale and add bs4. Verified locally: built rleapp_macOS.spec on Python 3.14 with these changes and ran the frozen CLI end to end (--help plus an empty-input run): 385 modules loaded, exit 0, no import errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)