### PR TITLE
Skip non-Messenger JSONs in get_fb_messages instead of crashing

### DIFF
--- a/scripts/artifacts/facebookE2EMessages.py
+++ b/scripts/artifacts/facebookE2EMessages.py
@@ -45,16 +45,27 @@ def get_fb_messages(context):
         if filename.endswith('.json'):
 
             with open(file_found, "r", encoding='utf-8') as fp:
-                deserialized = json.load(fp)
+                try:
+                    deserialized = json.load(fp)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
 
+            # the glob matches every JSON in a return package; only process
+            # files with the Messenger export shape
+            if not isinstance(deserialized, dict):
+                continue
             participants = deserialized.get('participants')
+            messages = deserialized.get('messages')
+            if not isinstance(participants, list) or not participants \
+                    or not isinstance(messages, list):
+                continue
             owner = participants[0]
             without_owner = [p for p in participants if p != owner]
             without_owner = ", ".join(without_owner)
 
             thread = deserialized.get('threadName')
 
-            for x in deserialized['messages']:
+            for x in messages:
                 sender_name = x.get('senderName', '')
                 unsent = x.get('isUnsent', '')
                 timestamp = x.get('timestamp', '')


### PR DESCRIPTION
get_fb_messages globs */*.json, so in any return package it matches every JSON and then assumed the Messenger export shape. On a Google Takeout the first foreign JSON killed the artifact: a top-level list raised AttributeError on .get, and a dict without participants raised TypeError on participants[0].

Guard the shape: skip files that fail to parse, are not a dict, or lack a non-empty participants list and a messages list. A real Messenger-shaped export still parses (round-trip validated, 2 messages with conversation columns intact; shape-verified rather than corpus-verified since no registered corpus carries a Messenger E2E export yet). A full RLEAPP run over a 2021 Google Takeout goes from an artifact-killing traceback to zero error lines, with the correct empty result for Facebook Messenger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)