### PR TITLE
Check artifact notes for unsupported claim language

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -140,11 +140,70 @@ CLAIM_PATTERN = re.compile(
     r'|\balways\b'
     r'|\breliable'
     r'|\bvisited\b'
-    r'|\bhabit',
+    r'|\bhabits?\b',
     re.IGNORECASE)
 
+# `notes` reaches the examiner too, in the report and in the artifact info modal, so
+# the same standard applies to it. It cannot use the same vocabulary, because notes do
+# a job name and description do not: they state what was tested. "empty on all 18
+# copies tested" and "NULL for every account tested" are the coverage discipline this
+# project asks for, not claims about a person, and the completeness words fire on every
+# one of them. Measured 2026-08-29: the full vocabulary flags 368 of the 1,477
+# artifacts carrying notes across the five cores, dominated by `every` and `all`,
+# almost all describing a test set.
+#
+# `read by` comes out for the same reason. In a note it means read by the code, not by
+# a person: "columns are read by position", "not read by this artifact".
+#
+# What is left is attribution and certainty, which mean the same thing in a note as in
+# a description.
+NOTES_PATTERN = re.compile(
+    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent'
+    r'|created|hid|chose)\b'
+    r'|\buser[- ](?:created|entered|typed|searched|selected|initiated)\b'
+    r'|\bsearched by\b'
+    r'|\btyped by\b'
+    r'|\bviewed by\b'
+    r'|\bmanually\b'
+    r'|\bproves?\b'
+    r'|\bdefinitively\b'
+    r'|\balways\b'
+    r'|\breliable'
+    r'|\bvisited\b'
+    r'|\bhabits?\b',
+    re.IGNORECASE)
+
+# A note that *denies* a claim uses the same words as one that makes it: "not terms the
+# user searched for", "does not establish that the user viewed them". That denial is the
+# wording this project asks for, so matching it and demanding an allowlist entry would
+# tax the correct behaviour and grow the allowlist without bound. A match in `notes`
+# preceded by a negation inside the same clause is therefore not reported.
+#
+# The window is deliberately short. A negation two sentences back says nothing about
+# this clause, and a long window would swallow real claims. Suppressed matches are
+# counted and printed under --verbose, because a check that narrows its own scope
+# silently is worse than no check.
+NEGATION_WINDOW = 60
+NEGATION_PATTERN = re.compile(
+    r"\b(not|no|never|nor|neither|without|cannot|rather than|instead of"
+    r"|isn't|doesn't|don't|does not|do not)\b",
+    re.IGNORECASE)
+
+
+def negated(text, start):
+    """True when a negation appears close enough before `start` to govern it."""
+    window = text[max(0, start - NEGATION_WINDOW):start]
+    # A sentence boundary ends the clause, so a negation before it does not govern.
+    window = window.rsplit('. ', 1)[-1]
+    return bool(NEGATION_PATTERN.search(window))
+
+
 # Fields that reach the examiner through the report and the LAVA manifest.
-CHECKED_FIELDS = ('name', 'description')
+CHECKED_FIELDS = {
+    'name': CLAIM_PATTERN,
+    'description': CLAIM_PATTERN,
+    'notes': NOTES_PATTERN,
+}
 
 # Reviewed exceptions, keyed by (filename, artifact_key, field). Every entry
 # needs a comment justifying it. See the module docstring before adding one.
