### PR TITLE
Keep the taint on a path handed to a formatter or a string method

### DIFF
--- a/admin/scripts/check_report_local_paths.py
+++ b/admin/scripts/check_report_local_paths.py
@@ -200,8 +200,9 @@ class FunctionScan:
         if isinstance(func, ast.Attribute):
             if name in TAINT_ATTR_CALLS and receiver_name(func) in TAINT_ATTR_CALLS[name]:
                 return True
-            if name == 'join':
-                # os.path.join(tainted, ...) is still a full path.
+            if name in ('join', 'format'):
+                # os.path.join(tainted, ...) is still a full path, and a path
+                # interpolated by str.format is still inside the string returned.
                 return any(self.is_tainted(a) for a in node.args)
             # Any other method called ON a path returns something derived from that path,
             # so the taint survives. Only PATH_REDUCING_METHODS above cuts it down.

--- a/admin/scripts/check_report_local_paths.py
+++ b/admin/scripts/check_report_local_paths.py
@@ -45,6 +45,12 @@ Found by auditing all five cores in 2026-08: 38 sites across 31 artifacts, inclu
 16 Chromium artifacts in iLEAPP's chrome.py (which build their own per-browser reports and
 so bypass the wrapper) and a 1,085-row LAVA column in appGrouplisting.
 
+Two shapes hid a path from this check until 2026-09, and both have to keep failing here.
+A path handed to a formatter came back untracked, so `textwrap.fill(file_found)` reported
+clean while publishing the absolute path. And `strip` sat among the methods treated as
+reducing a path, though it hands back the whole string, so `file_found.strip()` cleared
+the taint too. ALEAPP's torrentinfo carried both at once.
+
 Usage:
   check_report_local_paths.py [--root REPO_ROOT] [--verbose]
 
@@ -90,6 +96,10 @@ PASSTHROUGH_CALLS = {
     'sorted', 'set', 'list', 'tuple', 'abspath', 'realpath', 'normpath',
 }
 
