### PR TITLE
ci: add manual PyInstaller test-build workflow

### DIFF
--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -1,0 +1,144 @@
+name: Test builds
+
+# Build the CLI and GUI binaries with PyInstaller on every platform PyInstaller
+# cannot cross-build for, smoke-test them on their own architecture, and upload
+# them as workflow artifacts.
+#
+# Manual only. This is not the release pipeline; it exists so testable binaries can
+# be produced and actually executed per platform without anyone owning the hardware.
+#
+# The smoke tests are the point, not decoration: iLEAPP's frozen builds shipped a
+# startup crash for a long time (missing hidden imports) precisely because nothing
+# ever ran a built binary. Every step here that runs a binary is a regression test
+# for that class of failure. Ported from iLEAPP's test_builds.yml minus its
+# unifiedlog parser steps, which have no RLEAPP counterpart.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            arch: x64
+          - runner: windows-11-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # Latest supported Python. PyMuPDF and pillow-heif may lack win_arm64
+          # wheels; that leg is exploratory until a run proves it.
+          python-version: '3.14'
+
+      - name: Install dependencies
+        # pyinstaller is installed after the requirements, in its own command:
+        # requirements.txt pins packaging==20.1, and resolving pyinstaller in the
+        # same command drags it back to 4.5.1 (the last release satisfied by that
+        # pin), which imports pkg_resources and cannot run on Python 3.14. The
+        # separate install lets pip upgrade packaging for the build environment.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install "pyinstaller>=6.22"
+
+      - name: Build CLI and GUI with PyInstaller
+        working-directory: scripts/pyinstaller
+        run: |
+          pyinstaller rleapp.spec --distpath ..\..\dist_build --workpath ..\..\build_tmp --noconfirm
+          pyinstaller rleappGUI.spec --distpath ..\..\dist_build --workpath ..\..\build_tmp --noconfirm
+
+      - name: Smoke test the frozen CLI
+        # --help proves the exe survives its imports (the historical crash class).
+        # The empty-input run proves module loading, report generation, and clean
+        # exit end to end; it must succeed with "no data found" everywhere.
+        run: |
+          dist_build\rleapp.exe --help
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          New-Item -ItemType Directory -Path smoke_in, smoke_out | Out-Null
+          "placeholder" | Out-File smoke_in\placeholder.txt
+          dist_build\rleapp.exe -t fs -i smoke_in -o smoke_out
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Package artifact
+        run: |
+          New-Item -ItemType Directory -Path artifact | Out-Null
+          Copy-Item dist_build\rleapp.exe artifact\
+          Copy-Item dist_build\rleappGUI.exe artifact\
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rleapp-windows-${{ matrix.arch }}-test
+          path: artifact/
+          retention-days: 14
+
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install tk libraries for the GUI build
+        # The GUI imports tkinter; PyInstaller needs the import to succeed at
+        # analysis time. The hard check turns a missing-toolkit problem into a
+        # readable failure instead of a cryptic PyInstaller one.
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q libtcl8.6 libtk8.6
+          python -c "import tkinter" || { echo "tkinter unavailable in this Python"; exit 1; }
+
+      - name: Install dependencies
+        # pyinstaller is installed after the requirements, in its own command:
+        # requirements.txt pins packaging==20.1, and resolving pyinstaller in the
+        # same command drags it back to 4.5.1 (the last release satisfied by that
+        # pin), which imports pkg_resources and cannot run on Python 3.14. The
+        # separate install lets pip upgrade packaging for the build environment.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install "pyinstaller>=6.22"
+
+      - name: Build CLI and GUI with PyInstaller
+        working-directory: scripts/pyinstaller
+        run: |
+          pyinstaller rleapp_Linux.spec --distpath ../../dist_build --workpath ../../build_tmp --noconfirm
+          pyinstaller rleappGUI_Linux.spec --distpath ../../dist_build --workpath ../../build_tmp --noconfirm
+
+      - name: Smoke test the frozen CLI
+        run: |
+          dist_build/rleapp --help
+          mkdir smoke_in smoke_out
+          echo placeholder > smoke_in/placeholder.txt
+          dist_build/rleapp -t fs -i smoke_in -o smoke_out
+
+      - name: Package artifact
+        run: |
+          mkdir artifact
+          cp dist_build/rleapp dist_build/rleappGUI artifact/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rleapp-linux-${{ matrix.arch }}-test
+          path: artifact/
+          retention-days: 14


### PR DESCRIPTION
Port of ALEAPP's test_builds.yml with names adapted. On manual dispatch it builds the CLI and GUI with PyInstaller on Windows x64/arm64 and Linux x64/arm64, smoke-tests each frozen CLI (--help plus an end-to-end empty-input run that must exit cleanly), and uploads the binaries as 14-day workflow artifacts. Not a release pipeline; it exists so testable binaries can be produced and actually executed per platform.

ALEAPP's two first-dispatch lessons are baked in from the start: pyinstaller>=6.22 installs in its own pip command (requirements.txt pins packaging==20.1, which would otherwise drag pyinstaller down to 4.5.1, dead on Python 3.14), and the hidden-import gaps in the specs are fixed in #407, which this builds on. The frozen CLI was verified locally on macOS before this: 385 modules loaded, clean exit. The Windows arm64 leg is exploratory (PyMuPDF and pillow-heif wheel coverage there is unproven); fail-fast is off, so a red leg is information.

I will dispatch a run after merge and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)