@@ -157,6 +216,10 @@ ALLOWLIST = {
     # allowlist: renaming it would make the artifact harder to match to what the
     # examiner sees in the export.
     ('takeoutGoogleMail.py', 'takeoutGoogleMail', 'description'),
+
+    # "opened and reviewed manually from the report" describes what the examiner does
+    # with the checked-in HTML, not anything the device user did.
+    ('takeoutMyActivity.py', 'takeoutMyActivity', 'notes'),
 }
 
 STANDARD_NOTE = (
@@ -210,30 +273,36 @@ def load_artifacts(path):
 
 
 def scan_file(path):
-    """Return (matches, skip_reason) for one artifact module.
+    """Return (matches, skip_reason, negated_count) for one artifact module.
 
     Each match is a (path, artifact_key, field, text, matched_terms, allowlisted)
     tuple.
     """
     artifacts, skip_reason = load_artifacts(path)
     if artifacts is None:
-        return [], skip_reason
+        return [], skip_reason, 0
 
     filename = os.path.basename(path)
     matches = []
+    negated_count = 0
     for artifact_key, entry in artifacts.items():
         if not isinstance(entry, dict):
             continue
-        for field in CHECKED_FIELDS:
+        for field, pattern in CHECKED_FIELDS.items():
             text = entry.get(field)
             if not isinstance(text, str):
                 continue
-            terms = CLAIM_PATTERN.findall(text)
+            hits = list(pattern.finditer(text))
+            if field == 'notes':
+                kept = [hit for hit in hits if not negated(text, hit.start())]
+                negated_count += len(hits) - len(kept)
+                hits = kept
+            terms = [hit.group(0) for hit in hits]
             if not terms:
                 continue
             allowlisted = (filename, str(artifact_key), field) in ALLOWLIST
             matches.append((path, str(artifact_key), field, text, terms, allowlisted))
-    return matches, None
+    return matches, None, negated_count
 
 
 def artifact_paths():
@@ -272,9 +341,11 @@ def main():
     allowlisted = []
     skipped = []
     fired = set()
+    negated_total = 0
     for path in paths:
         rel_path = os.path.relpath(path, REPO_ROOT)
-        matches, skip_reason = scan_file(path)
+        matches, skip_reason, negated_here = scan_file(path)
+        negated_total += negated_here
         if skip_reason:
             skipped.append((rel_path, skip_reason))
             continue
@@ -305,6 +376,8 @@ def main():
               f'{len(skipped)} skipped.')
         print(f'Allowlist holds {len(ALLOWLIST)} entr(ies); {len(allowlisted)} fired '
               f'this run.')
+        print(f'{negated_total} match(es) in notes were preceded by a negation and '
+              f'not reported.')
         print()
 
     if stale:

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -1,0 +1,179 @@
+"""Prove the claim checker reads notes, reads them with the right vocabulary, and
+that the vocabulary is the same one every core enforces.
+
+Extending the check to `notes` is only worth having if three things hold at once, and
+each fails silently on its own:
+
+* notes are actually matched, or the field is nominally covered and never read;
+* the completeness words do not apply to notes, or the check fires on every artifact
+  that states what it was tested against, which is the wording this project asks for;
+* a denial is not treated as a claim, or the same wording is taxed and the allowlist
+  grows every time somebody writes a limitation down correctly.
+
+The vocabulary is pinned to a literal here. The five cores each carry their own copy of
+the checker, and they had already drifted: four spelled the habit stem open, so
+"habitat" matched, and only one had it closed. A checker that quietly enforces a
+different standard per repo is worse than a strict one, and nothing else compares them.
+This file is identical in all five, so a change made in one repo alone fails that
+repo's own CI.
+
+The expected values are spelled out rather than derived from the patterns under test.
+A fixture built from the constant it verifies moves with the bug.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_claim_language.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_claim_language', _MODULE_PATH)
+ccl = importlib.util.module_from_spec(_spec)
+sys.modules['check_claim_language'] = ccl
+_spec.loader.exec_module(ccl)
+
+# The vocabulary every core is expected to enforce, written out rather than imported.
+EXPECTED_CLAIM = (
+    r'\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|'
+    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
+    r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
+    r'searched|selected|initiated)\b|\bsearched by\b|\btyped by\b|'
+    r'\bviewed by\b|\bread by\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
+    r'\balways\b|\breliable|\bvisited\b|\bhabits?\b'
+)
+EXPECTED_NOTES = (
+    r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
+    r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
+    r'searched|selected|initiated)\b|\bsearched by\b|\btyped by\b|'
+    r'\bviewed by\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|'
+    r'\breliable|\bvisited\b|\bhabits?\b'
+)
+EXPECTED_NEGATION = (
+    r'\b(not|no|never|nor|neither|without|cannot|rather than|instead of|'
+    r"isn't|doesn't|don't|does not|do not)\b"
+)
+EXPECTED_FIELDS = ('description', 'name', 'notes')
+
+
+def fires(field, text):
+    """True when the vocabulary for `field` reports a match in `text`, negation applied."""
+    pattern = ccl.CHECKED_FIELDS[field]
+    hits = list(pattern.finditer(text))
+    if field == 'notes':
+        hits = [hit for hit in hits if not ccl.negated(text, hit.start())]
+    return bool(hits)
+
+
+class VocabularyParity(unittest.TestCase):
+    """The five cores must enforce one standard. Drift in any of them fails here."""
+
+    def test_claim_vocabulary_is_the_shared_one(self):
+        self.assertEqual(ccl.CLAIM_PATTERN.pattern, EXPECTED_CLAIM)
+
+    def test_notes_vocabulary_is_the_shared_one(self):
+        self.assertEqual(ccl.NOTES_PATTERN.pattern, EXPECTED_NOTES)
+
+    def test_negation_vocabulary_is_the_shared_one(self):
+        self.assertEqual(ccl.NEGATION_PATTERN.pattern, EXPECTED_NEGATION)
+        self.assertEqual(ccl.NEGATION_WINDOW, 60)
+
+    def test_the_same_three_fields_are_checked(self):
+        self.assertEqual(tuple(sorted(ccl.CHECKED_FIELDS)), EXPECTED_FIELDS)
+
+    def test_the_habit_stem_is_closed(self):
+        # The open stem also matches "habitat". Four cores carried that until 2026-08-29.
+        self.assertFalse(ccl.CLAIM_PATTERN.search('habitat'))
+        self.assertFalse(ccl.NOTES_PATTERN.search('habitat'))
+        self.assertTrue(ccl.CLAIM_PATTERN.search('habits'))
+
+
+class FieldCoverage(unittest.TestCase):
+    def test_notes_is_checked(self):
+        self.assertIn('notes', ccl.CHECKED_FIELDS)
+
+    def test_name_and_description_keep_the_full_vocabulary(self):
+        self.assertIs(ccl.CHECKED_FIELDS['name'], ccl.CLAIM_PATTERN)
+        self.assertIs(ccl.CHECKED_FIELDS['description'], ccl.CLAIM_PATTERN)
+
+    def test_notes_uses_its_own_vocabulary(self):
+        self.assertIs(ccl.CHECKED_FIELDS['notes'], ccl.NOTES_PATTERN)
+
+
+class NotesVocabulary(unittest.TestCase):
+    # Attribution and certainty mean the same thing in a note as in a description.
+    CLAIMS = (
+        'the term the user typed into the search box',
+        'a page the user visited',
+        'a term the user entered',
+        'this proves the account holder sent it',
+        'the column is always populated',
+        'a reliable record of the conversation',
+    )
+    # Notes state what was tested. These must stay silent or the check punishes the
+    # coverage discipline it exists alongside.
+    COVERAGE = (
+        'empty on all 18 copies tested',
+        'NULL for every account tested',
+        'the complete table list is given above',
+        'present on the entire corpus',
+        'columns are read by position over a select star',
+        'the sidecar is not read by this artifact',
+    )
+
+    def test_claims_fire(self):
+        for text in self.CLAIMS:
+            with self.subTest(text=text):
+                self.assertTrue(fires('notes', text))
+
+    def test_coverage_wording_stays_silent(self):
+        for text in self.COVERAGE:
+            with self.subTest(text=text):
+                self.assertFalse(fires('notes', text))
+
+    def test_notes_drops_exactly_the_two_documented_classes(self):
+        """The two vocabularies differ only where the module says they do."""
+        removed = ('all', 'every', 'complete', 'entire', 'full list', 'read by')
+        for word in removed:
+            with self.subTest(word=word, vocabulary='description'):
+                self.assertTrue(ccl.CLAIM_PATTERN.search(word))
+            with self.subTest(word=word, vocabulary='notes'):
+                self.assertFalse(ccl.NOTES_PATTERN.search(word))
+        kept = ('the user typed', 'typed by', 'manually', 'proves', 'always',
+                'reliable', 'visited', 'habits', 'user-created')
+        for word in kept:
+            with self.subTest(word=word):
+                self.assertTrue(ccl.CLAIM_PATTERN.search(word))
+                self.assertTrue(ccl.NOTES_PATTERN.search(word))
+
+    def test_description_still_flags_completeness(self):
+        # The narrowing applies to notes only. Regression guard on the original behaviour.
+        self.assertTrue(fires('description', 'every message in the conversation'))
+        self.assertTrue(fires('description', 'all sites the user visited'))
+
+
+class Negation(unittest.TestCase):
+    def test_denial_in_the_same_clause_is_not_a_claim(self):
+        for text in (
+            'this store holds suggestions the app downloaded, not terms the user searched for',
+            'their presence does not establish that the user viewed them',
+            'they evidence the app running rather than anything the user chose',
+            'the app stores no user created images',
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(fires('notes', text))
+
+    def test_a_negation_in_the_previous_sentence_does_not_carry(self):
+        # "not" governs its own clause. A full stop ends it, so the claim after it stands.
+        text = 'The table is not a cache. It records the term the user typed.'
+        self.assertTrue(fires('notes', text))
+
+    def test_a_distant_negation_does_not_carry(self):
+        # Sixty characters is the window; padding past it must leave the claim visible.
+        text = 'not' + ' x' * 45 + ' the term the user typed'
+        self.assertTrue(fires('notes', text))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Brings this core in line with ALEAPP #1242, which extended the claim-language check to the artifact `notes` field.

- `notes` is now checked. It reaches the report and the LAVA manifest and was not covered.
- Notes get their own vocabulary. The completeness words are dropped, because a note states what it was tested against ("empty on all 18 copies tested"). `read by` is dropped because in a note it means read by the code.
- A match preceded by a negation in the same clause is not reported, so a note that denies a claim is not flagged for making it. Suppressed matches are counted and printed under `--verbose`.
- Closes the habit stem in the claim vocabulary. The open spelling also matched "habitat". Four of the five cores carried it.
- The new test pins the vocabulary to a literal and is byte-identical in all five cores, so a change made in one repo alone fails that repo's own CI.

One reviewed exception allowlisted with a reason.
