### PR TITLE
Show evidence relative paths in the processed files log

### DIFF
--- a/rleapp.py
+++ b/rleapp.py
@@ -436,7 +436,7 @@ def crunch_artifacts(
                         # Strip \\?\ only for log display; file_infos is keyed with the
                         # original long-path form on Windows.
                         display_path = pathh[4:] if pathh.startswith('\\\\?\\') else pathh
-                        log.write(f'<ul><li>{display_path}</li></ul>')
+                        log.write(f'<ul><li>{Context.get_relative_path(display_path)}</li></ul>')
                         if seeker.file_infos.get(pathh):
                             file_path_id = id(seeker.file_infos.get(pathh))
                             if not pattern_already_searched and file_path_id not in file_path_ids:


### PR DESCRIPTION
The processed files log listed every matched file by its absolute staged path, so each entry carried the examiner home directory and case folder, once per matched file per search pattern. That content is also embedded into the report page as a tab, and the report folder is already stated once in index.html.

Now uses the same Context.get_relative_path the artifact columns use, so the log names where the file sat in the evidence.

Report output is otherwise unchanged. Only the log and the page that embeds it differ, and the LAVA file path values are identical.