### PR TITLE
Reset stdout and guard the close button after the worker-thread change

### DIFF
--- a/rleappGUI.py
+++ b/rleappGUI.py
@@ -563,7 +563,7 @@ def poll_crunch(message_queue, out_params):
         main_window.after(CRUNCH_POLL_MS, poll_crunch, message_queue, out_params)
         return
 
-    GuiWindow.message_queue = None  # logfunc goes back to writing straight to the widget
+    GuiWindow.end_worker_run()  # queue cleared, and print() put back on the console
     kind, payload = finished
     if kind == 'failed':
         logfunc('Processing failed with an unhandled error:')
@@ -625,6 +625,29 @@ def finish_crunch(crunch_successful, out_params):
             title='Error',
             message=f'Processing failed  :( \nSee log for error details..\nLog file located at {log_path}',
             parent=main_window)
+
+
+def close_main_window():
+    '''Handle the window's close button.
+
+    The GUI stays responsive during a run now, so this is reachable while the worker is
+    still going. The worker is a daemon thread: quitting kills it wherever it is, leaving
+    a part-written report, an unfinalised LAVA project, and any staging files the run
+    created. Ask first rather than losing a run to a stray click.
+    '''
+    if GuiWindow.message_queue is not None:
+        close_anyway = tk_msgbox.askokcancel(
+            title='Processing still running',
+            message='A run is still in progress.\n\n'
+                    'Closing now stops it where it is. The report and the LAVA project '
+                    'will be incomplete, and temporary files may be left behind.\n\n'
+                    'Close anyway?',
+            icon=tk_msgbox.WARNING,
+            default=tk_msgbox.CANCEL,
+            parent=main_window)
+        if not close_anyway:
+            return
+    main_window.quit()
 
 
 def select_input(button_type):
@@ -1105,6 +1128,7 @@ def center_main_window_macos(window, width, height):
 main_window.attributes('-topmost', True)
 main_window.focus_force()
 main_window.bind('<FocusIn>', OnFocusIn)
+main_window.protocol('WM_DELETE_WINDOW', close_main_window)
 
 if is_platform_macos():
     center_main_window_macos(main_window, 890, 690)

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -85,6 +85,17 @@ class GuiWindow:
     message_queue = None
 
     @staticmethod
+    def end_worker_run():
+        '''Called on the main thread once the worker is finished.
+
+        logfunc points sys.stdout.write at queue_logs for as long as message_queue is set.
+        Clearing the queue on its own leaves that binding in place, so the next print()
+        that does not go through logfunc raises AttributeError on a queue that is gone.
+        '''
+        GuiWindow.message_queue = None
+        sys.stdout.write = _console_write
+
+    @staticmethod
     def SetProgressBar(n, total):  # pylint: disable=unused-argument
         if GuiWindow.message_queue is not None:
             GuiWindow.message_queue.put(('progress', n))


### PR DESCRIPTION
Two follow-ups to #461.

- `GuiWindow.end_worker_run()` clears the message queue and puts `sys.stdout.write` back on the console. `logfunc` aims it at the queue for the length of a run, and clearing the queue alone left that binding in place, so the next `print()` outside `logfunc` raised AttributeError. Nothing on that path prints today. The poller calls the new method instead of clearing the queue by hand.
- The close button asks before quitting a run in progress. The worker is a daemon thread, so closing kills it where it stands and leaves a part-written report and an unfinalised LAVA project.

Same change in all five cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
