### PR TITLE
Count the vzmobile known value, and report media absence as observed

### DIFF
--- a/admin/test/results/synchronoss/synchronoss.synchronoss_mms_received.caseSYNTH001.20260904183054.json
+++ b/admin/test/results/synchronoss/synchronoss.synchronoss_mms_received.caseSYNTH001.20260904183054.json
@@ -6,19 +6,19 @@
     "case_number": "caseSYNTH001",
     "number_of_columns": 9,
     "number_of_rows": 6,
-    "total_data_size_bytes": 1231,
+    "total_data_size_bytes": 1222,
     "media_checkins": 4,
     "media_embedded_checkins": 0,
     "input_zip_path": "admin/test/cases/data/synchronoss/testdata.synchronoss.synchronoss_mms_received.caseSYNTH001.zip",
-    "start_time": "2026-09-04T03:39:53.299755+00:00",
-    "end_time": "2026-09-04T03:39:53.327934+00:00",
-    "run_time_seconds": 0.001283884048461914,
+    "start_time": "2026-09-04T18:30:54.622940+00:00",
+    "end_time": "2026-09-04T18:30:54.649193+00:00",
+    "run_time_seconds": 0.0012514591217041016,
     "last_commit": {
-      "hash": "e610a63f92df487f3d5cc95c61ceb34278d6fb1d",
+      "hash": "bc0358bdf5234f869bc35b2f92a6e9760107e238",
       "author_name": "OneSixForensics",
       "author_email": "kyle@onesixforensics.com",
-      "date": "2026-09-03T09:34:48-06:00",
-      "message": "Resolve MMS media per date folder regardless of seeker file order"
+      "date": "2026-09-03T21:43:31-06:00",
+      "message": "Read the DV access log CSV case-insensitively, and pin media order"
     }
   },
   "headers": [
@@ -73,7 +73,7 @@
       "+12085550000",
       "",
       "9999999999999999999999999999999999999999999999999999999999999999.jpg",
-      "referenced \u2014 file not in daily folder; possibly quarantined/removed",
+      "referenced \u2014 no file of this name in the MMS media folders",
       "1764572400000:d14",
       "SYNTH001LCIDHASH/messages/20251201.csv"
     ],

--- a/admin/test/scripts/gen_synchronoss_synth.py
+++ b/admin/test/scripts/gen_synchronoss_synth.py
@@ -277,10 +277,13 @@ actual = {
     "dv_uploads":     sum(1 for r in DV_ALL if "checksum=" in str(r[3])),
     "dv_sync":        sum(1 for r in DV_ALL if "checksum=" not in str(r[3])),
     "quarantined":    len([n for n in os.listdir(mk(QDIR, ".")) if "zip_file_" in n]),
-    "vzmobile":       3,
+    "vzmobile":       sum(
+        len(files)
+        for _, _, files in os.walk(os.path.join(BASE, LCID, "VZMOBILE"))
+    ),
     "mms_media_files": sum(
         len(files)
-        for root, _, files in os.walk(os.path.join(BASE, LCID, "messages", "attachments", "mms"))
+        for _, _, files in os.walk(os.path.join(BASE, LCID, "messages", "attachments", "mms"))
     ),
 }
 