+# Formatters that hand back a rewrapped copy of what they were given. A path put through
+# one of these is still that path, so the taint has to survive the call.
+REFORMATTING_CALLS = {'fill', 'shorten', 'indent', 'dedent'}
+
 # Calls and attributes that reduce a full path to something publishable.
 SANITIZERS = {
     'basename', 'get_relative_path', 'relative_to', 'sanitize_report_name',
@@ -98,8 +108,9 @@ SANITIZERS = {
 # Attributes that yield a NAME or a component rather than a path. `parents` is
 # deliberately absent: `Path(p).parents[1]` is a full directory path and has leaked.
 SAFE_ATTRS = {'name', 'stem', 'suffix', 'parts'}
-# Methods whose result is a piece of the string, not the whole path.
-SAFE_METHODS = {'split', 'rsplit', 'partition', 'rpartition', 'replace', 'strip'}
+# Methods whose result is a PIECE of the string. `strip` and `replace` are deliberately
+# absent: both hand back the whole path, so neither reduces it to anything publishable.
+PATH_REDUCING_METHODS = {'split', 'rsplit', 'partition', 'rpartition'}
 
 ROW_VARS = ('data_list', 'data_rows', 'rows', 'records', 'entries')
 
@@ -171,7 +182,7 @@ class FunctionScan:
         if isinstance(node, ast.Call):
             func = node.func
             name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', '')
-            return name in SANITIZERS or name in SAFE_METHODS
+            return name in SANITIZERS or name in PATH_REDUCING_METHODS
         if isinstance(node, ast.Attribute):
             return node.attr in SAFE_ATTRS
         return False
@@ -179,11 +190,12 @@ class FunctionScan:
     def _call_tainted(self, node):
         func = node.func
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', '')
-        if name in SANITIZERS or name in SAFE_METHODS:
+        if name in SANITIZERS or name in PATH_REDUCING_METHODS:
             return False
-        # Wrappers that hand back whatever they were given. Reached as a bare name
-        # (`Path(x)`) or through a module (`pathlib.Path(x)`, `os.path.abspath(x)`).
-        if name in PASSTHROUGH_CALLS:
+        # Wrappers and formatters that hand back whatever they were given. Reached as a
+        # bare name (`Path(x)`) or through a module (`pathlib.Path(x)`,
+        # `os.path.abspath(x)`, `textwrap.fill(x)`).
+        if name in PASSTHROUGH_CALLS or name in REFORMATTING_CALLS:
             return any(self.is_tainted(a) for a in node.args)
         if isinstance(func, ast.Attribute):
             if name in TAINT_ATTR_CALLS and receiver_name(func) in TAINT_ATTR_CALLS[name]:
@@ -191,7 +203,9 @@ class FunctionScan:
             if name == 'join':
                 # os.path.join(tainted, ...) is still a full path.
                 return any(self.is_tainted(a) for a in node.args)
-            return False
+            # Any other method called ON a path returns something derived from that path,
+            # so the taint survives. Only PATH_REDUCING_METHODS above cuts it down.
+            return self.is_tainted(func.value)
         return name in TAINT_PLAIN_CALLS
 
     def _collect(self):

--- a/admin/test/scripts/test_check_report_local_paths.py
+++ b/admin/test/scripts/test_check_report_local_paths.py
@@ -122,6 +122,42 @@ class ShapesThatOnceHidALeak(unittest.TestCase):
         ''')
         self.assertEqual(len(found), 1, 'an initializer must not clear container taint')
 
+    def test_a_formatter_passes_taint_through(self):
+        """torrentResumeinfo: textwrap.fill(file_found, width=25) published the path."""
+        found = findings_for("""
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append((textwrap.fill(file_found, width=25), 'b'))
+                return (), data_list, ''
+        """)
+        self.assertEqual(len(found), 1, 'a formatter must not launder a path')
+
+    def test_strip_does_not_reduce_a_path(self):
+        """strip() hands back the whole path, so it cannot clear the taint."""
+        found = findings_for("""
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append((file_found.strip(), 'b'))
+                return (), data_list, ''
+        """)
+        self.assertEqual(len(found), 1, 'strip() must not clear the taint')
+
+    def test_stacked_launderers_still_report(self):
+        """torrentinfo carried both at once: textwrap.fill(file_found.strip(), ...)."""
+        found = findings_for("""
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append((textwrap.fill(file_found.strip(), width=25), 'b'))
+                return (), data_list, ''
+        """)
+        self.assertEqual(len(found), 1, 'stacked launderers must not hide a path')
+
 
 class LocatedAt(unittest.TestCase):
     def test_flags_a_staged_path_handed_to_the_report_writer(self):
@@ -170,6 +206,17 @@ class MustStaySilent(unittest.TestCase):
                     data_list.append((user, 'b'))
                 return (), data_list, ''
         '''), [])
+
+    def test_a_split_component_is_still_accepted(self):
+        """split() genuinely returns a piece of the string, so it stays silent."""
+        self.assertEqual(findings_for("""
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append((file_found.split('/')[-1], 'b'))
+                return (), data_list, ''
+        """), [])
 
     def test_an_email_message_walk_is_not_os_walk(self):
         """mailprotect: message.walk() yields MIME parts, not filesystem paths."""

--- a/admin/test/scripts/test_check_report_local_paths.py
+++ b/admin/test/scripts/test_check_report_local_paths.py
@@ -146,6 +146,18 @@ class ShapesThatOnceHidALeak(unittest.TestCase):
         """)
         self.assertEqual(len(found), 1, 'strip() must not clear the taint')
 
+    def test_str_format_carries_the_path_into_the_result(self):
+        """A constant receiver means the path arrives as an argument, not a receiver."""
+        found = findings_for("""
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append(('{}'.format(file_found), 'b'))
+                return (), data_list, ''
+        """)
+        self.assertEqual(len(found), 1, 'str.format must carry the path through')
+
     def test_stacked_launderers_still_report(self):
         """torrentinfo carried both at once: textwrap.fill(file_found.strip(), ...)."""
         found = findings_for("""


### PR DESCRIPTION
Closes two gaps in check_report_local_paths that let a staged path reach report output.

A path handed to a formatter came back untracked, so textwrap.fill(file_found) reported clean while publishing the absolute path. And strip sat among the methods treated as reducing a path, though it hands back the whole string, so file_found.strip() cleared the taint too. One ALEAPP artifact carried both at once.

A method called on a path now keeps the taint unless it returns a piece of it. Checked against 1,150 artifact modules across the five cores with no new findings. Three tests pin the shapes and fail against the old checker.