--- a/scripts/artifacts/synchronoss.py
+++ b/scripts/artifacts/synchronoss.py
@@ -31,7 +31,7 @@ __artifacts_v2__ = {
         "description": "Parses received MMS media with inline display, linked to message CSV metadata",
         "author": "@OneSixForensics",
         "creation_date": "2026-06-24",
-        "last_update_date": "2026-09-03",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Synchronoss",
         "notes": "Media at <LCID>/messages/attachments/mms/in/YYYY-MM-DD/. "
@@ -41,10 +41,10 @@ __artifacts_v2__ = {
                  "folders in these returns (image000000.jpg and the extensionless '0' recur daily), so "
                  "where a name is in more than one folder and none is the message's own date, the "
                  "token is reported as not linked, with the number of folders carrying the name, "
-                 "rather than linked to another date's copy. 'referenced -- file not in daily folder' "
-                 "means the token names media that is not in the return at all; per Synchronoss, "
-                 "flagged files are quarantined out of the daily folder, so absence here is expected "
-                 "for reported content and is not on its own a finding about the file. Direction is "
+                 "rather than linked to another date's copy. 'referenced -- no file of this name in the "
+                 "MMS media folders' means exactly that and nothing more: per Synchronoss, flagged "
+                 "files are quarantined out of the daily folder, so absence is expected for reported "
+                 "content, but absence alone does not establish why any one file is missing. Direction is "
                  "constant in this artifact by construction, since the artifact selects one direction.",
         "paths": (
             '*/messages/2*.csv',
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
         "description": "Parses sent MMS media with inline display, linked to message CSV metadata",
         "author": "@OneSixForensics",
         "creation_date": "2026-06-24",
-        "last_update_date": "2026-09-03",
+        "last_update_date": "2026-09-04",
         "requirements": "none",
         "category": "Synchronoss",
         "notes": "Media at <LCID>/messages/attachments/mms/out/YYYY-MM-DD/. "
@@ -69,10 +69,10 @@ __artifacts_v2__ = {
                  "folders in these returns (image000000.jpg and the extensionless '0' recur daily), so "
                  "where a name is in more than one folder and none is the message's own date, the "
                  "token is reported as not linked, with the number of folders carrying the name, "
-                 "rather than linked to another date's copy. 'referenced -- file not in daily folder' "
-                 "means the token names media that is not in the return at all; per Synchronoss, "
-                 "flagged files are quarantined out of the daily folder, so absence here is expected "
-                 "for reported content and is not on its own a finding about the file. Direction is "
+                 "rather than linked to another date's copy. 'referenced -- no file of this name in the "
+                 "MMS media folders' means exactly that and nothing more: per Synchronoss, flagged "
+                 "files are quarantined out of the daily folder, so absence is expected for reported "
+                 "content, but absence alone does not establish why any one file is missing. Direction is "
                  "constant in this artifact by construction, since the artifact selects one direction.",
         "paths": (
             '*/messages/2*.csv',
@@ -668,10 +668,13 @@ def _synchronoss_mms_media(context, direction):
                                f'date folders, none matching message date '
                                f'{date_folder or "?"}; manual review required')
             else:
-                # Media-looking token with no file present — likely quarantined/removed.
+                # Media-looking token with no file of that name anywhere under this
+                # direction. Quarantine is the common cause, but the cell states what
+                # was observed and leaves the cause to the notes: this string is what
+                # lands in front of an examiner, and it cannot tell the two apart.
                 media_cell = ''
-                link_status = ('referenced — file not in daily folder; '
-                               'possibly quarantined/removed')
+                link_status = ('referenced — no file of this name in the '
+                               'MMS media folders')
 
             data_list.append((
                 _ts_utc(msg_date),


### PR DESCRIPTION
Two follow-ups you raised on #452 after it merged. You said neither was worth a PR on its own, so they are together here.

## 1. The vzmobile known value could not fail

The generator asserts its declared known values against what it actually wrote, which is what makes the fixture worth trusting. `actual["vzmobile"]` was the literal `3` rather than a count, so it compared 3 against 3 and could never go red. The other seven keys are computed.

It now walks the VZMOBILE folder the way `mms_media_files` walks the attachment folders. Verified by declaring 4:

```
generator known values are stale, fix EXPECTED or the data: vzmobile: declared 4, emitted 3
```

exit 1, where before it printed and passed.

## 2. Link Status offered a cause the artifact cannot distinguish

```
was:  referenced — file not in daily folder; possibly quarantined/removed
now:  referenced — no file of this name in the MMS media folders
```

The notes explain that absence is expected for reported content, but the string is what lands in the examiner's column, and a file absent because it was quarantined and one absent for any other reason produce exactly the same observation. The cell now states what was checked; the notes carry the quarantine explanation, and now also say that absence alone does not establish why any one file is missing.

`last_update_date` bumped on both MMS artifacts, since the string is user-visible.

## Verified

Only `synchronoss_mms_received`'s baseline changes; the other nine are untouched.

- committed case 10/10 PASS
- real `rleapp.py -t fs` run reports the new string, with the same counts as the harness: uploads 11, sync 8, messages 12, calls 2, contacts 4, mms 6/1/1, quarantined 4, vzmobile 3
- `pytest admin/test/scripts` 205 passed plus 239 subtests
- pylint 10.00/10, `lint_changed` no new warnings, admin checkers clean
